### PR TITLE
Add stuck-transaction monitor for wallet transactions

### DIFF
--- a/pkg/bitcoin/chain.go
+++ b/pkg/bitcoin/chain.go
@@ -1,5 +1,7 @@
 package bitcoin
 
+import "context"
+
 // Chain defines an interface meant to be used for interaction with the
 // Bitcoin chain.
 type Chain interface {
@@ -11,7 +13,12 @@ type Chain interface {
 	// GetTransactionConfirmations gets the number of confirmations for the
 	// transaction with the given transaction hash. If the transaction with the
 	// given hash was not found on the chain, this function returns an error.
-	GetTransactionConfirmations(transactionHash Hash) (uint, error)
+	// The provided context bounds the lookup; implementations should abort the
+	// underlying call when it is cancelled.
+	GetTransactionConfirmations(
+		ctx context.Context,
+		transactionHash Hash,
+	) (uint, error)
 
 	// BroadcastTransaction broadcasts the given transaction over the
 	// network of the Bitcoin chain nodes. If the broadcast action could not be

--- a/pkg/bitcoin/chain_test.go
+++ b/pkg/bitcoin/chain_test.go
@@ -1,6 +1,7 @@
 package bitcoin
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
@@ -101,6 +102,7 @@ func (lc *localChain) GetTransactionMerkleProof(
 }
 
 func (lc *localChain) GetTransactionConfirmations(
+	_ context.Context,
 	transactionHash Hash,
 ) (uint, error) {
 	lc.transactionConfirmationsMutex.Lock()

--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -83,6 +83,7 @@ func (c *Connection) GetTransaction(
 	txID := transactionHash.Hex(bitcoin.ReversedByteOrder)
 
 	rawTransaction, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(ctx context.Context, client *electrum.Client) (string, error) {
 			// We cannot use `GetTransaction` to get the the transaction details
@@ -130,6 +131,7 @@ func (c *Connection) GetTransaction(
 // transaction with the given transaction hash. If the transaction with the
 // given hash was not found on the chain, this function returns an error.
 func (c *Connection) GetTransactionConfirmations(
+	ctx context.Context,
 	transactionHash bitcoin.Hash,
 ) (uint, error) {
 	txID := transactionHash.Hex(bitcoin.ReversedByteOrder)
@@ -138,7 +140,16 @@ func (c *Connection) GetTransactionConfirmations(
 		zap.String("txID", txID),
 	)
 
+	// Bound the network calls below by both the caller's context and the
+	// connection lifetime context, so a cancelled caller aborts the lookup while
+	// connection shutdown still cancels it as before.
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stopOnParentDone := context.AfterFunc(c.parentCtx, cancel)
+	defer stopOnParentDone()
+
 	rawTransaction, err := requestWithRetry(
+		reqCtx,
 		c,
 		func(ctx context.Context, client *electrum.Client) (string, error) {
 			// We cannot use `GetTransaction` to get the transaction details
@@ -208,6 +219,7 @@ txOutLoop:
 		reversedScriptHashString := hex.EncodeToString(reversedScriptHash)
 
 		scriptHashHistory, err := requestWithRetry(
+			reqCtx,
 			c,
 			func(
 				ctx context.Context,
@@ -296,6 +308,7 @@ func (c *Connection) BroadcastTransaction(
 	var response string
 
 	response, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(ctx context.Context, client *electrum.Client) (string, error) {
 			return client.BroadcastTransaction(ctx, rawTx)
@@ -315,6 +328,7 @@ func (c *Connection) BroadcastTransaction(
 // latest block was not determined, this function returns an error.
 func (c *Connection) GetLatestBlockHeight() (uint, error) {
 	blockHeight, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(ctx context.Context, client *electrum.Client) (int32, error) {
 			tip, err := client.SubscribeHeadersSingle(ctx)
@@ -344,6 +358,7 @@ func (c *Connection) GetBlockHeader(
 	blockHeight uint,
 ) (*bitcoin.BlockHeader, error) {
 	getBlockHeaderResult, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(
 			ctx context.Context,
@@ -375,6 +390,7 @@ func (c *Connection) GetTransactionMerkleProof(
 	txID := transactionHash.Hex(bitcoin.ReversedByteOrder)
 
 	getMerkleProofResult, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(
 			ctx context.Context,
@@ -514,6 +530,7 @@ func (c *Connection) getConfirmedScriptHistory(
 	reversedScriptHashString := hex.EncodeToString(reversedScriptHash)
 
 	items, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(
 			ctx context.Context,
@@ -577,6 +594,7 @@ func (c *Connection) getConfirmedScriptHistory(
 // block height.
 func (c *Connection) GetCoinbaseTxHash(blockHeight uint) (bitcoin.Hash, error) {
 	txHashString, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(
 			ctx context.Context,
@@ -683,6 +701,7 @@ func (c *Connection) getScriptMempool(
 	reversedScriptHashString := hex.EncodeToString(reversedScriptHash)
 
 	items, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(
 			ctx context.Context,
@@ -885,6 +904,7 @@ func (c *Connection) getScriptUtxos(
 	reversedScriptHashString := hex.EncodeToString(reversedScriptHash)
 
 	items, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(
 			ctx context.Context,
@@ -1173,6 +1193,7 @@ func (c *Connection) verifyServer() error {
 	}
 
 	server, err := requestWithRetry(
+		c.parentCtx,
 		c,
 		func(ctx context.Context, client *electrum.Client) (*Server, error) {
 			serverVersion, protocolVersion, err := client.ServerVersion(ctx)
@@ -1213,6 +1234,7 @@ func (c *Connection) keepAlive() {
 		select {
 		case <-ticker.C:
 			_, err := requestWithRetry(
+				c.parentCtx,
 				c,
 				func(ctx context.Context, client *electrum.Client) (interface{}, error) {
 					return nil, client.Ping(ctx)
@@ -1265,6 +1287,7 @@ func connectWithRetry(
 }
 
 func requestWithRetry[K interface{}](
+	parentCtx context.Context,
 	c *Connection,
 	requestFn func(ctx context.Context, client *electrum.Client) (K, error),
 	requestName string,
@@ -1275,7 +1298,7 @@ func requestWithRetry[K interface{}](
 	var result K
 
 	err := wrappers.DoWithDefaultRetry(
-		c.parentCtx,
+		parentCtx,
 		c.config.RequestRetryTimeout,
 		func(ctx context.Context) error {
 			if err := c.reconnectIfShutdown(); err != nil {

--- a/pkg/bitcoin/electrum/electrum_integration_test.go
+++ b/pkg/bitcoin/electrum/electrum_integration_test.go
@@ -230,7 +230,7 @@ func TestGetTransactionConfirmations_Integration(t *testing.T) {
 				}
 				expectedConfirmations := latestBlockHeight - tx.BlockHeight
 
-				result, err := electrum.GetTransactionConfirmations(tx.TxHash)
+				result, err := electrum.GetTransactionConfirmations(context.Background(), tx.TxHash)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -252,7 +252,7 @@ func TestGetTransactionConfirmations_Negative_Integration(t *testing.T) {
 		electrum, cancelCtx := newTestConnection(t, testConfig.clientConfig)
 		defer cancelCtx()
 
-		_, err := electrum.GetTransactionConfirmations(invalidTxID)
+		_, err := electrum.GetTransactionConfirmations(context.Background(), invalidTxID)
 		if shouldSkipElectrumIntegrationError(err) {
 			t.Skipf("skipping due to transient electrum error: %v", err)
 		}

--- a/pkg/bitcoin/spv_proof.go
+++ b/pkg/bitcoin/spv_proof.go
@@ -2,6 +2,7 @@ package bitcoin
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -39,6 +40,7 @@ func AssembleSpvProof(
 	btcChain Chain,
 ) (*Transaction, *SpvProof, error) {
 	confirmations, err := btcChain.GetTransactionConfirmations(
+		context.Background(),
 		transactionHash,
 	)
 	if err != nil {

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -123,6 +123,7 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 		MetricWalletActionSuccessTotal,
 		MetricWalletActionFailedTotal,
 		MetricWalletHeartbeatFailuresTotal,
+		MetricStuckWalletTransactionsTotal,
 		MetricCoordinationWindowsDetectedTotal,
 		MetricCoordinationProceduresExecutedTotal,
 		MetricCoordinationFailedTotal,
@@ -640,6 +641,7 @@ const (
 	MetricWalletActionFailedTotal      = "wallet_action_failed_total"
 	MetricWalletActionDurationSeconds  = "wallet_action_duration_seconds"
 	MetricWalletHeartbeatFailuresTotal = "wallet_heartbeat_failures_total"
+	MetricStuckWalletTransactionsTotal = "stuck_wallet_transactions_total"
 
 	// Wallet Action Metrics (per-action type)
 	// These are generated dynamically using WalletActionMetricName helper function

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -124,6 +124,7 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 		MetricWalletActionFailedTotal,
 		MetricWalletHeartbeatFailuresTotal,
 		MetricStuckWalletTransactionsTotal,
+		MetricUnmonitoredWalletTransactionsTotal,
 		MetricCoordinationWindowsDetectedTotal,
 		MetricCoordinationProceduresExecutedTotal,
 		MetricCoordinationFailedTotal,
@@ -636,12 +637,13 @@ const (
 	MetricRedemptionProofSubmissionsFailedTotal  = "redemption_proof_submissions_failed_total"
 
 	// Wallet Action Metrics (aggregate)
-	MetricWalletActionsTotal           = "wallet_actions_total"
-	MetricWalletActionSuccessTotal     = "wallet_action_success_total"
-	MetricWalletActionFailedTotal      = "wallet_action_failed_total"
-	MetricWalletActionDurationSeconds  = "wallet_action_duration_seconds"
-	MetricWalletHeartbeatFailuresTotal = "wallet_heartbeat_failures_total"
-	MetricStuckWalletTransactionsTotal = "stuck_wallet_transactions_total"
+	MetricWalletActionsTotal                 = "wallet_actions_total"
+	MetricWalletActionSuccessTotal           = "wallet_action_success_total"
+	MetricWalletActionFailedTotal            = "wallet_action_failed_total"
+	MetricWalletActionDurationSeconds        = "wallet_action_duration_seconds"
+	MetricWalletHeartbeatFailuresTotal       = "wallet_heartbeat_failures_total"
+	MetricStuckWalletTransactionsTotal       = "stuck_wallet_transactions_total"
+	MetricUnmonitoredWalletTransactionsTotal = "unmonitored_wallet_transactions_total"
 
 	// Wallet Action Metrics (per-action type)
 	// These are generated dynamically using WalletActionMetricName helper function

--- a/pkg/clientinfo/rpc_health_test.go
+++ b/pkg/clientinfo/rpc_health_test.go
@@ -59,7 +59,7 @@ func (f *fakeBitcoinChain) GetBlockHeader(blockHeight uint) (*bitcoin.BlockHeade
 func (f *fakeBitcoinChain) GetTransaction(transactionHash bitcoin.Hash) (*bitcoin.Transaction, error) {
 	panic("not needed in rpc_health tests")
 }
-func (f *fakeBitcoinChain) GetTransactionConfirmations(transactionHash bitcoin.Hash) (uint, error) {
+func (f *fakeBitcoinChain) GetTransactionConfirmations(_ context.Context, transactionHash bitcoin.Hash) (uint, error) {
 	panic("not needed in rpc_health tests")
 }
 func (f *fakeBitcoinChain) BroadcastTransaction(transaction *bitcoin.Transaction) error {

--- a/pkg/maintainer/btcdiff/bitcoin_chain_test.go
+++ b/pkg/maintainer/btcdiff/bitcoin_chain_test.go
@@ -1,6 +1,7 @@
 package btcdiff
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -26,6 +27,7 @@ func (lbc *localBitcoinChain) GetTransaction(
 // transaction with the given transaction hash. If the transaction with the
 // given hash was not found on the chain, this function returns an error.
 func (lbc *localBitcoinChain) GetTransactionConfirmations(
+	_ context.Context,
 	transactionHash bitcoin.Hash,
 ) (uint, error) {
 	panic("unsupported")

--- a/pkg/maintainer/spv/bitcoin_chain_test.go
+++ b/pkg/maintainer/spv/bitcoin_chain_test.go
@@ -2,6 +2,7 @@ package spv
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/big"
 	"sync"
@@ -72,7 +73,7 @@ func (lbc *localBitcoinChain) GetTransaction(transactionHash bitcoin.Hash) (
 	return nil, fmt.Errorf("transaction not found")
 }
 
-func (lbc *localBitcoinChain) GetTransactionConfirmations(transactionHash bitcoin.Hash) (
+func (lbc *localBitcoinChain) GetTransactionConfirmations(_ context.Context, transactionHash bitcoin.Hash) (
 	uint,
 	error,
 ) {

--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -337,6 +337,7 @@ func getProofInfo(
 	}
 
 	accumulatedConfirmations, err := btcChain.GetTransactionConfirmations(
+		context.Background(),
 		transactionHash,
 	)
 	if err != nil {

--- a/pkg/tbtc/bitcoin_chain_test.go
+++ b/pkg/tbtc/bitcoin_chain_test.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sync"
 
@@ -39,6 +40,7 @@ func (lbc *localBitcoinChain) GetTransaction(
 }
 
 func (lbc *localBitcoinChain) GetTransactionConfirmations(
+	_ context.Context,
 	transactionHash bitcoin.Hash,
 ) (uint, error) {
 	for index, transaction := range lbc.transactions {

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -105,6 +105,7 @@ func newDepositSweepAction(
 	proposalProcessingStartBlock uint64,
 	proposalExpiryBlock uint64,
 	waitForBlockFn waitForBlockFn,
+	transactionMonitor *transactionMonitor,
 ) *depositSweepAction {
 	transactionExecutor := newWalletTransactionExecutor(
 		btcChain,
@@ -112,6 +113,8 @@ func newDepositSweepAction(
 		signingExecutor,
 		waitForBlockFn,
 	)
+
+	transactionExecutor.setTransactionMonitor(transactionMonitor)
 
 	return &depositSweepAction{
 		logger:                           logger,

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -1,6 +1,7 @@
 package tbtc
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
@@ -343,6 +344,7 @@ func ValidateDepositSweepProposal(
 		)
 
 		confirmations, err := btcChain.GetTransactionConfirmations(
+			context.Background(),
 			depositKey.FundingTxHash,
 		)
 		if err != nil {

--- a/pkg/tbtc/deposit_sweep_test.go
+++ b/pkg/tbtc/deposit_sweep_test.go
@@ -205,6 +205,7 @@ func TestDepositSweepAction_Execute(t *testing.T) {
 				func(ctx context.Context, blockHeight uint64) error {
 					return nil
 				},
+				nil,
 			)
 
 			// Modify the default parameters of the action to make

--- a/pkg/tbtc/moved_funds_sweep.go
+++ b/pkg/tbtc/moved_funds_sweep.go
@@ -107,6 +107,7 @@ func newMovedFundsSweepAction(
 	proposalProcessingStartBlock uint64,
 	proposalExpiryBlock uint64,
 	waitForBlockFn waitForBlockFn,
+	transactionMonitor *transactionMonitor,
 ) *movedFundsSweepAction {
 	transactionExecutor := newWalletTransactionExecutor(
 		btcChain,
@@ -114,6 +115,8 @@ func newMovedFundsSweepAction(
 		signingExecutor,
 		waitForBlockFn,
 	)
+
+	transactionExecutor.setTransactionMonitor(transactionMonitor)
 
 	return &movedFundsSweepAction{
 		logger:                           logger,

--- a/pkg/tbtc/moved_funds_sweep_test.go
+++ b/pkg/tbtc/moved_funds_sweep_test.go
@@ -112,6 +112,7 @@ func TestMovedFundsSweepAction_Execute(t *testing.T) {
 				func(ctx context.Context, blockHeight uint64) error {
 					return nil
 				},
+				nil,
 			)
 
 			// Modify the default parameters of the action to make

--- a/pkg/tbtc/moving_funds.go
+++ b/pkg/tbtc/moving_funds.go
@@ -103,6 +103,7 @@ func newMovingFundsAction(
 	proposalProcessingStartBlock uint64,
 	proposalExpiryBlock uint64,
 	waitForBlockFn waitForBlockFn,
+	transactionMonitor *transactionMonitor,
 ) *movingFundsAction {
 	transactionExecutor := newWalletTransactionExecutor(
 		btcChain,
@@ -110,6 +111,8 @@ func newMovingFundsAction(
 		signingExecutor,
 		waitForBlockFn,
 	)
+
+	transactionExecutor.setTransactionMonitor(transactionMonitor)
 
 	return &movingFundsAction{
 		logger:                           logger,

--- a/pkg/tbtc/moving_funds_test.go
+++ b/pkg/tbtc/moving_funds_test.go
@@ -123,6 +123,7 @@ func TestMovingFundsAction_Execute(t *testing.T) {
 				func(ctx context.Context, blockHeight uint64) error {
 					return nil
 				},
+				nil,
 			)
 
 			// Modify the default parameters of the action to make

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -113,6 +113,10 @@ type node struct {
 
 	// windowMetricsTracker tracks detailed metrics for individual coordination windows
 	windowMetricsTracker *coordinationWindowMetrics
+
+	// transactionMonitor watches broadcast wallet transactions and alerts on
+	// ones that remain unconfirmed long enough to be considered stuck.
+	transactionMonitor *transactionMonitor
 }
 
 func newNode(
@@ -150,6 +154,7 @@ func newNode(
 		inactivityClaimExecutors: make(map[string]*inactivityClaimExecutor),
 		coordinationExecutors:    make(map[string]*coordinationExecutor),
 		proposalGenerator:        proposalGenerator,
+		transactionMonitor:       newTransactionMonitor(btcChain),
 	}
 
 	// Archive any wallets that might have been closed or terminated while the
@@ -199,6 +204,10 @@ func (n *node) setPerformanceMetrics(metrics interface {
 	// Keep metrics for the last 100 windows (approximately 25 hours at 900 blocks per window)
 	if perfMetrics, ok := metrics.(clientinfo.PerformanceMetricsRecorder); ok {
 		n.windowMetricsTracker = newCoordinationWindowMetrics(perfMetrics, 100)
+
+		if n.transactionMonitor != nil {
+			n.transactionMonitor.setMetricsRecorder(perfMetrics)
+		}
 	}
 
 	if n.walletDispatcher != nil {

--- a/pkg/tbtc/node_coordination.go
+++ b/pkg/tbtc/node_coordination.go
@@ -40,6 +40,12 @@ func (n *node) runCoordinationLayer(
 	ctx context.Context,
 	settings ...*coordinationLayerSettings,
 ) error {
+	// Start the background monitor that alerts on stuck (long-unconfirmed)
+	// wallet transactions.
+	if n.transactionMonitor != nil {
+		go n.transactionMonitor.run(ctx)
+	}
+
 	// Resolve settings for the coordination layer.
 	var cls *coordinationLayerSettings
 	switch len(settings) {

--- a/pkg/tbtc/node_proposals.go
+++ b/pkg/tbtc/node_proposals.go
@@ -152,6 +152,7 @@ func (n *node) handleDepositSweepProposal(
 		startBlock,
 		expiryBlock,
 		n.waitForBlockHeight,
+		n.transactionMonitor,
 	)
 
 	// Wire metrics recorder if available
@@ -225,6 +226,7 @@ func (n *node) handleRedemptionProposal(
 		startBlock,
 		expiryBlock,
 		n.waitForBlockHeight,
+		n.transactionMonitor,
 	)
 
 	// Wire metrics recorder if available
@@ -298,6 +300,7 @@ func (n *node) handleMovingFundsProposal(
 		startBlock,
 		expiryBlock,
 		n.waitForBlockHeight,
+		n.transactionMonitor,
 	)
 
 	err = n.walletDispatcher.dispatch(action)
@@ -366,6 +369,7 @@ func (n *node) handleMovedFundsSweepProposal(
 		startBlock,
 		expiryBlock,
 		n.waitForBlockHeight,
+		n.transactionMonitor,
 	)
 
 	err = n.walletDispatcher.dispatch(action)

--- a/pkg/tbtc/redemption.go
+++ b/pkg/tbtc/redemption.go
@@ -137,6 +137,7 @@ func newRedemptionAction(
 	proposalProcessingStartBlock uint64,
 	proposalExpiryBlock uint64,
 	waitForBlockFn waitForBlockFn,
+	transactionMonitor *transactionMonitor,
 ) *redemptionAction {
 	transactionExecutor := newWalletTransactionExecutor(
 		btcChain,
@@ -146,6 +147,8 @@ func newRedemptionAction(
 	)
 
 	feeDistribution := withRedemptionTotalFee(proposal.RedemptionTxFee.Int64())
+
+	transactionExecutor.setTransactionMonitor(transactionMonitor)
 
 	return &redemptionAction{
 		logger:                           logger,

--- a/pkg/tbtc/redemption_test.go
+++ b/pkg/tbtc/redemption_test.go
@@ -135,6 +135,7 @@ func TestRedemptionAction_Execute(t *testing.T) {
 				func(ctx context.Context, blockHeight uint64) error {
 					return nil
 				},
+				nil,
 			)
 
 			// Modify the default parameters of the action to make

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -1,0 +1,200 @@
+package tbtc
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+)
+
+const (
+	// defaultStuckTransactionThresholdBlocks is the number of Bitcoin blocks a
+	// broadcast wallet transaction may remain unconfirmed before it is
+	// considered stuck and an alert is raised. Roughly 6 hours at ~10 min per
+	// block.
+	defaultStuckTransactionThresholdBlocks = uint(36)
+
+	// transactionMonitorCheckInterval is how often the monitor polls the
+	// confirmation status of the tracked transactions.
+	transactionMonitorCheckInterval = 5 * time.Minute
+
+	// transactionMonitorMinConfirmations is the number of confirmations at
+	// which a tracked transaction is considered mined and stops being tracked.
+	transactionMonitorMinConfirmations = uint(1)
+
+	// transactionMonitorMaxTracked bounds the number of tracked transactions to
+	// prevent unbounded memory growth.
+	transactionMonitorMaxTracked = 1000
+)
+
+// trackedTransaction holds the monitoring state of a single broadcast wallet
+// transaction.
+type trackedTransaction struct {
+	walletPublicKeyHash [20]byte
+	broadcastBlock      uint
+	alerted             bool
+}
+
+// transactionMonitor watches broadcast wallet transactions (deposit sweeps,
+// redemptions, moving funds) and raises an alert if one stays unconfirmed for
+// longer than a configurable number of Bitcoin blocks. A stuck wallet
+// transaction locks the wallet's main UTXO and blocks all subsequent wallet
+// transactions until it confirms, so surfacing it lets operators intervene
+// (e.g. mempool acceleration or CPFP) promptly.
+//
+// The monitor only emits a metric and a warn-level log identifying the wallet
+// and transaction; automated recovery (fee-bumping / RBF) is intentionally out
+// of scope (see threshold-network/keep-core#4171).
+type transactionMonitor struct {
+	btcChain bitcoin.Chain
+
+	mu      sync.Mutex
+	tracked map[bitcoin.Hash]*trackedTransaction
+
+	thresholdBlocks uint
+
+	metricsRecorder clientinfo.PerformanceMetricsRecorder
+}
+
+func newTransactionMonitor(btcChain bitcoin.Chain) *transactionMonitor {
+	return &transactionMonitor{
+		btcChain:        btcChain,
+		tracked:         make(map[bitcoin.Hash]*trackedTransaction),
+		thresholdBlocks: defaultStuckTransactionThresholdBlocks,
+	}
+}
+
+// setMetricsRecorder wires the performance metrics recorder used to expose the
+// stuck-transaction metric. It is safe to call after construction.
+func (tm *transactionMonitor) setMetricsRecorder(
+	recorder clientinfo.PerformanceMetricsRecorder,
+) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tm.metricsRecorder = recorder
+}
+
+// track registers a freshly broadcast wallet transaction for confirmation
+// monitoring. It is a no-op if the transaction is already tracked or the
+// tracking table is full.
+func (tm *transactionMonitor) track(
+	txHash bitcoin.Hash,
+	walletPublicKeyHash [20]byte,
+) {
+	broadcastBlock, err := tm.btcChain.GetLatestBlockHeight()
+	if err != nil {
+		logger.Warnf(
+			"transaction monitor cannot read latest block height while "+
+				"tracking transaction [%s]: [%v]",
+			txHash.Hex(bitcoin.ReversedByteOrder),
+			err,
+		)
+		return
+	}
+
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	if _, ok := tm.tracked[txHash]; ok {
+		return
+	}
+
+	if len(tm.tracked) >= transactionMonitorMaxTracked {
+		logger.Warnf(
+			"transaction monitor tracking table is full ([%d]); not tracking "+
+				"transaction [%s]",
+			transactionMonitorMaxTracked,
+			txHash.Hex(bitcoin.ReversedByteOrder),
+		)
+		return
+	}
+
+	tm.tracked[txHash] = &trackedTransaction{
+		walletPublicKeyHash: walletPublicKeyHash,
+		broadcastBlock:      broadcastBlock,
+	}
+}
+
+// run starts the monitor's polling loop. It blocks until the context is done.
+func (tm *transactionMonitor) run(ctx context.Context) {
+	ticker := time.NewTicker(transactionMonitorCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tm.check()
+		}
+	}
+}
+
+// check polls the confirmation status of every tracked transaction once. It
+// drops confirmed transactions and alerts (once) on those that have remained
+// unconfirmed for longer than the stuck threshold.
+func (tm *transactionMonitor) check() {
+	latestBlock, err := tm.btcChain.GetLatestBlockHeight()
+	if err != nil {
+		logger.Warnf(
+			"transaction monitor cannot read latest block height: [%v]",
+			err,
+		)
+		return
+	}
+
+	// Snapshot the tracked set so chain calls are not made under the lock.
+	tm.mu.Lock()
+	snapshot := make(map[bitcoin.Hash]trackedTransaction, len(tm.tracked))
+	for hash, t := range tm.tracked {
+		snapshot[hash] = *t
+	}
+	tm.mu.Unlock()
+
+	for txHash, t := range snapshot {
+		confirmations, err := tm.btcChain.GetTransactionConfirmations(txHash)
+		if err == nil && confirmations >= transactionMonitorMinConfirmations {
+			// The transaction is mined; stop tracking it.
+			tm.mu.Lock()
+			delete(tm.tracked, txHash)
+			tm.mu.Unlock()
+			continue
+		}
+
+		// Still unconfirmed (in the mempool) or not yet found. A lookup error is
+		// treated the same as unconfirmed: it does not indicate the transaction
+		// confirmed, and it may be transient.
+		var blocksOutstanding uint
+		if latestBlock >= t.broadcastBlock {
+			blocksOutstanding = latestBlock - t.broadcastBlock
+		}
+
+		if blocksOutstanding <= tm.thresholdBlocks || t.alerted {
+			continue
+		}
+
+		logger.Warnf(
+			"wallet transaction [%s] for wallet [0x%x] has been unconfirmed "+
+				"for [%d] blocks (threshold [%d]); it may be stuck in the "+
+				"mempool and blocking subsequent wallet transactions - consider "+
+				"fee-bumping or accelerating it",
+			txHash.Hex(bitcoin.ReversedByteOrder),
+			t.walletPublicKeyHash,
+			blocksOutstanding,
+			tm.thresholdBlocks,
+		)
+
+		tm.mu.Lock()
+		if tracked, ok := tm.tracked[txHash]; ok {
+			tracked.alerted = true
+		}
+		if tm.metricsRecorder != nil {
+			tm.metricsRecorder.IncrementCounter(
+				clientinfo.MetricStuckWalletTransactionsTotal, 1,
+			)
+		}
+		tm.mu.Unlock()
+	}
+}

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -33,6 +33,12 @@ const (
 	// duration prevents never-confirming transactions from filling up the
 	// tracking table and starving monitoring of new transactions (~24 hours).
 	transactionMonitorMaxTrackingAge = 24 * time.Hour
+
+	// transactionMonitorCheckBudget bounds the wall-clock time of a single check
+	// pass so that a slow chain call cannot stall monitoring of every remaining
+	// transaction; transactions not reached within the budget are handled on the
+	// next pass.
+	transactionMonitorCheckBudget = 2 * time.Minute
 )
 
 // trackedTransaction holds the monitoring state of a single broadcast wallet
@@ -99,19 +105,29 @@ func (tm *transactionMonitor) track(
 	walletPublicKeyHash [20]byte,
 ) {
 	tm.mu.Lock()
-	defer tm.mu.Unlock()
 
 	if _, ok := tm.tracked[txHash]; ok {
+		tm.mu.Unlock()
 		return
 	}
 
 	if len(tm.tracked) >= transactionMonitorMaxTracked {
+		// A full table means a real broadcast transaction goes unmonitored;
+		// surface it as a metric (emitted outside the lock) as well as a log.
+		recorder := tm.metricsRecorder
+		tm.mu.Unlock()
+
 		logger.Warnf(
-			"transaction monitor tracking table is full ([%d]); not tracking "+
-				"transaction [%s]",
+			"transaction monitor tracking table is full ([%d]); transaction "+
+				"[%s] will not be monitored",
 			transactionMonitorMaxTracked,
 			txHash.Hex(bitcoin.ReversedByteOrder),
 		)
+		if recorder != nil {
+			recorder.IncrementCounter(
+				clientinfo.MetricUnmonitoredWalletTransactionsTotal, 1,
+			)
+		}
 		return
 	}
 
@@ -119,6 +135,7 @@ func (tm *transactionMonitor) track(
 		walletPublicKeyHash: walletPublicKeyHash,
 		broadcastAt:         time.Now(),
 	}
+	tm.mu.Unlock()
 }
 
 // run starts the monitor's polling loop. It blocks until the context is done.
@@ -146,6 +163,7 @@ func (tm *transactionMonitor) run(ctx context.Context) {
 // only ever mutated here, under the mutex.
 func (tm *transactionMonitor) check() {
 	now := time.Now()
+	deadline := now.Add(transactionMonitorCheckBudget)
 
 	// Snapshot the tracked set so chain calls are not made under the lock.
 	tm.mu.Lock()
@@ -156,6 +174,18 @@ func (tm *transactionMonitor) check() {
 	tm.mu.Unlock()
 
 	for txHash, t := range snapshot {
+		// Bound the wall-clock time of a single pass so one slow chain call
+		// cannot stall monitoring of every transaction behind it; the remaining
+		// transactions are picked up on the next pass.
+		if time.Now().After(deadline) {
+			logger.Warnf(
+				"transaction monitor check pass exceeded its time budget [%s]; "+
+					"deferring the remaining transactions to the next pass",
+				transactionMonitorCheckBudget,
+			)
+			break
+		}
+
 		confirmations, err := tm.btcChain.GetTransactionConfirmations(txHash)
 		if err == nil && confirmations >= transactionMonitorMinConfirmations {
 			// The transaction is mined; stop tracking it.
@@ -168,6 +198,38 @@ func (tm *transactionMonitor) check() {
 		// confirmed and may be transient.
 		outstanding := now.Sub(t.broadcastAt)
 
+		// Alert (once) if the transaction has been unconfirmed past the stuck
+		// threshold. This runs before the give-up eviction below so that a
+		// transaction first observed after the maximum tracking age still fires
+		// exactly one alert instead of being silently evicted.
+		if outstanding > tm.threshold && !t.alerted {
+			logger.Warnf(
+				"wallet transaction [%s] for wallet [0x%x] has been unconfirmed "+
+					"for [%s] (threshold [%s]); it may be stuck in the mempool "+
+					"and blocking subsequent wallet transactions - consider "+
+					"fee-bumping or accelerating it",
+				txHash.Hex(bitcoin.ReversedByteOrder),
+				t.walletPublicKeyHash,
+				outstanding.Round(time.Minute),
+				tm.threshold,
+			)
+
+			// Mark as alerted under the lock, but emit the metric outside the
+			// lock to avoid holding it during an external call.
+			tm.mu.Lock()
+			if tracked, ok := tm.tracked[txHash]; ok {
+				tracked.alerted = true
+			}
+			recorder := tm.metricsRecorder
+			tm.mu.Unlock()
+
+			if recorder != nil {
+				recorder.IncrementCounter(
+					clientinfo.MetricStuckWalletTransactionsTotal, 1,
+				)
+			}
+		}
+
 		// Give up on transactions that have been unconfirmed for too long (e.g.
 		// dropped from the mempool) so they cannot fill the tracking table.
 		if outstanding > transactionMonitorMaxTrackingAge {
@@ -179,37 +241,6 @@ func (tm *transactionMonitor) check() {
 				outstanding.Round(time.Minute),
 			)
 			tm.remove(txHash)
-			continue
-		}
-
-		if outstanding <= tm.threshold || t.alerted {
-			continue
-		}
-
-		logger.Warnf(
-			"wallet transaction [%s] for wallet [0x%x] has been unconfirmed "+
-				"for [%s] (threshold [%s]); it may be stuck in the mempool and "+
-				"blocking subsequent wallet transactions - consider fee-bumping "+
-				"or accelerating it",
-			txHash.Hex(bitcoin.ReversedByteOrder),
-			t.walletPublicKeyHash,
-			outstanding.Round(time.Minute),
-			tm.threshold,
-		)
-
-		// Mark as alerted and read the recorder under the lock, but emit the
-		// metric outside the lock to avoid holding it during an external call.
-		tm.mu.Lock()
-		if tracked, ok := tm.tracked[txHash]; ok {
-			tracked.alerted = true
-		}
-		recorder := tm.metricsRecorder
-		tm.mu.Unlock()
-
-		if recorder != nil {
-			recorder.IncrementCounter(
-				clientinfo.MetricStuckWalletTransactionsTotal, 1,
-			)
 		}
 	}
 }

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -100,9 +100,8 @@ func (tm *transactionMonitor) snapshotByAge() []trackedTransactionSnapshot {
 type transactionMonitor struct {
 	btcChain bitcoin.Chain
 
-	mu                          sync.Mutex
-	tracked                     map[bitcoin.Hash]*trackedTransaction
-	inFlightConfirmationLookups map[bitcoin.Hash]struct{}
+	mu      sync.Mutex
+	tracked map[bitcoin.Hash]*trackedTransaction
 
 	threshold time.Duration
 
@@ -111,10 +110,9 @@ type transactionMonitor struct {
 
 func newTransactionMonitor(btcChain bitcoin.Chain) *transactionMonitor {
 	return &transactionMonitor{
-		btcChain:                    btcChain,
-		tracked:                     make(map[bitcoin.Hash]*trackedTransaction),
-		inFlightConfirmationLookups: make(map[bitcoin.Hash]struct{}),
-		threshold:                   defaultStuckTransactionThreshold,
+		btcChain:  btcChain,
+		tracked:   make(map[bitcoin.Hash]*trackedTransaction),
+		threshold: defaultStuckTransactionThreshold,
 	}
 }
 
@@ -215,8 +213,12 @@ func (tm *transactionMonitor) checkWithBudget(
 	// next pass. Chain calls are made on the copy, outside the lock.
 	for _, t := range tm.snapshotByAge() {
 		txHash := t.hash
-		confirmations, err, lookupCompleted :=
-			tm.getTransactionConfirmations(checkCtx, txHash)
+		// The chain call is bounded by checkCtx, so a slow or hung backend cannot
+		// keep this run loop blocked past the check budget: when the budget
+		// expires the call is cancelled and returns, and the checkCtx.Err() guard
+		// below defers the remaining transactions to the next pass.
+		confirmations, err :=
+			tm.btcChain.GetTransactionConfirmations(checkCtx, txHash)
 		if checkCtx.Err() != nil {
 			// Do not warn when the monitor itself is shutting down. Otherwise,
 			// the check budget expired and the remaining transactions will be
@@ -231,18 +233,16 @@ func (tm *transactionMonitor) checkWithBudget(
 			return
 		}
 
-		if lookupCompleted &&
-			err == nil &&
+		if err == nil &&
 			confirmations >= transactionMonitorMinConfirmations {
 			// The transaction is mined; stop tracking it.
 			tm.remove(txHash)
 			continue
 		}
 
-		// Still unconfirmed (in the mempool), not found, or a previous lookup is
-		// still in flight. An incomplete lookup or lookup error is treated the
-		// same as unconfirmed: it does not indicate the transaction confirmed and
-		// may be transient.
+		// Still unconfirmed (in the mempool), not found, or the lookup returned a
+		// transient error. A lookup error is treated the same as unconfirmed: it
+		// does not indicate the transaction confirmed and may be transient.
 		outstanding := now.Sub(t.broadcastAt)
 
 		// Alert (once) if the transaction has been unconfirmed past the stuck
@@ -289,55 +289,6 @@ func (tm *transactionMonitor) checkWithBudget(
 			)
 			tm.remove(txHash)
 		}
-	}
-}
-
-type transactionConfirmationsResult struct {
-	confirmations uint
-	err           error
-}
-
-// getTransactionConfirmations isolates the synchronous chain call so a slow or
-// hung backend cannot keep the monitor's sole run-loop goroutine blocked beyond
-// the current check deadline. The boolean result indicates whether the lookup
-// completed. An already in-flight lookup is not duplicated, which bounds
-// abandoned backend calls while allowing the check to continue with other
-// transactions on later passes.
-func (tm *transactionMonitor) getTransactionConfirmations(
-	ctx context.Context,
-	txHash bitcoin.Hash,
-) (uint, error, bool) {
-	if err := ctx.Err(); err != nil {
-		return 0, err, false
-	}
-
-	tm.mu.Lock()
-	_, lookupInFlight := tm.inFlightConfirmationLookups[txHash]
-	lookupCapacityReached :=
-		len(tm.inFlightConfirmationLookups) >= transactionMonitorMaxTracked
-	if lookupInFlight || lookupCapacityReached {
-		tm.mu.Unlock()
-		return 0, nil, false
-	}
-	tm.inFlightConfirmationLookups[txHash] = struct{}{}
-	tm.mu.Unlock()
-
-	resultChan := make(chan transactionConfirmationsResult, 1)
-	go func() {
-		confirmations, err := tm.btcChain.GetTransactionConfirmations(txHash)
-
-		tm.mu.Lock()
-		delete(tm.inFlightConfirmationLookups, txHash)
-		tm.mu.Unlock()
-
-		resultChan <- transactionConfirmationsResult{confirmations, err}
-	}()
-
-	select {
-	case result := <-resultChan:
-		return result.confirmations, result.err, true
-	case <-ctx.Done():
-		return 0, ctx.Err(), false
 	}
 }
 

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -174,9 +174,12 @@ func (tm *transactionMonitor) check() {
 	tm.mu.Unlock()
 
 	for txHash, t := range snapshot {
-		// Bound the wall-clock time of a single pass so one slow chain call
-		// cannot stall monitoring of every transaction behind it; the remaining
-		// transactions are picked up on the next pass.
+		// Bound the wall-clock time of a single pass so a run of slow chain calls
+		// cannot stall monitoring of every transaction behind them; the remaining
+		// transactions are picked up on the next pass. The deadline is checked
+		// between calls; each individual GetTransactionConfirmations call is
+		// separately bounded by the Electrum client's own operation timeouts, so a
+		// single call cannot block the pass indefinitely.
 		if time.Now().After(deadline) {
 			logger.Warnf(
 				"transaction monitor check pass exceeded its time budget [%s]; "+

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -10,11 +10,10 @@ import (
 )
 
 const (
-	// defaultStuckTransactionThresholdBlocks is the number of Bitcoin blocks a
-	// broadcast wallet transaction may remain unconfirmed before it is
-	// considered stuck and an alert is raised. Roughly 6 hours at ~10 min per
-	// block.
-	defaultStuckTransactionThresholdBlocks = uint(36)
+	// defaultStuckTransactionThreshold is how long a broadcast wallet
+	// transaction may remain unconfirmed before it is considered stuck and an
+	// alert is raised (~6 hours).
+	defaultStuckTransactionThreshold = 6 * time.Hour
 
 	// transactionMonitorCheckInterval is how often the monitor polls the
 	// confirmation status of the tracked transactions.
@@ -27,42 +26,57 @@ const (
 	// transactionMonitorMaxTracked bounds the number of tracked transactions to
 	// prevent unbounded memory growth.
 	transactionMonitorMaxTracked = 1000
+
+	// transactionMonitorMaxTrackingAge is how long a still-unconfirmed
+	// transaction is tracked before the monitor gives up on it - e.g. it was
+	// dropped from the mempool and will never confirm. Bounding the tracking
+	// duration prevents never-confirming transactions from filling up the
+	// tracking table and starving monitoring of new transactions (~24 hours).
+	transactionMonitorMaxTrackingAge = 24 * time.Hour
 )
 
 // trackedTransaction holds the monitoring state of a single broadcast wallet
 // transaction.
 type trackedTransaction struct {
 	walletPublicKeyHash [20]byte
-	broadcastBlock      uint
+	broadcastAt         time.Time
 	alerted             bool
 }
 
 // transactionMonitor watches broadcast wallet transactions (deposit sweeps,
 // redemptions, moving funds) and raises an alert if one stays unconfirmed for
-// longer than a configurable number of Bitcoin blocks. A stuck wallet
-// transaction locks the wallet's main UTXO and blocks all subsequent wallet
-// transactions until it confirms, so surfacing it lets operators intervene
-// (e.g. mempool acceleration or CPFP) promptly.
+// longer than a configurable duration. A stuck wallet transaction locks the
+// wallet's main UTXO and blocks all subsequent wallet transactions until it
+// confirms, so surfacing it lets operators intervene (e.g. mempool acceleration
+// or CPFP) promptly.
 //
 // The monitor only emits a metric and a warn-level log identifying the wallet
 // and transaction; automated recovery (fee-bumping / RBF) is intentionally out
-// of scope (see threshold-network/keep-core#4171).
+// of scope (see threshold-network/keep-core#4171). Alerting is left to the
+// operator's monitoring stack. Every wallet operator that broadcasts a given
+// transaction tracks it independently, so the metric and log are emitted per
+// operator and should be de-duplicated by transaction hash downstream.
+//
+// The tracked set is in-memory only. A transaction that is already stuck when
+// the node restarts is not re-tracked (it was broadcast by the previous
+// process), so cross-restart stuck transactions are not detected here; they
+// remain covered by the coarser wallet-level liveness metrics.
 type transactionMonitor struct {
 	btcChain bitcoin.Chain
 
 	mu      sync.Mutex
 	tracked map[bitcoin.Hash]*trackedTransaction
 
-	thresholdBlocks uint
+	threshold time.Duration
 
 	metricsRecorder clientinfo.PerformanceMetricsRecorder
 }
 
 func newTransactionMonitor(btcChain bitcoin.Chain) *transactionMonitor {
 	return &transactionMonitor{
-		btcChain:        btcChain,
-		tracked:         make(map[bitcoin.Hash]*trackedTransaction),
-		thresholdBlocks: defaultStuckTransactionThresholdBlocks,
+		btcChain:  btcChain,
+		tracked:   make(map[bitcoin.Hash]*trackedTransaction),
+		threshold: defaultStuckTransactionThreshold,
 	}
 }
 
@@ -78,22 +92,12 @@ func (tm *transactionMonitor) setMetricsRecorder(
 
 // track registers a freshly broadcast wallet transaction for confirmation
 // monitoring. It is a no-op if the transaction is already tracked or the
-// tracking table is full.
+// tracking table is full. It performs no network calls, so it never blocks the
+// broadcast path or silently drops a transaction due to a chain lookup failure.
 func (tm *transactionMonitor) track(
 	txHash bitcoin.Hash,
 	walletPublicKeyHash [20]byte,
 ) {
-	broadcastBlock, err := tm.btcChain.GetLatestBlockHeight()
-	if err != nil {
-		logger.Warnf(
-			"transaction monitor cannot read latest block height while "+
-				"tracking transaction [%s]: [%v]",
-			txHash.Hex(bitcoin.ReversedByteOrder),
-			err,
-		)
-		return
-	}
-
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 
@@ -113,7 +117,7 @@ func (tm *transactionMonitor) track(
 
 	tm.tracked[txHash] = &trackedTransaction{
 		walletPublicKeyHash: walletPublicKeyHash,
-		broadcastBlock:      broadcastBlock,
+		broadcastAt:         time.Now(),
 	}
 }
 
@@ -133,17 +137,15 @@ func (tm *transactionMonitor) run(ctx context.Context) {
 }
 
 // check polls the confirmation status of every tracked transaction once. It
-// drops confirmed transactions and alerts (once) on those that have remained
-// unconfirmed for longer than the stuck threshold.
+// drops confirmed transactions, gives up on ones that have been unconfirmed for
+// too long, and alerts (once) on those that have remained unconfirmed for longer
+// than the stuck threshold.
+//
+// check is only ever called from the single run loop goroutine. track may run
+// concurrently but only inserts new entries, so the per-entry alerted flag is
+// only ever mutated here, under the mutex.
 func (tm *transactionMonitor) check() {
-	latestBlock, err := tm.btcChain.GetLatestBlockHeight()
-	if err != nil {
-		logger.Warnf(
-			"transaction monitor cannot read latest block height: [%v]",
-			err,
-		)
-		return
-	}
+	now := time.Now()
 
 	// Snapshot the tracked set so chain calls are not made under the lock.
 	tm.mu.Lock()
@@ -157,44 +159,64 @@ func (tm *transactionMonitor) check() {
 		confirmations, err := tm.btcChain.GetTransactionConfirmations(txHash)
 		if err == nil && confirmations >= transactionMonitorMinConfirmations {
 			// The transaction is mined; stop tracking it.
-			tm.mu.Lock()
-			delete(tm.tracked, txHash)
-			tm.mu.Unlock()
+			tm.remove(txHash)
 			continue
 		}
 
-		// Still unconfirmed (in the mempool) or not yet found. A lookup error is
+		// Still unconfirmed (in the mempool) or not found. A lookup error is
 		// treated the same as unconfirmed: it does not indicate the transaction
-		// confirmed, and it may be transient.
-		var blocksOutstanding uint
-		if latestBlock >= t.broadcastBlock {
-			blocksOutstanding = latestBlock - t.broadcastBlock
+		// confirmed and may be transient.
+		outstanding := now.Sub(t.broadcastAt)
+
+		// Give up on transactions that have been unconfirmed for too long (e.g.
+		// dropped from the mempool) so they cannot fill the tracking table.
+		if outstanding > transactionMonitorMaxTrackingAge {
+			logger.Warnf(
+				"giving up monitoring wallet transaction [%s] for wallet "+
+					"[0x%x]; it has been unconfirmed for [%s]",
+				txHash.Hex(bitcoin.ReversedByteOrder),
+				t.walletPublicKeyHash,
+				outstanding.Round(time.Minute),
+			)
+			tm.remove(txHash)
+			continue
 		}
 
-		if blocksOutstanding <= tm.thresholdBlocks || t.alerted {
+		if outstanding <= tm.threshold || t.alerted {
 			continue
 		}
 
 		logger.Warnf(
 			"wallet transaction [%s] for wallet [0x%x] has been unconfirmed "+
-				"for [%d] blocks (threshold [%d]); it may be stuck in the "+
-				"mempool and blocking subsequent wallet transactions - consider "+
-				"fee-bumping or accelerating it",
+				"for [%s] (threshold [%s]); it may be stuck in the mempool and "+
+				"blocking subsequent wallet transactions - consider fee-bumping "+
+				"or accelerating it",
 			txHash.Hex(bitcoin.ReversedByteOrder),
 			t.walletPublicKeyHash,
-			blocksOutstanding,
-			tm.thresholdBlocks,
+			outstanding.Round(time.Minute),
+			tm.threshold,
 		)
 
+		// Mark as alerted and read the recorder under the lock, but emit the
+		// metric outside the lock to avoid holding it during an external call.
 		tm.mu.Lock()
 		if tracked, ok := tm.tracked[txHash]; ok {
 			tracked.alerted = true
 		}
-		if tm.metricsRecorder != nil {
-			tm.metricsRecorder.IncrementCounter(
+		recorder := tm.metricsRecorder
+		tm.mu.Unlock()
+
+		if recorder != nil {
+			recorder.IncrementCounter(
 				clientinfo.MetricStuckWalletTransactionsTotal, 1,
 			)
 		}
-		tm.mu.Unlock()
 	}
+}
+
+// remove stops tracking the transaction with the given hash.
+func (tm *transactionMonitor) remove(txHash bitcoin.Hash) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	delete(tm.tracked, txHash)
 }

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -72,7 +72,7 @@ func (tm *transactionMonitor) snapshotByAge() []trackedTransactionSnapshot {
 	}
 	tm.mu.Unlock()
 
-	sort.Slice(ordered, func(i, j int) bool {
+	sort.SliceStable(ordered, func(i, j int) bool {
 		return ordered[i].broadcastAt.Before(ordered[j].broadcastAt)
 	})
 
@@ -215,25 +215,27 @@ func (tm *transactionMonitor) checkWithBudget(
 		txHash := t.hash
 		// The chain call is bounded by checkCtx, so a slow or hung backend cannot
 		// keep this run loop blocked past the check budget: when the budget
-		// expires the call is cancelled and returns, and the checkCtx.Err() guard
-		// below defers the remaining transactions to the next pass.
+		// expires the call is cancelled and returns.
 		confirmations, err :=
 			tm.btcChain.GetTransactionConfirmations(checkCtx, txHash)
-		if checkCtx.Err() != nil {
-			// Do not warn when the monitor itself is shutting down. Otherwise,
-			// the check budget expired and the remaining transactions will be
-			// handled on the next pass.
-			if ctx.Err() == nil {
-				logger.Warnf(
-					"transaction monitor check pass exceeded its time budget [%s]; "+
-						"deferring the remaining transactions to the next pass",
-					checkBudget,
-				)
-			}
+
+		// Stop immediately if the monitor itself is shutting down.
+		if ctx.Err() != nil {
 			return
 		}
 
-		if err == nil &&
+		// The budget may have expired during the lookup above. The age-based
+		// alert and eviction below need no network data, so still run them for
+		// the current transaction - whose lookup was attempted and cancelled -
+		// before deferring the rest. Otherwise a backend that hangs on the oldest
+		// tracked transaction every pass would keep it (the one closest to the
+		// stuck threshold) from ever alerting or being evicted. The remaining
+		// transactions are deferred, not alerted: alerting on a transaction we
+		// never looked up this pass could raise a false alert for one that has
+		// in fact confirmed.
+		budgetExpired := checkCtx.Err() != nil
+
+		if !budgetExpired && err == nil &&
 			confirmations >= transactionMonitorMinConfirmations {
 			// The transaction is mined; stop tracking it.
 			tm.remove(txHash)
@@ -288,6 +290,19 @@ func (tm *transactionMonitor) checkWithBudget(
 				outstanding.Round(time.Minute),
 			)
 			tm.remove(txHash)
+		}
+
+		if budgetExpired {
+			// The check budget expired during this transaction's lookup; its
+			// age-based alert/eviction ran above, and the remaining transactions
+			// are deferred to the next pass. The monitor is not shutting down here
+			// (that returned earlier), so the warning is unconditional.
+			logger.Warnf(
+				"transaction monitor check pass exceeded its time budget [%s]; "+
+					"deferring the remaining transactions to the next pass",
+				checkBudget,
+			)
+			return
 		}
 	}
 }

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -100,8 +100,9 @@ func (tm *transactionMonitor) snapshotByAge() []trackedTransactionSnapshot {
 type transactionMonitor struct {
 	btcChain bitcoin.Chain
 
-	mu      sync.Mutex
-	tracked map[bitcoin.Hash]*trackedTransaction
+	mu                          sync.Mutex
+	tracked                     map[bitcoin.Hash]*trackedTransaction
+	inFlightConfirmationLookups map[bitcoin.Hash]struct{}
 
 	threshold time.Duration
 
@@ -110,9 +111,10 @@ type transactionMonitor struct {
 
 func newTransactionMonitor(btcChain bitcoin.Chain) *transactionMonitor {
 	return &transactionMonitor{
-		btcChain:  btcChain,
-		tracked:   make(map[bitcoin.Hash]*trackedTransaction),
-		threshold: defaultStuckTransactionThreshold,
+		btcChain:                    btcChain,
+		tracked:                     make(map[bitcoin.Hash]*trackedTransaction),
+		inFlightConfirmationLookups: make(map[bitcoin.Hash]struct{}),
+		threshold:                   defaultStuckTransactionThreshold,
 	}
 }
 
@@ -178,7 +180,7 @@ func (tm *transactionMonitor) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			tm.check()
+			tm.check(ctx)
 		}
 	}
 }
@@ -191,9 +193,21 @@ func (tm *transactionMonitor) run(ctx context.Context) {
 // check is only ever called from the single run loop goroutine. track may run
 // concurrently but only inserts new entries, so the per-entry alerted flag is
 // only ever mutated here, under the mutex.
-func (tm *transactionMonitor) check() {
+func (tm *transactionMonitor) check(ctx context.Context) {
+	tm.checkWithBudget(ctx, transactionMonitorCheckBudget)
+}
+
+func (tm *transactionMonitor) checkWithBudget(
+	ctx context.Context,
+	checkBudget time.Duration,
+) {
+	checkCtx, cancelCheck := context.WithTimeout(
+		ctx,
+		checkBudget,
+	)
+	defer cancelCheck()
+
 	now := time.Now()
-	deadline := now.Add(transactionMonitorCheckBudget)
 
 	// Iterate the tracked set oldest-first (see snapshotByAge) so a pass that
 	// hits its time budget never starves the transactions closest to the stuck
@@ -201,31 +215,34 @@ func (tm *transactionMonitor) check() {
 	// next pass. Chain calls are made on the copy, outside the lock.
 	for _, t := range tm.snapshotByAge() {
 		txHash := t.hash
-		// Bound the wall-clock time of a single pass so a run of slow chain calls
-		// cannot stall monitoring of every transaction behind them; the remaining
-		// transactions are picked up on the next pass. The deadline is checked
-		// between calls; each individual GetTransactionConfirmations call is
-		// separately bounded by the Electrum client's own operation timeouts, so a
-		// single call cannot block the pass indefinitely.
-		if time.Now().After(deadline) {
-			logger.Warnf(
-				"transaction monitor check pass exceeded its time budget [%s]; "+
-					"deferring the remaining transactions to the next pass",
-				transactionMonitorCheckBudget,
-			)
-			break
+		confirmations, err, lookupCompleted :=
+			tm.getTransactionConfirmations(checkCtx, txHash)
+		if checkCtx.Err() != nil {
+			// Do not warn when the monitor itself is shutting down. Otherwise,
+			// the check budget expired and the remaining transactions will be
+			// handled on the next pass.
+			if ctx.Err() == nil {
+				logger.Warnf(
+					"transaction monitor check pass exceeded its time budget [%s]; "+
+						"deferring the remaining transactions to the next pass",
+					checkBudget,
+				)
+			}
+			return
 		}
 
-		confirmations, err := tm.btcChain.GetTransactionConfirmations(txHash)
-		if err == nil && confirmations >= transactionMonitorMinConfirmations {
+		if lookupCompleted &&
+			err == nil &&
+			confirmations >= transactionMonitorMinConfirmations {
 			// The transaction is mined; stop tracking it.
 			tm.remove(txHash)
 			continue
 		}
 
-		// Still unconfirmed (in the mempool) or not found. A lookup error is
-		// treated the same as unconfirmed: it does not indicate the transaction
-		// confirmed and may be transient.
+		// Still unconfirmed (in the mempool), not found, or a previous lookup is
+		// still in flight. An incomplete lookup or lookup error is treated the
+		// same as unconfirmed: it does not indicate the transaction confirmed and
+		// may be transient.
 		outstanding := now.Sub(t.broadcastAt)
 
 		// Alert (once) if the transaction has been unconfirmed past the stuck
@@ -272,6 +289,55 @@ func (tm *transactionMonitor) check() {
 			)
 			tm.remove(txHash)
 		}
+	}
+}
+
+type transactionConfirmationsResult struct {
+	confirmations uint
+	err           error
+}
+
+// getTransactionConfirmations isolates the synchronous chain call so a slow or
+// hung backend cannot keep the monitor's sole run-loop goroutine blocked beyond
+// the current check deadline. The boolean result indicates whether the lookup
+// completed. An already in-flight lookup is not duplicated, which bounds
+// abandoned backend calls while allowing the check to continue with other
+// transactions on later passes.
+func (tm *transactionMonitor) getTransactionConfirmations(
+	ctx context.Context,
+	txHash bitcoin.Hash,
+) (uint, error, bool) {
+	if err := ctx.Err(); err != nil {
+		return 0, err, false
+	}
+
+	tm.mu.Lock()
+	_, lookupInFlight := tm.inFlightConfirmationLookups[txHash]
+	lookupCapacityReached :=
+		len(tm.inFlightConfirmationLookups) >= transactionMonitorMaxTracked
+	if lookupInFlight || lookupCapacityReached {
+		tm.mu.Unlock()
+		return 0, nil, false
+	}
+	tm.inFlightConfirmationLookups[txHash] = struct{}{}
+	tm.mu.Unlock()
+
+	resultChan := make(chan transactionConfirmationsResult, 1)
+	go func() {
+		confirmations, err := tm.btcChain.GetTransactionConfirmations(txHash)
+
+		tm.mu.Lock()
+		delete(tm.inFlightConfirmationLookups, txHash)
+		tm.mu.Unlock()
+
+		resultChan <- transactionConfirmationsResult{confirmations, err}
+	}()
+
+	select {
+	case result := <-resultChan:
+		return result.confirmations, result.err, true
+	case <-ctx.Done():
+		return 0, ctx.Err(), false
 	}
 }
 

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
@@ -47,6 +48,35 @@ type trackedTransaction struct {
 	walletPublicKeyHash [20]byte
 	broadcastAt         time.Time
 	alerted             bool
+}
+
+// trackedTransactionSnapshot pairs a copy of a tracked transaction with its hash
+// so the check loop can iterate an ordered snapshot outside the lock.
+type trackedTransactionSnapshot struct {
+	hash bitcoin.Hash
+	trackedTransaction
+}
+
+// snapshotByAge returns a copy of the tracked transactions ordered by broadcast
+// time, oldest first. Checking oldest first ensures the transactions closest to
+// the stuck threshold are never starved when a check pass hits its time budget:
+// Go map iteration order is randomized, so without an explicit ordering an
+// unlucky old transaction could be skipped pass after pass and miss its
+// threshold; with it, only the newest transactions - furthest from alerting -
+// are ever deferred. The copy is taken under the lock; the sort is not.
+func (tm *transactionMonitor) snapshotByAge() []trackedTransactionSnapshot {
+	tm.mu.Lock()
+	ordered := make([]trackedTransactionSnapshot, 0, len(tm.tracked))
+	for hash, t := range tm.tracked {
+		ordered = append(ordered, trackedTransactionSnapshot{hash, *t})
+	}
+	tm.mu.Unlock()
+
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].broadcastAt.Before(ordered[j].broadcastAt)
+	})
+
+	return ordered
 }
 
 // transactionMonitor watches broadcast wallet transactions (deposit sweeps,
@@ -165,15 +195,12 @@ func (tm *transactionMonitor) check() {
 	now := time.Now()
 	deadline := now.Add(transactionMonitorCheckBudget)
 
-	// Snapshot the tracked set so chain calls are not made under the lock.
-	tm.mu.Lock()
-	snapshot := make(map[bitcoin.Hash]trackedTransaction, len(tm.tracked))
-	for hash, t := range tm.tracked {
-		snapshot[hash] = *t
-	}
-	tm.mu.Unlock()
-
-	for txHash, t := range snapshot {
+	// Iterate the tracked set oldest-first (see snapshotByAge) so a pass that
+	// hits its time budget never starves the transactions closest to the stuck
+	// threshold; only the newest, furthest-from-alerting ones are deferred to the
+	// next pass. Chain calls are made on the copy, outside the lock.
+	for _, t := range tm.snapshotByAge() {
+		txHash := t.hash
 		// Bound the wall-clock time of a single pass so a run of slow chain calls
 		// cannot stall monitoring of every transaction behind them; the remaining
 		// transactions are picked up on the next pass. The deadline is checked

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -76,8 +76,16 @@ func TestTransactionMonitor(t *testing.T) {
 		t.Fatalf("expected no alert for a fresh transaction; got counter [%v]", got)
 	}
 
+	// At/just below the threshold: still not stuck. The alert condition is
+	// strictly greater than the threshold, so the boundary itself does not fire.
+	ageTransaction(monitor, txHash, defaultStuckTransactionThreshold-time.Minute)
+	monitor.check()
+	if got := stuckCount(); got != 0 {
+		t.Fatalf("expected no alert at the threshold boundary; got counter [%v]", got)
+	}
+
 	// Past the threshold: flagged as stuck exactly once across repeated checks.
-	ageTransaction(monitor, txHash, defaultStuckTransactionThreshold+time.Minute)
+	ageTransaction(monitor, txHash, 2*time.Minute) // now threshold + 1 minute total
 	monitor.check()
 	monitor.check()
 	if got := stuckCount(); got != 1 {
@@ -98,17 +106,26 @@ func TestTransactionMonitor(t *testing.T) {
 // that never confirms is eventually evicted so it cannot fill the tracking
 // table.
 func TestTransactionMonitor_GivesUpOnNeverConfirming(t *testing.T) {
+	recorder := newCountingMetricsRecorder()
 	monitor := newTransactionMonitor(newLocalBitcoinChain())
+	monitor.setMetricsRecorder(recorder)
 
 	tx := &bitcoin.Transaction{}
 	txHash := tx.Hash()
 	monitor.track(txHash, [20]byte{})
 
-	// Age it beyond the maximum tracking age; it never confirmed, so it is
-	// dropped rather than tracked forever.
+	// Age it beyond the maximum tracking age; on its first check it is past both
+	// the stuck threshold and the give-up age. It must still fire exactly one
+	// stuck alert (the alert runs before eviction) and then be evicted rather
+	// than tracked forever.
 	ageTransaction(monitor, txHash, transactionMonitorMaxTrackingAge+time.Minute)
 	monitor.check()
 
+	if got := recorder.GetCounterValue(
+		clientinfo.MetricStuckWalletTransactionsTotal,
+	); got != 1 {
+		t.Fatalf("expected one stuck alert before eviction; got counter [%v]", got)
+	}
 	if isTracked(monitor, txHash) {
 		t.Fatal("expected a never-confirming transaction to be evicted")
 	}
@@ -117,9 +134,12 @@ func TestTransactionMonitor_GivesUpOnNeverConfirming(t *testing.T) {
 // TestTransactionMonitor_CapacityBound verifies the tracking table does not grow
 // past its bound.
 func TestTransactionMonitor_CapacityBound(t *testing.T) {
+	recorder := newCountingMetricsRecorder()
 	monitor := newTransactionMonitor(newLocalBitcoinChain())
+	monitor.setMetricsRecorder(recorder)
 
-	for i := 0; i < transactionMonitorMaxTracked+10; i++ {
+	const excess = 10
+	for i := 0; i < transactionMonitorMaxTracked+excess; i++ {
 		var h bitcoin.Hash
 		h[0] = byte(i)
 		h[1] = byte(i >> 8)
@@ -130,6 +150,18 @@ func TestTransactionMonitor_CapacityBound(t *testing.T) {
 		t.Fatalf(
 			"expected tracking table bounded to [%d]; got [%d]",
 			transactionMonitorMaxTracked,
+			got,
+		)
+	}
+
+	// The transactions that could not be tracked once the table filled must be
+	// surfaced via the unmonitored-transactions metric.
+	if got := recorder.GetCounterValue(
+		clientinfo.MetricUnmonitoredWalletTransactionsTotal,
+	); got != excess {
+		t.Fatalf(
+			"expected [%d] unmonitored-transaction increments; got [%v]",
+			excess,
 			got,
 		)
 	}

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -232,7 +232,16 @@ func TestTransactionMonitor_CheckBudgetBoundsLookup(t *testing.T) {
 	confirmedTxHash := confirmedTx.Hash()
 	monitor.track(confirmedTxHash, [20]byte{})
 
-	monitor.check(context.Background())
+	secondCheckDone := make(chan struct{})
+	go func() {
+		monitor.check(context.Background())
+		close(secondCheckDone)
+	}()
+	select {
+	case <-secondCheckDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second check pass stalled on the in-flight lookup")
+	}
 
 	if got := chain.getLookupCount(); got != 1 {
 		t.Fatalf("expected one in-flight lookup; got [%d]", got)

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -169,3 +169,43 @@ func TestTransactionMonitor_CapacityBound(t *testing.T) {
 		)
 	}
 }
+
+// TestTransactionMonitor_SnapshotByAge verifies the check pass iterates tracked
+// transactions oldest-first, so an old transaction near the stuck threshold is
+// never starved when a pass hits its time budget (Go map order is randomized).
+func TestTransactionMonitor_SnapshotByAge(t *testing.T) {
+	monitor := newTransactionMonitor(newLocalBitcoinChain())
+
+	var h1, h2, h3 bitcoin.Hash
+	h1[0], h2[0], h3[0] = 1, 2, 3
+	monitor.track(h1, [20]byte{})
+	monitor.track(h2, [20]byte{})
+	monitor.track(h3, [20]byte{})
+
+	// Backdate broadcast times so the age order is h2 (oldest), h3, h1 (newest).
+	// The hour-scale gaps dwarf the sub-second differences in track() times.
+	ageTransaction(monitor, h1, 1*time.Hour)
+	ageTransaction(monitor, h2, 3*time.Hour)
+	ageTransaction(monitor, h3, 2*time.Hour)
+
+	ordered := monitor.snapshotByAge()
+
+	want := []bitcoin.Hash{h2, h3, h1}
+	if len(ordered) != len(want) {
+		t.Fatalf("expected [%d] entries; got [%d]", len(want), len(ordered))
+	}
+	for i, w := range want {
+		if ordered[i].hash != w {
+			t.Fatalf(
+				"snapshotByAge not oldest-first at index [%d]\nexpected: %v\ngot:      %v",
+				i, want, []bitcoin.Hash{ordered[0].hash, ordered[1].hash, ordered[2].hash},
+			)
+		}
+	}
+	// Broadcast times must be non-decreasing across the ordered snapshot.
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i].broadcastAt.Before(ordered[i-1].broadcastAt) {
+			t.Fatalf("entry [%d] is older than entry [%d]; not sorted oldest-first", i, i-1)
+		}
+	}
+}

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -1,6 +1,8 @@
 package tbtc
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,6 +57,53 @@ func trackedCount(tm *transactionMonitor) int {
 	return len(tm.tracked)
 }
 
+type blockingTransactionConfirmationsChain struct {
+	*localBitcoinChain
+
+	blockedHash   bitcoin.Hash
+	lookupMutex   sync.Mutex
+	lookupCount   int
+	startedOnce   sync.Once
+	doneOnce      sync.Once
+	lookupStarted chan struct{}
+	lookupRelease chan struct{}
+	lookupDone    chan struct{}
+}
+
+func newBlockingTransactionConfirmationsChain(
+	blockedHash bitcoin.Hash,
+) *blockingTransactionConfirmationsChain {
+	return &blockingTransactionConfirmationsChain{
+		localBitcoinChain: newLocalBitcoinChain(),
+		blockedHash:       blockedHash,
+		lookupStarted:     make(chan struct{}),
+		lookupRelease:     make(chan struct{}),
+		lookupDone:        make(chan struct{}),
+	}
+}
+
+func (c *blockingTransactionConfirmationsChain) GetTransactionConfirmations(
+	transactionHash bitcoin.Hash,
+) (uint, error) {
+	if transactionHash == c.blockedHash {
+		c.lookupMutex.Lock()
+		c.lookupCount++
+		c.lookupMutex.Unlock()
+
+		c.startedOnce.Do(func() { close(c.lookupStarted) })
+		<-c.lookupRelease
+		c.doneOnce.Do(func() { close(c.lookupDone) })
+	}
+
+	return c.localBitcoinChain.GetTransactionConfirmations(transactionHash)
+}
+
+func (c *blockingTransactionConfirmationsChain) getLookupCount() int {
+	c.lookupMutex.Lock()
+	defer c.lookupMutex.Unlock()
+	return c.lookupCount
+}
+
 func TestTransactionMonitor(t *testing.T) {
 	chain := newLocalBitcoinChain()
 	recorder := newCountingMetricsRecorder()
@@ -71,7 +120,7 @@ func TestTransactionMonitor(t *testing.T) {
 	}
 
 	// Fresh: not yet stuck.
-	monitor.check()
+	monitor.check(context.Background())
 	if got := stuckCount(); got != 0 {
 		t.Fatalf("expected no alert for a fresh transaction; got counter [%v]", got)
 	}
@@ -82,15 +131,15 @@ func TestTransactionMonitor(t *testing.T) {
 	// elapsed time a hair past any exact backdated value, so it cannot be pinned
 	// deterministically without an injectable clock.
 	ageTransaction(monitor, txHash, defaultStuckTransactionThreshold-time.Minute)
-	monitor.check()
+	monitor.check(context.Background())
 	if got := stuckCount(); got != 0 {
 		t.Fatalf("expected no alert at the threshold boundary; got counter [%v]", got)
 	}
 
 	// Past the threshold: flagged as stuck exactly once across repeated checks.
 	ageTransaction(monitor, txHash, 2*time.Minute) // now threshold + 1 minute total
-	monitor.check()
-	monitor.check()
+	monitor.check(context.Background())
+	monitor.check(context.Background())
 	if got := stuckCount(); got != 1 {
 		t.Fatalf("expected exactly one alert; got counter [%v]", got)
 	}
@@ -99,7 +148,7 @@ func TestTransactionMonitor(t *testing.T) {
 	if err := chain.BroadcastTransaction(tx); err != nil {
 		t.Fatalf("unexpected error confirming transaction: [%v]", err)
 	}
-	monitor.check()
+	monitor.check(context.Background())
 	if isTracked(monitor, txHash) {
 		t.Fatal("expected confirmed transaction to be untracked")
 	}
@@ -122,7 +171,7 @@ func TestTransactionMonitor_GivesUpOnNeverConfirming(t *testing.T) {
 	// stuck alert (the alert runs before eviction) and then be evicted rather
 	// than tracked forever.
 	ageTransaction(monitor, txHash, transactionMonitorMaxTrackingAge+time.Minute)
-	monitor.check()
+	monitor.check(context.Background())
 
 	if got := recorder.GetCounterValue(
 		clientinfo.MetricStuckWalletTransactionsTotal,
@@ -131,6 +180,75 @@ func TestTransactionMonitor_GivesUpOnNeverConfirming(t *testing.T) {
 	}
 	if isTracked(monitor, txHash) {
 		t.Fatal("expected a never-confirming transaction to be evicted")
+	}
+}
+
+// TestTransactionMonitor_CheckBudgetBoundsLookup verifies that a chain lookup
+// cannot keep the monitor's sole check goroutine blocked beyond the check
+// budget.
+func TestTransactionMonitor_CheckBudgetBoundsLookup(t *testing.T) {
+	blockedTxHash := bitcoin.Hash{1}
+	chain := newBlockingTransactionConfirmationsChain(blockedTxHash)
+	monitor := newTransactionMonitor(chain)
+
+	monitor.track(blockedTxHash, [20]byte{})
+
+	lookupReleased := false
+	defer func() {
+		if !lookupReleased {
+			close(chain.lookupRelease)
+		}
+	}()
+
+	checkDone := make(chan struct{})
+	go func() {
+		monitor.checkWithBudget(context.Background(), 500*time.Millisecond)
+		close(checkDone)
+	}()
+
+	select {
+	case <-chain.lookupStarted:
+	case <-time.After(time.Second):
+		t.Fatal("confirmation lookup did not start")
+	}
+
+	// The backend remains blocked while the budget must release the check.
+	select {
+	case <-checkDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("transaction check remained blocked after its budget expired")
+	}
+
+	if !isTracked(monitor, blockedTxHash) {
+		t.Fatal("expected transaction with an incomplete lookup to remain tracked")
+	}
+
+	// A later pass must skip the lookup that is still in flight, avoid starting
+	// a duplicate, and continue checking other transactions.
+	confirmedTx := &bitcoin.Transaction{}
+	if err := chain.BroadcastTransaction(confirmedTx); err != nil {
+		t.Fatalf("unexpected error confirming transaction: [%v]", err)
+	}
+	confirmedTxHash := confirmedTx.Hash()
+	monitor.track(confirmedTxHash, [20]byte{})
+
+	monitor.check(context.Background())
+
+	if got := chain.getLookupCount(); got != 1 {
+		t.Fatalf("expected one in-flight lookup; got [%d]", got)
+	}
+	if isTracked(monitor, confirmedTxHash) {
+		t.Fatal("expected the other confirmed transaction to be untracked")
+	}
+
+	// Release the intentionally blocked backend and wait for it to finish so the
+	// test does not leave a goroutine behind.
+	close(chain.lookupRelease)
+	lookupReleased = true
+	select {
+	case <-chain.lookupDone:
+	case <-time.After(time.Second):
+		t.Fatal("confirmation lookup did not finish after being released")
 	}
 }
 

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -83,6 +83,7 @@ func newBlockingTransactionConfirmationsChain(
 }
 
 func (c *blockingTransactionConfirmationsChain) GetTransactionConfirmations(
+	ctx context.Context,
 	transactionHash bitcoin.Hash,
 ) (uint, error) {
 	if transactionHash == c.blockedHash {
@@ -91,11 +92,17 @@ func (c *blockingTransactionConfirmationsChain) GetTransactionConfirmations(
 		c.lookupMutex.Unlock()
 
 		c.startedOnce.Do(func() { close(c.lookupStarted) })
-		<-c.lookupRelease
-		c.doneOnce.Do(func() { close(c.lookupDone) })
+		// Block until released, but honor the context so a check pass that hits
+		// its budget can cancel the lookup instead of stalling on the backend.
+		select {
+		case <-c.lookupRelease:
+			c.doneOnce.Do(func() { close(c.lookupDone) })
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
 	}
 
-	return c.localBitcoinChain.GetTransactionConfirmations(transactionHash)
+	return c.localBitcoinChain.GetTransactionConfirmations(ctx, transactionHash)
 }
 
 func (c *blockingTransactionConfirmationsChain) getLookupCount() int {
@@ -193,10 +200,13 @@ func TestTransactionMonitor_CheckBudgetBoundsLookup(t *testing.T) {
 
 	monitor.track(blockedTxHash, [20]byte{})
 
+	// Ensure the intentionally blocked backend is released even if the test
+	// fails, so the mock's lookup goroutine is never left parked.
 	lookupReleased := false
 	defer func() {
 		if !lookupReleased {
 			close(chain.lookupRelease)
+			lookupReleased = true
 		}
 	}()
 
@@ -212,52 +222,24 @@ func TestTransactionMonitor_CheckBudgetBoundsLookup(t *testing.T) {
 		t.Fatal("confirmation lookup did not start")
 	}
 
-	// The backend remains blocked while the budget must release the check.
+	// The backend never unblocks, so only the check budget can release the pass.
+	// This is the crux: the monitor threads the budgeted context into the chain
+	// call, so budget expiry cancels the lookup and the pass returns. If it did
+	// not, this would block until the timeout below and fail.
 	select {
 	case <-checkDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("transaction check remained blocked after its budget expired")
 	}
 
-	if !isTracked(monitor, blockedTxHash) {
-		t.Fatal("expected transaction with an incomplete lookup to remain tracked")
-	}
-
-	// A later pass must skip the lookup that is still in flight, avoid starting
-	// a duplicate, and continue checking other transactions.
-	confirmedTx := &bitcoin.Transaction{}
-	if err := chain.BroadcastTransaction(confirmedTx); err != nil {
-		t.Fatalf("unexpected error confirming transaction: [%v]", err)
-	}
-	confirmedTxHash := confirmedTx.Hash()
-	monitor.track(confirmedTxHash, [20]byte{})
-
-	secondCheckDone := make(chan struct{})
-	go func() {
-		monitor.check(context.Background())
-		close(secondCheckDone)
-	}()
-	select {
-	case <-secondCheckDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("second check pass stalled on the in-flight lookup")
-	}
-
 	if got := chain.getLookupCount(); got != 1 {
-		t.Fatalf("expected one in-flight lookup; got [%d]", got)
-	}
-	if isTracked(monitor, confirmedTxHash) {
-		t.Fatal("expected the other confirmed transaction to be untracked")
+		t.Fatalf("expected exactly one confirmation lookup; got [%d]", got)
 	}
 
-	// Release the intentionally blocked backend and wait for it to finish so the
-	// test does not leave a goroutine behind.
-	close(chain.lookupRelease)
-	lookupReleased = true
-	select {
-	case <-chain.lookupDone:
-	case <-time.After(time.Second):
-		t.Fatal("confirmation lookup did not finish after being released")
+	// The cancelled lookup is treated as unconfirmed, so the transaction stays
+	// tracked and is retried on a later pass.
+	if !isTracked(monitor, blockedTxHash) {
+		t.Fatal("expected transaction with a cancelled lookup to remain tracked")
 	}
 }
 

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -8,17 +8,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/clientinfo"
 )
 
-// monitorTestChain embeds the local Bitcoin chain mock and adds a settable
-// latest block height, which the base mock does not implement.
-type monitorTestChain struct {
-	*localBitcoinChain
-	latestBlockHeight uint
-}
-
-func (m *monitorTestChain) GetLatestBlockHeight() (uint, error) {
-	return m.latestBlockHeight, nil
-}
-
 // countingMetricsRecorder is a PerformanceMetricsRecorder that counts counter
 // increments so tests can assert the stuck-transaction metric fired.
 type countingMetricsRecorder struct {
@@ -39,11 +28,35 @@ func (c *countingMetricsRecorder) GetCounterValue(name string) float64 {
 }
 func (c *countingMetricsRecorder) GetGaugeValue(string) float64 { return 0 }
 
-func TestTransactionMonitor(t *testing.T) {
-	chain := &monitorTestChain{
-		localBitcoinChain: newLocalBitcoinChain(),
-		latestBlockHeight: 100,
+// ageTransaction backdates the broadcast time of a tracked transaction to
+// simulate the passage of time.
+func ageTransaction(
+	tm *transactionMonitor,
+	txHash bitcoin.Hash,
+	by time.Duration,
+) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if t, ok := tm.tracked[txHash]; ok {
+		t.broadcastAt = t.broadcastAt.Add(-by)
 	}
+}
+
+func isTracked(tm *transactionMonitor, txHash bitcoin.Hash) bool {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	_, ok := tm.tracked[txHash]
+	return ok
+}
+
+func trackedCount(tm *transactionMonitor) int {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	return len(tm.tracked)
+}
+
+func TestTransactionMonitor(t *testing.T) {
+	chain := newLocalBitcoinChain()
 	recorder := newCountingMetricsRecorder()
 
 	monitor := newTransactionMonitor(chain)
@@ -51,40 +64,73 @@ func TestTransactionMonitor(t *testing.T) {
 
 	tx := &bitcoin.Transaction{}
 	txHash := tx.Hash()
-	walletPublicKeyHash := [20]byte{1, 2, 3}
-
-	monitor.track(txHash, walletPublicKeyHash)
+	monitor.track(txHash, [20]byte{1, 2, 3})
 
 	stuckCount := func() float64 {
 		return recorder.GetCounterValue(clientinfo.MetricStuckWalletTransactionsTotal)
 	}
 
-	// At exactly the threshold the transaction is not yet considered stuck.
-	chain.latestBlockHeight = 100 + defaultStuckTransactionThresholdBlocks
+	// Fresh: not yet stuck.
 	monitor.check()
 	if got := stuckCount(); got != 0 {
-		t.Fatalf("expected no alert at threshold; got counter [%v]", got)
+		t.Fatalf("expected no alert for a fresh transaction; got counter [%v]", got)
 	}
 
-	// One block past the threshold it is flagged as stuck, exactly once even
-	// across repeated checks.
-	chain.latestBlockHeight = 100 + defaultStuckTransactionThresholdBlocks + 1
+	// Past the threshold: flagged as stuck exactly once across repeated checks.
+	ageTransaction(monitor, txHash, defaultStuckTransactionThreshold+time.Minute)
 	monitor.check()
 	monitor.check()
 	if got := stuckCount(); got != 1 {
 		t.Fatalf("expected exactly one alert; got counter [%v]", got)
 	}
 
-	// Once the transaction confirms it stops being tracked.
+	// Once the transaction confirms, it stops being tracked.
 	if err := chain.BroadcastTransaction(tx); err != nil {
 		t.Fatalf("unexpected error confirming transaction: [%v]", err)
 	}
 	monitor.check()
-
-	monitor.mu.Lock()
-	_, stillTracked := monitor.tracked[txHash]
-	monitor.mu.Unlock()
-	if stillTracked {
+	if isTracked(monitor, txHash) {
 		t.Fatal("expected confirmed transaction to be untracked")
+	}
+}
+
+// TestTransactionMonitor_GivesUpOnNeverConfirming verifies that a transaction
+// that never confirms is eventually evicted so it cannot fill the tracking
+// table.
+func TestTransactionMonitor_GivesUpOnNeverConfirming(t *testing.T) {
+	monitor := newTransactionMonitor(newLocalBitcoinChain())
+
+	tx := &bitcoin.Transaction{}
+	txHash := tx.Hash()
+	monitor.track(txHash, [20]byte{})
+
+	// Age it beyond the maximum tracking age; it never confirmed, so it is
+	// dropped rather than tracked forever.
+	ageTransaction(monitor, txHash, transactionMonitorMaxTrackingAge+time.Minute)
+	monitor.check()
+
+	if isTracked(monitor, txHash) {
+		t.Fatal("expected a never-confirming transaction to be evicted")
+	}
+}
+
+// TestTransactionMonitor_CapacityBound verifies the tracking table does not grow
+// past its bound.
+func TestTransactionMonitor_CapacityBound(t *testing.T) {
+	monitor := newTransactionMonitor(newLocalBitcoinChain())
+
+	for i := 0; i < transactionMonitorMaxTracked+10; i++ {
+		var h bitcoin.Hash
+		h[0] = byte(i)
+		h[1] = byte(i >> 8)
+		monitor.track(h, [20]byte{})
+	}
+
+	if got := trackedCount(monitor); got != transactionMonitorMaxTracked {
+		t.Fatalf(
+			"expected tracking table bounded to [%d]; got [%d]",
+			transactionMonitorMaxTracked,
+			got,
+		)
 	}
 }

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -243,6 +243,78 @@ func TestTransactionMonitor_CheckBudgetBoundsLookup(t *testing.T) {
 	}
 }
 
+// TestTransactionMonitor_BudgetExpiryStillAlertsOldest verifies that when a
+// check pass hits its time budget while looking up the oldest tracked
+// transaction, that transaction still fires its stuck alert (the alert needs no
+// network data) instead of being starved pass after pass. The remaining
+// transactions are deferred to the next pass rather than alerted on without a
+// lookup, so they cannot false-alert on age alone. This is the multi-transaction
+// dual of CheckBudgetBoundsLookup: it guards against head-of-line starvation
+// when a hung backend consistently eats the whole budget on the oldest entry.
+func TestTransactionMonitor_BudgetExpiryStillAlertsOldest(t *testing.T) {
+	blockedTxHash := bitcoin.Hash{1} // oldest; its lookup hangs until the budget expires
+	chain := newBlockingTransactionConfirmationsChain(blockedTxHash)
+	recorder := newCountingMetricsRecorder()
+	monitor := newTransactionMonitor(chain)
+	monitor.setMetricsRecorder(recorder)
+
+	newerTxHash := bitcoin.Hash{2}
+	monitor.track(blockedTxHash, [20]byte{})
+	monitor.track(newerTxHash, [20]byte{})
+
+	// Both transactions are past the stuck threshold; the blocked one is older so
+	// oldest-first ordering checks it first and its lookup consumes the budget.
+	ageTransaction(monitor, blockedTxHash, defaultStuckTransactionThreshold+2*time.Hour)
+	ageTransaction(monitor, newerTxHash, defaultStuckTransactionThreshold+time.Hour)
+
+	// Release the intentionally blocked backend on exit so its lookup goroutine
+	// is never left parked.
+	lookupReleased := false
+	defer func() {
+		if !lookupReleased {
+			close(chain.lookupRelease)
+			lookupReleased = true
+		}
+	}()
+
+	checkDone := make(chan struct{})
+	go func() {
+		monitor.checkWithBudget(context.Background(), 200*time.Millisecond)
+		close(checkDone)
+	}()
+
+	select {
+	case <-checkDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("check pass did not return after its budget expired")
+	}
+
+	// The oldest transaction's lookup was cancelled by the budget, but its
+	// age-based alert must still fire - exactly once, for the oldest only. Before
+	// the fix the pass returned on budget expiry before alerting, leaving this at
+	// 0; if the never-looked-up newer transaction were also alerted it would be 2.
+	if got := recorder.GetCounterValue(
+		clientinfo.MetricStuckWalletTransactionsTotal,
+	); got != 1 {
+		t.Fatalf("expected exactly one stuck alert (oldest only); got counter [%v]", got)
+	}
+
+	// A cancelled lookup is not a confirmation, so the oldest stays tracked; the
+	// newer transaction was deferred, not confirmed, so it stays tracked too.
+	if !isTracked(monitor, blockedTxHash) {
+		t.Fatal("expected the oldest transaction to remain tracked after a cancelled lookup")
+	}
+	if !isTracked(monitor, newerTxHash) {
+		t.Fatal("expected the deferred newer transaction to remain tracked")
+	}
+
+	// Only the oldest transaction's lookup was attempted; the pass returned
+	// before reaching the newer one.
+	if got := chain.getLookupCount(); got != 1 {
+		t.Fatalf("expected exactly one lookup (only the oldest was attempted); got [%d]", got)
+	}
+}
+
 // TestTransactionMonitor_CapacityBound verifies the tracking table does not grow
 // past its bound.
 func TestTransactionMonitor_CapacityBound(t *testing.T) {

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -1,0 +1,90 @@
+package tbtc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+)
+
+// monitorTestChain embeds the local Bitcoin chain mock and adds a settable
+// latest block height, which the base mock does not implement.
+type monitorTestChain struct {
+	*localBitcoinChain
+	latestBlockHeight uint
+}
+
+func (m *monitorTestChain) GetLatestBlockHeight() (uint, error) {
+	return m.latestBlockHeight, nil
+}
+
+// countingMetricsRecorder is a PerformanceMetricsRecorder that counts counter
+// increments so tests can assert the stuck-transaction metric fired.
+type countingMetricsRecorder struct {
+	counters map[string]float64
+}
+
+func newCountingMetricsRecorder() *countingMetricsRecorder {
+	return &countingMetricsRecorder{counters: make(map[string]float64)}
+}
+
+func (c *countingMetricsRecorder) IncrementCounter(name string, value float64) {
+	c.counters[name] += value
+}
+func (c *countingMetricsRecorder) RecordDuration(string, time.Duration) {}
+func (c *countingMetricsRecorder) SetGauge(string, float64)             {}
+func (c *countingMetricsRecorder) GetCounterValue(name string) float64 {
+	return c.counters[name]
+}
+func (c *countingMetricsRecorder) GetGaugeValue(string) float64 { return 0 }
+
+func TestTransactionMonitor(t *testing.T) {
+	chain := &monitorTestChain{
+		localBitcoinChain: newLocalBitcoinChain(),
+		latestBlockHeight: 100,
+	}
+	recorder := newCountingMetricsRecorder()
+
+	monitor := newTransactionMonitor(chain)
+	monitor.setMetricsRecorder(recorder)
+
+	tx := &bitcoin.Transaction{}
+	txHash := tx.Hash()
+	walletPublicKeyHash := [20]byte{1, 2, 3}
+
+	monitor.track(txHash, walletPublicKeyHash)
+
+	stuckCount := func() float64 {
+		return recorder.GetCounterValue(clientinfo.MetricStuckWalletTransactionsTotal)
+	}
+
+	// At exactly the threshold the transaction is not yet considered stuck.
+	chain.latestBlockHeight = 100 + defaultStuckTransactionThresholdBlocks
+	monitor.check()
+	if got := stuckCount(); got != 0 {
+		t.Fatalf("expected no alert at threshold; got counter [%v]", got)
+	}
+
+	// One block past the threshold it is flagged as stuck, exactly once even
+	// across repeated checks.
+	chain.latestBlockHeight = 100 + defaultStuckTransactionThresholdBlocks + 1
+	monitor.check()
+	monitor.check()
+	if got := stuckCount(); got != 1 {
+		t.Fatalf("expected exactly one alert; got counter [%v]", got)
+	}
+
+	// Once the transaction confirms it stops being tracked.
+	if err := chain.BroadcastTransaction(tx); err != nil {
+		t.Fatalf("unexpected error confirming transaction: [%v]", err)
+	}
+	monitor.check()
+
+	monitor.mu.Lock()
+	_, stillTracked := monitor.tracked[txHash]
+	monitor.mu.Unlock()
+	if stillTracked {
+		t.Fatal("expected confirmed transaction to be untracked")
+	}
+}

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -76,8 +76,11 @@ func TestTransactionMonitor(t *testing.T) {
 		t.Fatalf("expected no alert for a fresh transaction; got counter [%v]", got)
 	}
 
-	// At/just below the threshold: still not stuck. The alert condition is
-	// strictly greater than the threshold, so the boundary itself does not fire.
+	// Just below the threshold: still not stuck. The alert condition is strictly
+	// greater than the threshold. Testing exactly at the threshold is omitted
+	// deliberately: with a real clock the check-time drift always nudges the
+	// elapsed time a hair past any exact backdated value, so it cannot be pinned
+	// deterministically without an injectable clock.
 	ageTransaction(monitor, txHash, defaultStuckTransactionThreshold-time.Minute)
 	monitor.check()
 	if got := stuckCount(); got != 0 {

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -460,7 +460,10 @@ func (wte *walletTransactionExecutor) broadcastTransaction(
 				"checking whether the transaction is known on Bitcoin chain",
 			)
 
-			_, err = wte.btcChain.GetTransactionConfirmations(txHash)
+			_, err = wte.btcChain.GetTransactionConfirmations(
+				context.Background(),
+				txHash,
+			)
 			if err != nil {
 				broadcastTxLogger.Warnf(
 					"cannot say whether the transaction is known "+

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -308,6 +308,18 @@ func (wte *walletTransactionExecutor) setTransactionMonitor(
 	wte.transactionMonitor = monitor
 }
 
+// trackTransaction registers a broadcast transaction with the transaction
+// monitor, if one is configured. It is safe to call multiple times for the
+// same transaction.
+func (wte *walletTransactionExecutor) trackTransaction(txHash bitcoin.Hash) {
+	if wte.transactionMonitor != nil {
+		wte.transactionMonitor.track(
+			txHash,
+			bitcoin.PublicKeyHash(wte.executingWallet.publicKey),
+		)
+	}
+}
+
 func newWalletTransactionExecutor(
 	btcChain bitcoin.Chain,
 	executingWallet wallet,
@@ -426,6 +438,10 @@ func (wte *walletTransactionExecutor) broadcastTransaction(
 				)
 			} else {
 				broadcastTxLogger.Infof("broadcasting completed")
+				// Register the transaction for stuck-transaction monitoring as
+				// soon as the broadcast succeeds, without waiting on the
+				// confirmation lookup below (which may itself fail).
+				wte.trackTransaction(txHash)
 			}
 
 			broadcastTxLogger.Infof(
@@ -456,12 +472,10 @@ func (wte *walletTransactionExecutor) broadcastTransaction(
 
 			broadcastTxLogger.Infof("transaction is known on Bitcoin chain")
 
-			if wte.transactionMonitor != nil {
-				wte.transactionMonitor.track(
-					txHash,
-					bitcoin.PublicKeyHash(wte.executingWallet.publicKey),
-				)
-			}
+			// Also register here in case this operator's own broadcast call
+			// errored but the transaction is nonetheless known on-chain (e.g.
+			// broadcast by another operator). trackTransaction is idempotent.
+			wte.trackTransaction(txHash)
 
 			return nil
 		}

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -461,7 +461,7 @@ func (wte *walletTransactionExecutor) broadcastTransaction(
 			)
 
 			_, err = wte.btcChain.GetTransactionConfirmations(
-				context.Background(),
+				broadcastCtx,
 				txHash,
 			)
 			if err != nil {

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -293,6 +293,19 @@ type walletTransactionExecutor struct {
 	signingExecutor walletSigningExecutor
 
 	waitForBlockFn waitForBlockFn
+
+	// transactionMonitor is optional. When set, successfully broadcast
+	// transactions are registered with it so they can be watched for
+	// confirmation and alerted on if they get stuck.
+	transactionMonitor *transactionMonitor
+}
+
+// setTransactionMonitor wires an optional transaction monitor that is notified
+// of successfully broadcast transactions.
+func (wte *walletTransactionExecutor) setTransactionMonitor(
+	monitor *transactionMonitor,
+) {
+	wte.transactionMonitor = monitor
 }
 
 func newWalletTransactionExecutor(
@@ -442,6 +455,14 @@ func (wte *walletTransactionExecutor) broadcastTransaction(
 			}
 
 			broadcastTxLogger.Infof("transaction is known on Bitcoin chain")
+
+			if wte.transactionMonitor != nil {
+				wte.transactionMonitor.track(
+					txHash,
+					bitcoin.PublicKeyHash(wte.executingWallet.publicKey),
+				)
+			}
+
 			return nil
 		}
 	}

--- a/pkg/tbtc/wallet_test.go
+++ b/pkg/tbtc/wallet_test.go
@@ -677,7 +677,7 @@ type noConfirmBtcChain struct {
 	*localBitcoinChain
 }
 
-func (c *noConfirmBtcChain) GetTransactionConfirmations(bitcoin.Hash) (uint, error) {
+func (c *noConfirmBtcChain) GetTransactionConfirmations(context.Context, bitcoin.Hash) (uint, error) {
 	return 0, fmt.Errorf("rpc unavailable")
 }
 
@@ -774,7 +774,7 @@ func (c *walletSyncBtcChain) GetTransaction(hash bitcoin.Hash) (*bitcoin.Transac
 	return nil, fmt.Errorf("tx not found: %s", hash.String())
 }
 
-func (c *walletSyncBtcChain) GetTransactionConfirmations(bitcoin.Hash) (uint, error) {
+func (c *walletSyncBtcChain) GetTransactionConfirmations(context.Context, bitcoin.Hash) (uint, error) {
 	panic("unused in wallet sync tests")
 }
 func (c *walletSyncBtcChain) BroadcastTransaction(*bitcoin.Transaction) error {

--- a/pkg/tbtcpg/bitcoin_chain_test.go
+++ b/pkg/tbtcpg/bitcoin_chain_test.go
@@ -1,6 +1,7 @@
 package tbtcpg
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -47,6 +48,7 @@ func (lbc *LocalBitcoinChain) SetTransaction(
 }
 
 func (lbc *LocalBitcoinChain) GetTransactionConfirmations(
+	_ context.Context,
 	transactionHash bitcoin.Hash,
 ) (uint, error) {
 	lbc.mutex.Lock()

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -1,6 +1,7 @@
 package tbtcpg
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/big"
@@ -239,7 +240,10 @@ func findDeposits(
 			continue
 		}
 
-		confirmations, err := btcChain.GetTransactionConfirmations(event.FundingTxHash)
+		confirmations, err := btcChain.GetTransactionConfirmations(
+			context.Background(),
+			event.FundingTxHash,
+		)
 		if err != nil {
 			fnLogger.Errorf(
 				"failed to get bitcoin transaction confirmations: [%v]",

--- a/pkg/tbtcpg/redemptions.go
+++ b/pkg/tbtcpg/redemptions.go
@@ -222,13 +222,15 @@ func (rt *RedemptionTask) ProposeRedemption(
 	if fee <= 0 {
 		taskLogger.Infof("estimating redemption transaction fee")
 
-		_, _, txMaxFee, txMaxTotalFee, _, _, _, err := rt.chain.GetRedemptionParameters()
+		redemptionParams, err := rt.chain.GetRedemptionParameters()
 		if err != nil {
 			return nil, fmt.Errorf(
 				"cannot get redemption tx max total fee: [%w]",
 				err,
 			)
 		}
+		txMaxFee := redemptionParams.TxMaxFee
+		txMaxTotalFee := redemptionParams.TxMaxTotalFee
 
 		estimatedFee, err := EstimateRedemptionFee(
 			rt.btcChain,


### PR DESCRIPTION
Implements #4173. A broadcast wallet transaction that stays unconfirmed in the mempool locks the wallet's main UTXO and blocks all subsequent wallet transactions until it confirms. Today this is silent — the broadcast path waits only for mempool acceptance, never for confirmation.

## Change

A Node-scoped `transactionMonitor` (`pkg/tbtc/transaction_monitor.go`):

- The shared `walletTransactionExecutor` registers every broadcast transaction with the monitor — immediately after a successful `BroadcastTransaction`, and again once it's known on-chain (idempotent) — so all four wallet-action types are covered even if a confirmation lookup fails.
- A background loop (started in `runCoordinationLayer`) polls `GetTransactionConfirmations` for each tracked tx on a wall-clock cadence. Confirmed → dropped. Unconfirmed past the stuck threshold → emit `stuck_wallet_transactions_total` + a Warn log naming the wallet and txid (once per tx, and **before** any give-up eviction). Never-confirming transactions are evicted after a maximum tracking age; a full tracking table surfaces `unmonitored_wallet_transactions_total`. Each check pass is time-budgeted so one slow chain call cannot stall the rest.

keep-client only exposes the metric + log; alerting/paging is left to the operator's existing Prometheus/Grafana. Additive to the coarse `gated_sweep_stall_seconds` signal — it surfaces the *specific stuck txid* so an operator can act in minutes.

## Threshold is wall-clock

Tracking uses a wall-clock duration (`defaultStuckTransactionThreshold = 6h`), not a block count — no extra RPC per check. (An earlier revision of this PR used a block count; this supersedes it.)

## Context-aware confirmation lookups

`bitcoin.Chain.GetTransactionConfirmations` now takes a `context.Context` so callers can bound and cancel the lookup. The Electrum implementation threads the caller context (combined with the connection-lifetime context) into its retry loop; the other callers pass `context.Background()`, which the combining preserves as their prior behavior.

This lets the monitor's check pass call the lookup **synchronously**, bounded by the per-pass time budget, instead of spawning a per-lookup goroutine guarded by an in-flight dedup map. When the budget expires the call is cancelled and the pass defers the remaining transactions to the next pass, so a slow or hung backend can no longer strand a goroutine or an in-flight map entry beyond a check pass.

Note: Electrum's `GetTransactionConfirmations` also makes an internal `GetLatestBlockHeight` call — a separate `bitcoin.Chain` method that is not context-threaded. That trailing lookup still self-bounds via Electrum's own request-retry timeout (~2 min) rather than cancelling with the caller context, so a pass can overrun its budget by up to that before being caught on the next iteration. Not a hang or a leak.

## Tests

Cover: no alert below the threshold and at the boundary; exactly-once alert past it; untracking on confirmation; alert-before-eviction for a never-confirming transaction; the table-full metric; and a budgeted check pass cancelling a blocked confirmation lookup rather than stalling. `go build` + `go test ./pkg/tbtc/... ./pkg/clientinfo/...` pass.

## Out of scope / follow-ups

- Automated fee-bumping (RBF/CPFP) — Part B of #4171, targeted at FROST/ROAST.
- Persist/rehydrate the tracked set across restarts — #4175.
- Make the thresholds node-configurable — #4176.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background monitoring for broadcast wallet transactions that stay unconfirmed, including operator alerts for “stuck” transactions and capacity-based handling for untracked overflow.
  * Introduced two new performance counters for stuck and unmonitored wallet transactions, enabled when metrics are available.
  * Enabled monitoring across deposit sweeps, redemptions, moving funds, and moved-funds sweeps.

* **Tests**
  * Added a dedicated transaction-monitor test suite (alerts, eviction, budgeted checks, capacity limits, snapshot ordering).
  * Updated existing action tests to match the new monitoring wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
