### PR TITLE
ENG-469 Stabilize integration suites: Electrum skips, retries, env RPC, keep-common bump

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -321,8 +321,11 @@ jobs:
           docker load --input /tmp/go-build-env-image.tar
 
       - name: Run Go Integration Tests
+        env:
+          ETHEREUM_MAINNET_RPC_URL: ${{ secrets.ETHEREUM_MAINNET_RPC_URL }}
         run: |
           docker run \
+            -e ETHEREUM_MAINNET_RPC_URL \
             --workdir /go/src/github.com/keep-network/keep-core \
             go-build-env \
             gotestsum -- -timeout 20m -tags=integration ./...

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -379,8 +379,11 @@ jobs:
           docker load --input /tmp/go-build-env-image.tar
 
       - name: Run Go Integration Tests
+        env:
+          ETHEREUM_MAINNET_RPC_URL: ${{ secrets.ETHEREUM_MAINNET_RPC_URL }}
         run: |
           docker run \
+            -e ETHEREUM_MAINNET_RPC_URL \
             --workdir /go/src/github.com/keep-network/keep-core \
             go-build-env \
             gotestsum -- -timeout 20m -tags=integration ./...

--- a/pkg/bitcoin/electrum/electrum_integration_test.go
+++ b/pkg/bitcoin/electrum/electrum_integration_test.go
@@ -44,7 +44,7 @@ var testConfigs = map[string]testConfig{
 		clientConfig: electrum.Config{
 			URL:                 "tcp://electrum.blockstream.info:60001",
 			RequestTimeout:      requestTimeout * 2,
-			RequestRetryTimeout: requestRetryTimeout * 2,
+			RequestRetryTimeout: requestRetryTimeout * 6, // allow slower public electrum responses
 		},
 		network: bitcoin.Testnet,
 	},
@@ -52,7 +52,7 @@ var testConfigs = map[string]testConfig{
 		clientConfig: electrum.Config{
 			URL:                 "ssl://electrum.blockstream.info:60002",
 			RequestTimeout:      requestTimeout * 2,
-			RequestRetryTimeout: requestRetryTimeout * 2,
+			RequestRetryTimeout: requestRetryTimeout * 6, // allow slower public electrum responses
 		},
 		network: bitcoin.Testnet,
 	},

--- a/pkg/bitcoin/electrum/electrum_integration_test.go
+++ b/pkg/bitcoin/electrum/electrum_integration_test.go
@@ -58,7 +58,7 @@ var testConfigs = map[string]testConfig{
 			URL:                 "tcp://electrum.blockstream.info:60001",
 			Network:             bitcoin.Testnet,
 			RequestTimeout:      requestTimeout * 2,
-			RequestRetryTimeout: requestRetryTimeout * 2,
+			RequestRetryTimeout: requestRetryTimeout * 6, // allow slower public electrum responses
 		},
 		network: bitcoin.Testnet,
 	},
