### PR TITLE
ci(npm-random-beacon): pin @threshold-network/solidity-contracts to 1.2.1

### DIFF
--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -34,10 +34,17 @@ jobs:
           cache-dependency-path: solidity/random-beacon/yarn.lock
 
       - name: Resolve latest contracts
+        # `@threshold-network/solidity-contracts` is pinned to 1.3.0-dev.11
+        # (the version used by the last successful publish, 2.1.0-dev.18)
+        # because the `development` dist-tag was bumped to 1.3.0-dev.16,
+        # which refactored `TokenStaking` and removed `approveApplication`
+        # (called by `deploy/05_approve_random_beacon_in_token_staking.ts`).
+        # Unpin once the deploy scripts and Go ABI bindings are migrated
+        # to the new TokenStaking API.
         run: |
           yarn upgrade --exact \
             @keep-network/sortition-pools \
-            @threshold-network/solidity-contracts
+            @threshold-network/solidity-contracts@1.3.0-dev.11
 
       # Deploy contracts to a local network to generate deployment artifacts that
       # are required by dashboard and client compilation.


### PR DESCRIPTION
## Summary

- The `NPM Random Beacon` workflow has been failing on `main` since the `@threshold-network/solidity-contracts` `development` dist-tag jumped from `1.3.0-dev.11` to `1.3.0-dev.16`.
- In `1.3.0-dev.16` upstream refactored `TokenStaking` so `approveApplication` is no longer exposed by the deployed ABI, causing `deploy/05_approve_random_beacon_in_token_staking.ts` to error out with:
  ```
  Error: No method named "approveApplication" on contract deployed as "TokenStaking"
  ```
- This PR pins the upgrade step to `@threshold-network/solidity-contracts@1.3.0-dev.11` — the exact version used by the last successful `@keep-network/random-beacon` publish (`2.1.0-dev.18`). Unpinning should be done in a follow-up once the deploy scripts (and the Go ABI bindings in `pkg/chain/ethereum/threshold/gen/`) are migrated to the new TokenStaking API.

## Test plan

- [ ] Workflow run on this branch (via `workflow_dispatch`) succeeds at the `Deploy contracts` step
- [ ] After merge, the `NPM Random Beacon` workflow on `main` is green