@@ -67,7 +67,7 @@ var testConfigs = map[string]testConfig{
 			URL:                 "ssl://electrum.blockstream.info:60002",
 			Network:             bitcoin.Testnet,
 			RequestTimeout:      requestTimeout * 2,
-			RequestRetryTimeout: requestRetryTimeout * 2,
+			RequestRetryTimeout: requestRetryTimeout * 6, // allow slower public electrum responses
 		},
 		network: bitcoin.Testnet,
 	},

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -448,7 +448,14 @@ func (bc *baseChain) blockByNumber(number uint64) (*types.Block, error) {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelCtx()
 
-	return bc.client.BlockByNumber(ctx, big.NewInt(int64(number)))
+	// Fetch the header to avoid decoding full transactions (some providers
+	// may return transaction types the client library does not support yet).
+	header, err := bc.client.HeaderByNumber(ctx, big.NewInt(int64(number)))
+	if err != nil {
+		return nil, err
+	}
+
+	return types.NewBlockWithHeader(header), nil
 }
 
 // headerByNumber returns the header for the given block number. Times out

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -452,6 +452,8 @@ func (bc *baseChain) blockByNumber(number uint64) (*types.Block, error) {
 
 	// Fetch the header to avoid decoding full transactions (some providers
 	// may return transaction types the client library does not support yet).
+	// The returned *types.Block carries only header fields; transactions and
+	// uncles are empty. Callers that need tx data must fetch the full block.
 	header, err := bc.client.HeaderByNumber(ctx, big.NewInt(int64(number)))
 	if err != nil {
 		return nil, err

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -450,7 +450,14 @@ func (bc *baseChain) blockByNumber(number uint64) (*types.Block, error) {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelCtx()
 
-	return bc.client.BlockByNumber(ctx, big.NewInt(int64(number)))
+	// Fetch the header to avoid decoding full transactions (some providers
+	// may return transaction types the client library does not support yet).
+	header, err := bc.client.HeaderByNumber(ctx, big.NewInt(int64(number)))
+	if err != nil {
+		return nil, err
+	}
+
+	return types.NewBlockWithHeader(header), nil
 }
 
 // headerByNumber returns the header for the given block number. Times out

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -450,6 +450,8 @@ func (bc *baseChain) blockByNumber(number uint64) (*types.Block, error) {
 
 	// Fetch the header to avoid decoding full transactions (some providers
 	// may return transaction types the client library does not support yet).
+	// The returned *types.Block carries only header fields; transactions and
+	// uncles are empty. Callers that need tx data must fetch the full block.
 	header, err := bc.client.HeaderByNumber(ctx, big.NewInt(int64(number)))
 	if err != nil {
 		return nil, err

--- a/pkg/chain/ethereum/ethereum_integration_test.go
+++ b/pkg/chain/ethereum/ethereum_integration_test.go
@@ -5,6 +5,7 @@ package ethereum
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -17,9 +18,12 @@ import (
 // TODO: Include integration test in the CI.
 // To run the tests execute `go test -v -tags=integration ./...`
 
-const ethereumURL = "https://mainnet.infura.io/v3/f41c6e3d505d44c182a5e5adefdaa43f"
-
 func TestBaseChain_GetBlockNumberByTimestamp(t *testing.T) {
+	ethereumURL := os.Getenv("ETHEREUM_MAINNET_RPC_URL")
+	if ethereumURL == "" {
+		t.Skip("ETHEREUM_MAINNET_RPC_URL not set; skipping integration test")
+	}
+
 	client, err := ethclient.Dial(ethereumURL)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/chain/ethereum/ethereum_integration_test.go
+++ b/pkg/chain/ethereum/ethereum_integration_test.go
@@ -21,7 +21,7 @@ import (
 func TestBaseChain_GetBlockNumberByTimestamp(t *testing.T) {
 	ethereumURL := os.Getenv("ETHEREUM_MAINNET_RPC_URL")
 	if ethereumURL == "" {
-		t.Skip("ETHEREUM_MAINNET_RPC_URL not set; skipping integration test")
+		t.Fatal("ETHEREUM_MAINNET_RPC_URL not set")
 	}
 
 	client, err := ethclient.Dial(ethereumURL)

--- a/pkg/chain/ethereum/ethereum_integration_test.go
+++ b/pkg/chain/ethereum/ethereum_integration_test.go
@@ -30,7 +30,7 @@ import (
 func TestBaseChain_GetBlockNumberByTimestamp(t *testing.T) {
 	ethereumURL := os.Getenv("ETHEREUM_MAINNET_RPC_URL")
 	if ethereumURL == "" {
-		t.Fatal("ETHEREUM_MAINNET_RPC_URL not set")
+		t.Skip("ETHEREUM_MAINNET_RPC_URL not set; skipping mainnet integration test")
 	}
 
 	client, err := ethclient.Dial(ethereumURL)

--- a/pkg/chain/ethereum/ethereum_integration_test.go
+++ b/pkg/chain/ethereum/ethereum_integration_test.go
@@ -30,7 +30,7 @@ import (
 func TestBaseChain_GetBlockNumberByTimestamp(t *testing.T) {
 	ethereumURL := os.Getenv("ETHEREUM_MAINNET_RPC_URL")
 	if ethereumURL == "" {
-		t.Skip("ETHEREUM_MAINNET_RPC_URL not set; skipping integration test")
+		t.Fatal("ETHEREUM_MAINNET_RPC_URL not set")
 	}
 
 	client, err := ethclient.Dial(ethereumURL)

--- a/pkg/chain/ethereum/ethereum_integration_test.go
+++ b/pkg/chain/ethereum/ethereum_integration_test.go
@@ -21,7 +21,7 @@ import (
 func TestBaseChain_GetBlockNumberByTimestamp(t *testing.T) {
 	ethereumURL := os.Getenv("ETHEREUM_MAINNET_RPC_URL")
 	if ethereumURL == "" {
-		t.Fatal("ETHEREUM_MAINNET_RPC_URL not set")
+		t.Skip("ETHEREUM_MAINNET_RPC_URL not set; skipping mainnet integration test")
 	}
 
 	client, err := ethclient.Dial(ethereumURL)

--- a/pkg/tbtcpg/internal/test/marshaling.go
+++ b/pkg/tbtcpg/internal/test/marshaling.go
@@ -3,6 +3,7 @@ package test
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/keep-network/keep-core/pkg/tbtcpg"
 	"math/big"
@@ -273,7 +274,9 @@ func (psts *ProposeSweepTestScenario) UnmarshalJSON(data []byte) error {
 
 	// Unmarshal expected error
 	if len(unmarshaled.ExpectedErr) > 0 {
-		psts.ExpectedErr = fmt.Errorf(unmarshaled.ExpectedErr)
+		// fmt.Errorf requires a constant format string; ExpectedErr is a
+		// plain string so use errors.New to avoid formatting interpretation.
+		psts.ExpectedErr = errors.New(unmarshaled.ExpectedErr)
 	}
 
 	return nil

--- a/pkg/tbtcpg/internal/test/marshaling.go
+++ b/pkg/tbtcpg/internal/test/marshaling.go
@@ -274,6 +274,8 @@ func (psts *ProposeSweepTestScenario) UnmarshalJSON(data []byte) error {
 
 	// Unmarshal expected error
 	if len(unmarshaled.ExpectedErr) > 0 {
+		// fmt.Errorf requires a constant format string; ExpectedErr is a
+		// plain string so use errors.New to avoid formatting interpretation.
 		psts.ExpectedErr = errors.New(unmarshaled.ExpectedErr)
 	}
 


### PR DESCRIPTION
## Summary

Stabilization patch for the v2.3.1-rc integration suites. Rebased onto current `main`; superseded changes (WSS skip helper, sepolia peer refresh, direct keep-common version bump) have been dropped because `main` now handles them.

- Use a header-only block fetch in `pkg/chain/ethereum` to avoid `transaction type not supported` errors from upstream providers.
- Read `ETHEREUM_MAINNET_RPC_URL` from the environment in `TestBaseChain_GetBlockNumberByTimestamp`; skip (not fail) when unset so local `go test -tags=integration ./...` stays friendly. CI sets the secret.
- Pass `ETHEREUM_MAINNET_RPC_URL` into the integration job in `.github/workflows/client.yml`.
- Increase the electrs-esplora retry window in the Electrum integration test (`*2` → `*6`) to absorb slower public endpoints.
- Replace `fmt.Errorf` with `errors.New` in `pkg/tbtcpg/internal/test/marshaling.go` so the unmarshaled error string is not interpreted as a format directive.

## Testing

- `go vet ./pkg/chain/ethereum/... ./pkg/bitcoin/electrum/... ./pkg/tbtcpg/...`
- `go test ./config` (unchanged on this branch)
- `go test -tags=integration ./pkg/bitcoin/electrum` (electrs retries extended)
- `go test -tags=integration ./pkg/chain/ethereum` with `ETHEREUM_MAINNET_RPC_URL` set
- `go test -v ./pkg/tbtcpg/internal/test`

## Follow-ups (not in this PR)

- The leaked Infura project ID previously hardcoded in `ethereum_integration_test.go` (`f41c6e3d505d44c182a5e5adefdaa43f`) is still reachable via `git log`. Rotate it in the Infura dashboard.
- `blockByNumber` is now functionally equivalent to `headerByNumber`. Collapse post-release.

Closes ENG-469.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced Ethereum block retrieval overhead by requesting block headers instead of full transaction and uncle data.

* **Bug Fixes**
  * Improved reliability of Electrum integration tests by allowing additional time for slower public server responses.

* **Tests**
  * Integration tests now use the configured Ethereum mainnet RPC endpoint when available.
  * Updated test messaging to clarify the required RPC configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->