### PR TITLE
refactor(chain): return named parameter structs from tBTC getters

### DIFF
--- a/pkg/chain/ethereum/tbtc.go
+++ b/pkg/chain/ethereum/tbtc.go
@@ -1597,25 +1597,18 @@ func (tc *TbtcChain) BuildRedemptionKey(
 	return buildRedemptionKey(walletPublicKeyHash, redeemerOutputScript)
 }
 
-func (tc *TbtcChain) GetDepositParameters() (
-	dustThreshold uint64,
-	treasuryFeeDivisor uint64,
-	txMaxFee uint64,
-	revealAheadPeriod uint32,
-	err error,
-) {
-	parameters, callErr := tc.bridge.DepositParameters()
-	if callErr != nil {
-		err = callErr
-		return
+func (tc *TbtcChain) GetDepositParameters() (tbtc.DepositParameters, error) {
+	parameters, err := tc.bridge.DepositParameters()
+	if err != nil {
+		return tbtc.DepositParameters{}, err
 	}
 
-	dustThreshold = parameters.DepositDustThreshold
-	treasuryFeeDivisor = parameters.DepositTreasuryFeeDivisor
-	txMaxFee = parameters.DepositTxMaxFee
-	revealAheadPeriod = parameters.DepositRevealAheadPeriod
-
-	return
+	return tbtc.DepositParameters{
+		DustThreshold:      parameters.DepositDustThreshold,
+		TreasuryFeeDivisor: parameters.DepositTreasuryFeeDivisor,
+		TxMaxFee:           parameters.DepositTxMaxFee,
+		RevealAheadPeriod:  parameters.DepositRevealAheadPeriod,
+	}, nil
 }
 
 func (tc *TbtcChain) GetPendingRedemptionRequest(
@@ -1783,58 +1776,38 @@ func (tc *TbtcChain) SubmitDepositSweepProofWithReimbursement(
 	return err
 }
 
-func (tc *TbtcChain) GetRedemptionParameters() (
-	dustThreshold uint64,
-	treasuryFeeDivisor uint64,
-	txMaxFee uint64,
-	txMaxTotalFee uint64,
-	timeout uint32,
-	timeoutSlashingAmount *big.Int,
-	timeoutNotifierRewardMultiplier uint32,
-	err error,
-) {
-	parameters, callErr := tc.bridge.RedemptionParameters()
-	if callErr != nil {
-		err = callErr
-		return
+func (tc *TbtcChain) GetRedemptionParameters() (tbtc.RedemptionParameters, error) {
+	parameters, err := tc.bridge.RedemptionParameters()
+	if err != nil {
+		return tbtc.RedemptionParameters{}, err
 	}
 
-	dustThreshold = parameters.RedemptionDustThreshold
-	treasuryFeeDivisor = parameters.RedemptionTreasuryFeeDivisor
-	txMaxFee = parameters.RedemptionTxMaxFee
-	txMaxTotalFee = parameters.RedemptionTxMaxTotalFee
-	timeout = parameters.RedemptionTimeout
-	timeoutSlashingAmount = parameters.RedemptionTimeoutSlashingAmount
-	timeoutNotifierRewardMultiplier = parameters.RedemptionTimeoutNotifierRewardMultiplier
-
-	return
+	return tbtc.RedemptionParameters{
+		DustThreshold:                   parameters.RedemptionDustThreshold,
+		TreasuryFeeDivisor:              parameters.RedemptionTreasuryFeeDivisor,
+		TxMaxFee:                        parameters.RedemptionTxMaxFee,
+		TxMaxTotalFee:                   parameters.RedemptionTxMaxTotalFee,
+		Timeout:                         parameters.RedemptionTimeout,
+		TimeoutSlashingAmount:           parameters.RedemptionTimeoutSlashingAmount,
+		TimeoutNotifierRewardMultiplier: parameters.RedemptionTimeoutNotifierRewardMultiplier,
+	}, nil
 }
 
-func (tc *TbtcChain) GetWalletParameters() (
-	creationPeriod uint32,
-	creationMinBtcBalance uint64,
-	creationMaxBtcBalance uint64,
-	closureMinBtcBalance uint64,
-	maxAge uint32,
-	maxBtcTransfer uint64,
-	closingPeriod uint32,
-	err error,
-) {
-	parameters, callErr := tc.bridge.WalletParameters()
-	if callErr != nil {
-		err = callErr
-		return
+func (tc *TbtcChain) GetWalletParameters() (tbtc.WalletParameters, error) {
+	parameters, err := tc.bridge.WalletParameters()
+	if err != nil {
+		return tbtc.WalletParameters{}, err
 	}
 
-	creationPeriod = parameters.WalletCreationPeriod
-	creationMinBtcBalance = parameters.WalletCreationMinBtcBalance
-	creationMaxBtcBalance = parameters.WalletCreationMaxBtcBalance
-	closureMinBtcBalance = parameters.WalletClosureMinBtcBalance
-	maxAge = parameters.WalletMaxAge
-	maxBtcTransfer = parameters.WalletMaxBtcTransfer
-	closingPeriod = parameters.WalletClosingPeriod
-
-	return
+	return tbtc.WalletParameters{
+		CreationPeriod:        parameters.WalletCreationPeriod,
+		CreationMinBtcBalance: parameters.WalletCreationMinBtcBalance,
+		CreationMaxBtcBalance: parameters.WalletCreationMaxBtcBalance,
+		ClosureMinBtcBalance:  parameters.WalletClosureMinBtcBalance,
+		MaxAge:                parameters.WalletMaxAge,
+		MaxBtcTransfer:        parameters.WalletMaxBtcTransfer,
+		ClosingPeriod:         parameters.WalletClosingPeriod,
+	}, nil
 }
 
 func (tc *TbtcChain) GetLiveWalletsCount() (uint32, error) {
@@ -2280,39 +2253,25 @@ func (tc *TbtcChain) ValidateHeartbeatProposal(
 	return nil
 }
 
-func (tc *TbtcChain) GetMovingFundsParameters() (
-	txMaxTotalFee uint64,
-	dustThreshold uint64,
-	timeoutResetDelay uint32,
-	timeout uint32,
-	timeoutSlashingAmount *big.Int,
-	timeoutNotifierRewardMultiplier uint32,
-	commitmentGasOffset uint16,
-	sweepTxMaxTotalFee uint64,
-	sweepTimeout uint32,
-	sweepTimeoutSlashingAmount *big.Int,
-	sweepTimeoutNotifierRewardMultiplier uint32,
-	err error,
-) {
-	parameters, callErr := tc.bridge.MovingFundsParameters()
-	if callErr != nil {
-		err = callErr
-		return
+func (tc *TbtcChain) GetMovingFundsParameters() (tbtc.MovingFundsParameters, error) {
+	parameters, err := tc.bridge.MovingFundsParameters()
+	if err != nil {
+		return tbtc.MovingFundsParameters{}, err
 	}
 
-	txMaxTotalFee = parameters.MovingFundsTxMaxTotalFee
-	dustThreshold = parameters.MovingFundsDustThreshold
-	timeoutResetDelay = parameters.MovingFundsTimeoutResetDelay
-	timeout = parameters.MovingFundsTimeout
-	timeoutSlashingAmount = parameters.MovingFundsTimeoutSlashingAmount
-	timeoutNotifierRewardMultiplier = parameters.MovingFundsTimeoutNotifierRewardMultiplier
-	commitmentGasOffset = parameters.MovingFundsCommitmentGasOffset
-	sweepTxMaxTotalFee = parameters.MovedFundsSweepTxMaxTotalFee
-	sweepTimeout = parameters.MovedFundsSweepTimeout
-	sweepTimeoutSlashingAmount = parameters.MovedFundsSweepTimeoutSlashingAmount
-	sweepTimeoutNotifierRewardMultiplier = parameters.MovedFundsSweepTimeoutNotifierRewardMultiplier
-
-	return
+	return tbtc.MovingFundsParameters{
+		TxMaxTotalFee:                        parameters.MovingFundsTxMaxTotalFee,
+		DustThreshold:                        parameters.MovingFundsDustThreshold,
+		TimeoutResetDelay:                    parameters.MovingFundsTimeoutResetDelay,
+		Timeout:                              parameters.MovingFundsTimeout,
+		TimeoutSlashingAmount:                parameters.MovingFundsTimeoutSlashingAmount,
+		TimeoutNotifierRewardMultiplier:      parameters.MovingFundsTimeoutNotifierRewardMultiplier,
+		CommitmentGasOffset:                  parameters.MovingFundsCommitmentGasOffset,
+		SweepTxMaxTotalFee:                   parameters.MovedFundsSweepTxMaxTotalFee,
+		SweepTimeout:                         parameters.MovedFundsSweepTimeout,
+		SweepTimeoutSlashingAmount:           parameters.MovedFundsSweepTimeoutSlashingAmount,
+		SweepTimeoutNotifierRewardMultiplier: parameters.MovedFundsSweepTimeoutNotifierRewardMultiplier,
+	}, nil
 }
 
 func (tc *TbtcChain) GetMovedFundsSweepRequest(

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -302,20 +302,7 @@ type BridgeChain interface {
 
 	// GetMovingFundsParameters gets the current value of parameters relevant
 	// for the moving funds process.
-	GetMovingFundsParameters() (
-		txMaxTotalFee uint64,
-		dustThreshold uint64,
-		timeoutResetDelay uint32,
-		timeout uint32,
-		timeoutSlashingAmount *big.Int,
-		timeoutNotifierRewardMultiplier uint32,
-		commitmentGasOffset uint16,
-		sweepTxMaxTotalFee uint64,
-		sweepTimeout uint32,
-		sweepTimeoutSlashingAmount *big.Int,
-		sweepTimeoutNotifierRewardMultiplier uint32,
-		err error,
-	)
+	GetMovingFundsParameters() (MovingFundsParameters, error)
 
 	// PastMovingFundsCommitmentSubmittedEvents fetches past moving funds
 	// commitment submitted events according to the provided filter or

--- a/pkg/tbtc/chain_test.go
+++ b/pkg/tbtc/chain_test.go
@@ -32,20 +32,6 @@ const (
 	stakingProvider      = chain.Address("0x1111111111111111111111111111111111111111")
 )
 
-type movingFundsParameters = struct {
-	txMaxTotalFee                        uint64
-	dustThreshold                        uint64
-	timeoutResetDelay                    uint32
-	timeout                              uint32
-	timeoutSlashingAmount                *big.Int
-	timeoutNotifierRewardMultiplier      uint32
-	commitmentGasOffset                  uint16
-	sweepTxMaxTotalFee                   uint64
-	sweepTimeout                         uint32
-	sweepTimeoutSlashingAmount           *big.Int
-	sweepTimeoutNotifierRewardMultiplier uint32
-}
-
 type localChain struct {
 	dkgResultSubmissionHandlersMutex sync.Mutex
 	dkgResultSubmissionHandlers      map[int]func(submission *DKGResultSubmittedEvent)
@@ -109,7 +95,7 @@ type localChain struct {
 	depositRequests      map[[32]byte]*DepositChainRequest
 
 	movingFundsParametersMutex sync.Mutex
-	movingFundsParameters      movingFundsParameters
+	movingFundsParameters      MovingFundsParameters
 
 	eligibleStakesMutex sync.Mutex
 	eligibleStakes      map[chain.Address]*big.Int
@@ -1303,35 +1289,11 @@ func buildMovedFundsSweepProposalValidationKey(
 	return sha256.Sum256(buffer.Bytes()), nil
 }
 
-func (lc *localChain) GetMovingFundsParameters() (
-	txMaxTotalFee uint64,
-	dustThreshold uint64,
-	timeoutResetDelay uint32,
-	timeout uint32,
-	timeoutSlashingAmount *big.Int,
-	timeoutNotifierRewardMultiplier uint32,
-	commitmentGasOffset uint16,
-	sweepTxMaxTotalFee uint64,
-	sweepTimeout uint32,
-	sweepTimeoutSlashingAmount *big.Int,
-	sweepTimeoutNotifierRewardMultiplier uint32,
-	err error,
-) {
+func (lc *localChain) GetMovingFundsParameters() (MovingFundsParameters, error) {
 	lc.movingFundsParametersMutex.Lock()
 	defer lc.movingFundsParametersMutex.Unlock()
 
-	return lc.movingFundsParameters.txMaxTotalFee,
-		lc.movingFundsParameters.dustThreshold,
-		lc.movingFundsParameters.timeoutResetDelay,
-		lc.movingFundsParameters.timeout,
-		lc.movingFundsParameters.timeoutSlashingAmount,
-		lc.movingFundsParameters.timeoutNotifierRewardMultiplier,
-		lc.movingFundsParameters.commitmentGasOffset,
-		lc.movingFundsParameters.sweepTxMaxTotalFee,
-		lc.movingFundsParameters.sweepTimeout,
-		lc.movingFundsParameters.sweepTimeoutSlashingAmount,
-		lc.movingFundsParameters.sweepTimeoutNotifierRewardMultiplier,
-		nil
+	return lc.movingFundsParameters, nil
 }
 
 func (lc *localChain) SetMovingFundsParameters(
@@ -1350,18 +1312,18 @@ func (lc *localChain) SetMovingFundsParameters(
 	lc.movingFundsParametersMutex.Lock()
 	defer lc.movingFundsParametersMutex.Unlock()
 
-	lc.movingFundsParameters = movingFundsParameters{
-		txMaxTotalFee:                        txMaxTotalFee,
-		dustThreshold:                        dustThreshold,
-		timeoutResetDelay:                    timeoutResetDelay,
-		timeout:                              timeout,
-		timeoutSlashingAmount:                timeoutSlashingAmount,
-		timeoutNotifierRewardMultiplier:      timeoutNotifierRewardMultiplier,
-		commitmentGasOffset:                  commitmentGasOffset,
-		sweepTxMaxTotalFee:                   sweepTxMaxTotalFee,
-		sweepTimeout:                         sweepTimeout,
-		sweepTimeoutSlashingAmount:           sweepTimeoutSlashingAmount,
-		sweepTimeoutNotifierRewardMultiplier: sweepTimeoutNotifierRewardMultiplier,
+	lc.movingFundsParameters = MovingFundsParameters{
+		TxMaxTotalFee:                        txMaxTotalFee,
+		DustThreshold:                        dustThreshold,
+		TimeoutResetDelay:                    timeoutResetDelay,
+		Timeout:                              timeout,
+		TimeoutSlashingAmount:                timeoutSlashingAmount,
+		TimeoutNotifierRewardMultiplier:      timeoutNotifierRewardMultiplier,
+		CommitmentGasOffset:                  commitmentGasOffset,
+		SweepTxMaxTotalFee:                   sweepTxMaxTotalFee,
+		SweepTimeout:                         sweepTimeout,
+		SweepTimeoutSlashingAmount:           sweepTimeoutSlashingAmount,
+		SweepTimeoutNotifierRewardMultiplier: sweepTimeoutNotifierRewardMultiplier,
 	}
 }
 

--- a/pkg/tbtc/moving_funds.go
+++ b/pkg/tbtc/moving_funds.go
@@ -322,20 +322,7 @@ func ValidateMovingFundsProposal(
 
 		GetWallet(walletPublicKeyHash [20]byte) (*WalletChainData, error)
 
-		GetMovingFundsParameters() (
-			txMaxTotalFee uint64,
-			dustThreshold uint64,
-			timeoutResetDelay uint32,
-			timeout uint32,
-			timeoutSlashingAmount *big.Int,
-			timeoutNotifierRewardMultiplier uint32,
-			commitmentGasOffset uint16,
-			sweepTxMaxTotalFee uint64,
-			sweepTimeout uint32,
-			sweepTimeoutSlashingAmount *big.Int,
-			sweepTimeoutNotifierRewardMultiplier uint32,
-			err error,
-		)
+		GetMovingFundsParameters() (MovingFundsParameters, error)
 
 		PastMovingFundsCommitmentSubmittedEvents(
 			filter *MovingFundsCommitmentSubmittedEventFilter,
@@ -385,20 +372,7 @@ func ValidateMovingFundsSafetyMargin(
 
 		GetWallet(walletPublicKeyHash [20]byte) (*WalletChainData, error)
 
-		GetMovingFundsParameters() (
-			txMaxTotalFee uint64,
-			dustThreshold uint64,
-			timeoutResetDelay uint32,
-			timeout uint32,
-			timeoutSlashingAmount *big.Int,
-			timeoutNotifierRewardMultiplier uint32,
-			commitmentGasOffset uint16,
-			sweepTxMaxTotalFee uint64,
-			sweepTimeout uint32,
-			sweepTimeoutSlashingAmount *big.Int,
-			sweepTimeoutNotifierRewardMultiplier uint32,
-			err error,
-		)
+		GetMovingFundsParameters() (MovingFundsParameters, error)
 
 		PastMovingFundsCommitmentSubmittedEvents(
 			filter *MovingFundsCommitmentSubmittedEventFilter,
@@ -432,13 +406,12 @@ func ValidateMovingFundsSafetyMargin(
 	// As the moving funds procedure is time constrained, we must ensure the
 	// safety margin does not exceed half of the moving funds timeout parameter.
 	// This should give the wallet enough time to complete moving funds.
-	_, _, _, movingFundsTimeout, _, _, _, _, _, _, _, err :=
-		chain.GetMovingFundsParameters()
+	movingFundsParameters, err := chain.GetMovingFundsParameters()
 	if err != nil {
 		return fmt.Errorf("cannot get moving funds parameters: [%w]", err)
 	}
 
-	maxAllowedSafetyMargin := time.Duration(movingFundsTimeout/2) * time.Second
+	maxAllowedSafetyMargin := time.Duration(movingFundsParameters.Timeout/2) * time.Second
 
 	if safetyMargin > maxAllowedSafetyMargin {
 		safetyMargin = maxAllowedSafetyMargin
@@ -476,20 +449,7 @@ func isWalletPendingMovingFundsTarget(
 
 		GetWallet(walletPublicKeyHash [20]byte) (*WalletChainData, error)
 
-		GetMovingFundsParameters() (
-			txMaxTotalFee uint64,
-			dustThreshold uint64,
-			timeoutResetDelay uint32,
-			timeout uint32,
-			timeoutSlashingAmount *big.Int,
-			timeoutNotifierRewardMultiplier uint32,
-			commitmentGasOffset uint16,
-			sweepTxMaxTotalFee uint64,
-			sweepTimeout uint32,
-			sweepTimeoutSlashingAmount *big.Int,
-			sweepTimeoutNotifierRewardMultiplier uint32,
-			err error,
-		)
+		GetMovingFundsParameters() (MovingFundsParameters, error)
 
 		PastMovingFundsCommitmentSubmittedEvents(
 			filter *MovingFundsCommitmentSubmittedEventFilter,

--- a/pkg/tbtc/parameters.go
+++ b/pkg/tbtc/parameters.go
@@ -1,0 +1,53 @@
+package tbtc
+
+import "math/big"
+
+// MovingFundsParameters holds the current value of the on-chain parameters
+// relevant to the moving funds and moved funds sweep processes. It replaces a
+// wide positional return so callers access fields by name.
+type MovingFundsParameters struct {
+	TxMaxTotalFee                        uint64
+	DustThreshold                        uint64
+	TimeoutResetDelay                    uint32
+	Timeout                              uint32
+	TimeoutSlashingAmount                *big.Int
+	TimeoutNotifierRewardMultiplier      uint32
+	CommitmentGasOffset                  uint16
+	SweepTxMaxTotalFee                   uint64
+	SweepTimeout                         uint32
+	SweepTimeoutSlashingAmount           *big.Int
+	SweepTimeoutNotifierRewardMultiplier uint32
+}
+
+// WalletParameters holds the current value of the on-chain parameters relevant
+// to the wallet lifecycle.
+type WalletParameters struct {
+	CreationPeriod        uint32
+	CreationMinBtcBalance uint64
+	CreationMaxBtcBalance uint64
+	ClosureMinBtcBalance  uint64
+	MaxAge                uint32
+	MaxBtcTransfer        uint64
+	ClosingPeriod         uint32
+}
+
+// DepositParameters holds the current value of the on-chain parameters relevant
+// to deposits.
+type DepositParameters struct {
+	DustThreshold      uint64
+	TreasuryFeeDivisor uint64
+	TxMaxFee           uint64
+	RevealAheadPeriod  uint32
+}
+
+// RedemptionParameters holds the current value of the on-chain parameters
+// relevant to redemptions.
+type RedemptionParameters struct {
+	DustThreshold                   uint64
+	TreasuryFeeDivisor              uint64
+	TxMaxFee                        uint64
+	TxMaxTotalFee                   uint64
+	Timeout                         uint32
+	TimeoutSlashingAmount           *big.Int
+	TimeoutNotifierRewardMultiplier uint32
+}

--- a/pkg/tbtcpg/chain.go
+++ b/pkg/tbtcpg/chain.go
@@ -25,16 +25,7 @@ type Chain interface {
 
 	// GetWalletParameters gets the current value of parameters relevant to
 	// wallet.
-	GetWalletParameters() (
-		creationPeriod uint32,
-		creationMinBtcBalance uint64,
-		creationMaxBtcBalance uint64,
-		closureMinBtcBalance uint64,
-		maxAge uint32,
-		maxBtcTransfer uint64,
-		closingPeriod uint32,
-		err error,
-	)
+	GetWalletParameters() (tbtc.WalletParameters, error)
 
 	// GetLiveWalletsCount gets the current count of live wallets.
 	GetLiveWalletsCount() (uint32, error)
@@ -45,13 +36,7 @@ type Chain interface {
 
 	// GetDepositParameters gets the current value of parameters relevant
 	// for the depositing process.
-	GetDepositParameters() (
-		dustThreshold uint64,
-		treasuryFeeDivisor uint64,
-		txMaxFee uint64,
-		revealAheadPeriod uint32,
-		err error,
-	)
+	GetDepositParameters() (tbtc.DepositParameters, error)
 
 	// PastRedemptionRequestedEvents fetches past redemption requested events according
 	// to the provided filter or unfiltered if the filter is nil. Returned
@@ -71,16 +56,7 @@ type Chain interface {
 
 	// GetRedemptionParameters gets the current value of parameters relevant
 	// for the redemption process.
-	GetRedemptionParameters() (
-		dustThreshold uint64,
-		treasuryFeeDivisor uint64,
-		txMaxFee uint64,
-		txMaxTotalFee uint64,
-		timeout uint32,
-		timeoutSlashingAmount *big.Int,
-		timeoutNotifierRewardMultiplier uint32,
-		err error,
-	)
+	GetRedemptionParameters() (tbtc.RedemptionParameters, error)
 
 	// GetRedemptionMaxSize gets the maximum number of redemption requests that
 	// can be a part of a redemption sweep proposal.

--- a/pkg/tbtcpg/chain_test.go
+++ b/pkg/tbtcpg/chain_test.go
@@ -21,47 +21,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
-type depositParameters = struct {
-	dustThreshold      uint64
-	treasuryFeeDivisor uint64
-	txMaxFee           uint64
-	revealAheadPeriod  uint32
-}
-
-type redemptionParameters = struct {
-	dustThreshold                   uint64
-	treasuryFeeDivisor              uint64
-	txMaxFee                        uint64
-	txMaxTotalFee                   uint64
-	timeout                         uint32
-	timeoutSlashingAmount           *big.Int
-	timeoutNotifierRewardMultiplier uint32
-}
-
-type walletParameters = struct {
-	creationPeriod        uint32
-	creationMinBtcBalance uint64
-	creationMaxBtcBalance uint64
-	closureMinBtcBalance  uint64
-	maxAge                uint32
-	maxBtcTransfer        uint64
-	closingPeriod         uint32
-}
-
-type movingFundsParameters = struct {
-	txMaxTotalFee                        uint64
-	dustThreshold                        uint64
-	timeoutResetDelay                    uint32
-	timeout                              uint32
-	timeoutSlashingAmount                *big.Int
-	timeoutNotifierRewardMultiplier      uint32
-	commitmentGasOffset                  uint16
-	sweepTxMaxTotalFee                   uint64
-	sweepTimeout                         uint32
-	sweepTimeoutSlashingAmount           *big.Int
-	sweepTimeoutNotifierRewardMultiplier uint32
-}
-
 type movingFundsCommitmentSubmission struct {
 	WalletPublicKeyHash [20]byte
 	WalletMainUtxo      *bitcoin.UnspentTransactionOutput
@@ -76,11 +35,11 @@ type LocalChain struct {
 	depositRequests                          map[[32]byte]*tbtc.DepositChainRequest
 	pastDepositRevealedEvents                map[[32]byte][]*tbtc.DepositRevealedEvent
 	pastNewWalletRegisteredEvents            map[[32]byte][]*tbtc.NewWalletRegisteredEvent
-	depositParameters                        depositParameters
+	depositParameters                        tbtc.DepositParameters
 	depositSweepProposalValidations          map[[32]byte]bool
-	redemptionParameters                     redemptionParameters
+	redemptionParameters                     tbtc.RedemptionParameters
 	redemptionRequestMinAge                  uint32
-	walletParameters                         walletParameters
+	walletParameters                         tbtc.WalletParameters
 	walletChainData                          map[[20]byte]*tbtc.WalletChainData
 	blockCounter                             chain.BlockCounter
 	pastRedemptionRequestedEvents            map[[32]byte][]*tbtc.RedemptionRequestedEvent
@@ -88,7 +47,7 @@ type LocalChain struct {
 	pendingRedemptionRequests                map[[32]byte]*tbtc.RedemptionRequest
 	redemptionProposalValidations            map[[32]byte]bool
 	heartbeatProposalValidations             map[[16]byte]bool
-	movingFundsParameters                    movingFundsParameters
+	movingFundsParameters                    tbtc.MovingFundsParameters
 	pastMovingFundsCommitmentSubmittedEvents map[[32]byte][]*tbtc.MovingFundsCommitmentSubmittedEvent
 	movingFundsProposalValidations           map[[32]byte]bool
 	movingFundsCommitmentSubmissions         []*movingFundsCommitmentSubmission
@@ -472,21 +431,11 @@ func buildRedemptionRequestKey(
 	return sha256.Sum256(append(walletPublicKeyHash[:], redeemerOutputScript...))
 }
 
-func (lc *LocalChain) GetDepositParameters() (
-	dustThreshold uint64,
-	treasuryFeeDivisor uint64,
-	txMaxFee uint64,
-	revealAheadPeriod uint32,
-	err error,
-) {
+func (lc *LocalChain) GetDepositParameters() (tbtc.DepositParameters, error) {
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
-	return lc.depositParameters.dustThreshold,
-		lc.depositParameters.treasuryFeeDivisor,
-		lc.depositParameters.txMaxFee,
-		lc.depositParameters.revealAheadPeriod,
-		nil
+	return lc.depositParameters, nil
 }
 
 func (lc *LocalChain) GetPendingRedemptionRequest(
@@ -530,35 +479,19 @@ func (lc *LocalChain) SetDepositParameters(
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
-	lc.depositParameters = depositParameters{
-		dustThreshold:      dustThreshold,
-		treasuryFeeDivisor: treasuryFeeDivisor,
-		txMaxFee:           txMaxFee,
-		revealAheadPeriod:  revealAheadPeriod,
+	lc.depositParameters = tbtc.DepositParameters{
+		DustThreshold:      dustThreshold,
+		TreasuryFeeDivisor: treasuryFeeDivisor,
+		TxMaxFee:           txMaxFee,
+		RevealAheadPeriod:  revealAheadPeriod,
 	}
 }
 
-func (lc *LocalChain) GetRedemptionParameters() (
-	dustThreshold uint64,
-	treasuryFeeDivisor uint64,
-	txMaxFee uint64,
-	txMaxTotalFee uint64,
-	timeout uint32,
-	timeoutSlashingAmount *big.Int,
-	timeoutNotifierRewardMultiplier uint32,
-	err error,
-) {
+func (lc *LocalChain) GetRedemptionParameters() (tbtc.RedemptionParameters, error) {
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
-	return lc.redemptionParameters.dustThreshold,
-		lc.redemptionParameters.treasuryFeeDivisor,
-		lc.redemptionParameters.txMaxFee,
-		lc.redemptionParameters.txMaxTotalFee,
-		lc.redemptionParameters.timeout,
-		lc.redemptionParameters.timeoutSlashingAmount,
-		lc.redemptionParameters.timeoutNotifierRewardMultiplier,
-		nil
+	return lc.redemptionParameters, nil
 }
 
 func (lc *LocalChain) SetRedemptionParameters(
@@ -573,14 +506,14 @@ func (lc *LocalChain) SetRedemptionParameters(
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
-	lc.redemptionParameters = redemptionParameters{
-		dustThreshold:                   dustThreshold,
-		treasuryFeeDivisor:              treasuryFeeDivisor,
-		txMaxFee:                        txMaxFee,
-		txMaxTotalFee:                   txMaxTotalFee,
-		timeout:                         timeout,
-		timeoutSlashingAmount:           timeoutSlashingAmount,
-		timeoutNotifierRewardMultiplier: timeoutNotifierRewardMultiplier,
+	lc.redemptionParameters = tbtc.RedemptionParameters{
+		DustThreshold:                   dustThreshold,
+		TreasuryFeeDivisor:              treasuryFeeDivisor,
+		TxMaxFee:                        txMaxFee,
+		TxMaxTotalFee:                   txMaxTotalFee,
+		Timeout:                         timeout,
+		TimeoutSlashingAmount:           timeoutSlashingAmount,
+		TimeoutNotifierRewardMultiplier: timeoutNotifierRewardMultiplier,
 	}
 }
 
@@ -738,35 +671,11 @@ func (lc *LocalChain) SetHeartbeatProposalValidationResult(
 	lc.heartbeatProposalValidations[proposal.Message] = result
 }
 
-func (lc *LocalChain) GetMovingFundsParameters() (
-	txMaxTotalFee uint64,
-	dustThreshold uint64,
-	timeoutResetDelay uint32,
-	timeout uint32,
-	timeoutSlashingAmount *big.Int,
-	timeoutNotifierRewardMultiplier uint32,
-	commitmentGasOffset uint16,
-	sweepTxMaxTotalFee uint64,
-	sweepTimeout uint32,
-	sweepTimeoutSlashingAmount *big.Int,
-	sweepTimeoutNotifierRewardMultiplier uint32,
-	err error,
-) {
+func (lc *LocalChain) GetMovingFundsParameters() (tbtc.MovingFundsParameters, error) {
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
-	return lc.movingFundsParameters.txMaxTotalFee,
-		lc.movingFundsParameters.dustThreshold,
-		lc.movingFundsParameters.timeoutResetDelay,
-		lc.movingFundsParameters.timeout,
-		lc.movingFundsParameters.timeoutSlashingAmount,
-		lc.movingFundsParameters.timeoutNotifierRewardMultiplier,
-		lc.movingFundsParameters.commitmentGasOffset,
-		lc.movingFundsParameters.sweepTxMaxTotalFee,
-		lc.movingFundsParameters.sweepTimeout,
-		lc.movingFundsParameters.sweepTimeoutSlashingAmount,
-		lc.movingFundsParameters.sweepTimeoutNotifierRewardMultiplier,
-		nil
+	return lc.movingFundsParameters, nil
 }
 
 func (lc *LocalChain) GetMovedFundsSweepRequest(
@@ -836,18 +745,18 @@ func (lc *LocalChain) SetMovingFundsParameters(
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
-	lc.movingFundsParameters = movingFundsParameters{
-		txMaxTotalFee:                        txMaxTotalFee,
-		dustThreshold:                        dustThreshold,
-		timeoutResetDelay:                    timeoutResetDelay,
-		timeout:                              timeout,
-		timeoutSlashingAmount:                timeoutSlashingAmount,
-		timeoutNotifierRewardMultiplier:      timeoutNotifierRewardMultiplier,
-		commitmentGasOffset:                  commitmentGasOffset,
-		sweepTxMaxTotalFee:                   sweepTxMaxTotalFee,
-		sweepTimeout:                         sweepTimeout,
-		sweepTimeoutSlashingAmount:           sweepTimeoutSlashingAmount,
-		sweepTimeoutNotifierRewardMultiplier: sweepTimeoutNotifierRewardMultiplier,
+	lc.movingFundsParameters = tbtc.MovingFundsParameters{
+		TxMaxTotalFee:                        txMaxTotalFee,
+		DustThreshold:                        dustThreshold,
+		TimeoutResetDelay:                    timeoutResetDelay,
+		Timeout:                              timeout,
+		TimeoutSlashingAmount:                timeoutSlashingAmount,
+		TimeoutNotifierRewardMultiplier:      timeoutNotifierRewardMultiplier,
+		CommitmentGasOffset:                  commitmentGasOffset,
+		SweepTxMaxTotalFee:                   sweepTxMaxTotalFee,
+		SweepTimeout:                         sweepTimeout,
+		SweepTimeoutSlashingAmount:           sweepTimeoutSlashingAmount,
+		SweepTimeoutNotifierRewardMultiplier: sweepTimeoutNotifierRewardMultiplier,
 	}
 }
 
@@ -1063,27 +972,11 @@ func (lc *LocalChain) OnWalletClosed(
 	panic("unsupported")
 }
 
-func (lc *LocalChain) GetWalletParameters() (
-	creationPeriod uint32,
-	creationMinBtcBalance uint64,
-	creationMaxBtcBalance uint64,
-	closureMinBtcBalance uint64,
-	maxAge uint32,
-	maxBtcTransfer uint64,
-	closingPeriod uint32,
-	err error,
-) {
+func (lc *LocalChain) GetWalletParameters() (tbtc.WalletParameters, error) {
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
-	return lc.walletParameters.creationPeriod,
-		lc.walletParameters.creationMinBtcBalance,
-		lc.walletParameters.creationMaxBtcBalance,
-		lc.walletParameters.closureMinBtcBalance,
-		lc.walletParameters.maxAge,
-		lc.walletParameters.maxBtcTransfer,
-		lc.walletParameters.closingPeriod,
-		nil
+	return lc.walletParameters, nil
 }
 
 func (lc *LocalChain) SetWalletParameters(
@@ -1098,14 +991,14 @@ func (lc *LocalChain) SetWalletParameters(
 	lc.mutex.Lock()
 	defer lc.mutex.Unlock()
 
-	lc.walletParameters = walletParameters{
-		creationPeriod:        creationPeriod,
-		creationMinBtcBalance: creationMinBtcBalance,
-		creationMaxBtcBalance: creationMaxBtcBalance,
-		closureMinBtcBalance:  closureMinBtcBalance,
-		maxAge:                maxAge,
-		maxBtcTransfer:        maxBtcTransfer,
-		closingPeriod:         closingPeriod,
+	lc.walletParameters = tbtc.WalletParameters{
+		CreationPeriod:        creationPeriod,
+		CreationMinBtcBalance: creationMinBtcBalance,
+		CreationMaxBtcBalance: creationMaxBtcBalance,
+		ClosureMinBtcBalance:  closureMinBtcBalance,
+		MaxAge:                maxAge,
+		MaxBtcTransfer:        maxBtcTransfer,
+		ClosingPeriod:         closingPeriod,
 	}
 }
 

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -495,10 +495,11 @@ func (dst *DepositSweepTask) ProposeDepositsSweep(
 	if fee <= 0 {
 		taskLogger.Infof("estimating sweep transaction fee")
 		var err error
-		_, _, perDepositMaxFee, _, err := dst.chain.GetDepositParameters()
+		depositParameters, err := dst.chain.GetDepositParameters()
 		if err != nil {
 			return nil, fmt.Errorf("cannot get deposit tx max fee: [%w]", err)
 		}
+		perDepositMaxFee := depositParameters.TxMaxFee
 
 		estimatedFee, _, err := estimateDepositsSweepFee(
 			dst.btcChain,
@@ -594,10 +595,11 @@ func EstimateDepositsSweepFee(
 	},
 	error,
 ) {
-	_, _, perDepositMaxFee, _, err := chain.GetDepositParameters()
+	depositParameters, err := chain.GetDepositParameters()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get deposit tx max fee: [%v]", err)
 	}
+	perDepositMaxFee := depositParameters.TxMaxFee
 
 	fees := make(map[int]struct {
 		TotalFee       int64

--- a/pkg/tbtcpg/moved_funds_sweep.go
+++ b/pkg/tbtcpg/moved_funds_sweep.go
@@ -324,13 +324,14 @@ func (mfst *MovedFundsSweepTask) ProposeMovedFundsSweep(
 	if fee <= 0 {
 		taskLogger.Infof("estimating moved funds sweep transaction fee")
 
-		_, _, _, _, _, _, _, sweepTxMaxTotalFee, _, _, _, err := mfst.chain.GetMovingFundsParameters()
+		movingFundsParameters, err := mfst.chain.GetMovingFundsParameters()
 		if err != nil {
 			return nil, fmt.Errorf(
 				"cannot get moved funds sweep tx max total fee: [%w]",
 				err,
 			)
 		}
+		sweepTxMaxTotalFee := movingFundsParameters.SweepTxMaxTotalFee
 
 		estimatedFee, err := EstimateMovedFundsSweepFee(
 			mfst.btcChain,

--- a/pkg/tbtcpg/moving_funds.go
+++ b/pkg/tbtcpg/moving_funds.go
@@ -272,10 +272,11 @@ func (mft *MovingFundsTask) findNewTargetWallets(
 		"commitment not submitted yet; looking for new target wallets",
 	)
 
-	_, _, _, _, _, walletMaxBtcTransfer, _, err := mft.chain.GetWalletParameters()
+	walletParameters, err := mft.chain.GetWalletParameters()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get wallet parameters: [%w]", err)
 	}
+	walletMaxBtcTransfer := walletParameters.MaxBtcTransfer
 
 	if walletMaxBtcTransfer == 0 {
 		return nil, ErrMaxBtcTransferZero
@@ -574,13 +575,14 @@ func (mft *MovingFundsTask) ProposeMovingFunds(
 	if fee <= 0 {
 		taskLogger.Infof("estimating moving funds transaction fee")
 
-		txMaxTotalFee, _, _, _, _, _, _, _, _, _, _, err := mft.chain.GetMovingFundsParameters()
+		movingFundsParameters, err := mft.chain.GetMovingFundsParameters()
 		if err != nil {
 			return nil, fmt.Errorf(
 				"cannot get moving funds tx max total fee: [%w]",
 				err,
 			)
 		}
+		txMaxTotalFee := movingFundsParameters.TxMaxTotalFee
 
 		estimatedFee, err := EstimateMovingFundsFee(
 			mft.btcChain,

--- a/pkg/tbtcpg/redemptions.go
+++ b/pkg/tbtcpg/redemptions.go
@@ -152,13 +152,14 @@ func (rt *RedemptionTask) FindPendingRedemptions(
 		)
 	}
 
-	_, _, _, _, requestTimeout, _, _, err := rt.chain.GetRedemptionParameters()
+	redemptionParameters, err := rt.chain.GetRedemptionParameters()
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get redemption parameters: [%w]",
 			err,
 		)
 	}
+	requestTimeout := redemptionParameters.Timeout
 
 	taskLogger.Infof("fetching pending redemption requests")
 


### PR DESCRIPTION
## Summary

The on-chain tBTC parameter getters returned wide positional tuples that
callers destructured with long blank-identifier lists. For example:

```go
_, _, _, _, _, _, _, sweepTxMaxTotalFee, _, _, _, err := chain.GetMovingFundsParameters()
```

`GetMovingFundsParameters` returned 11 values plus `err`. Because many of the
values share a type, a positional slip in one of these lists compiles cleanly
and fails silently at runtime.

This replaces the wide tuples with named structs in `pkg/tbtc`, so callers
access fields by name:

```go
movingFundsParameters, err := chain.GetMovingFundsParameters()
... movingFundsParameters.SweepTxMaxTotalFee ...
```

## Changes

- New `pkg/tbtc/parameters.go` defining `MovingFundsParameters`,
  `WalletParameters`, `DepositParameters`, `RedemptionParameters`.
- `GetMovingFundsParameters` (on `tbtc.BridgeChain`, embedded by `tbtcpg.Chain`)
  and the three others (on `tbtcpg.Chain`) now return the corresponding struct.
- All structs live in `pkg/tbtc`, which both the ethereum adapter and `tbtcpg`
  already import, so no new dependency edges are introduced.
- Updated the ethereum adapter implementations, three inline-interface
  declarations in `pkg/tbtc/moving_funds.go`, both local test chains (which get
  simpler — their internal struct aliases are dropped), and all call sites.

Net: the diff removes more than it adds; the change is a simplification.

## Notes for review

- Each of the call-site conversions was mapped position-by-position against the
  original tuple order, and the `tbtcpg` tests discriminate a wrong-but-
  same-typed field pick (e.g. `moved_funds_sweep` sets `TxMaxTotalFee` to 0 but
  `SweepTxMaxTotalFee` to a non-zero value).
- `pkg/tbtc`'s test-only `localChain.GetWalletParameters` is left as the old
  wide-tuple `panic("unsupported")` stub. It satisfies no `tbtc` interface (only
  `tbtcpg.Chain` declares `GetWalletParameters`), so it is dead in the `tbtc`
  package and was left untouched to keep the change surgical.

## Verification

- `go build ./...` and `go vet ./...` clean.
- `pkg/tbtc`, `pkg/tbtcpg`, and `pkg/chain/ethereum` test suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized parameter structures for deposits, redemptions, wallets, and moving funds.
  * Consolidated configuration retrieval into structured results, making fee limits, thresholds, timeouts, and balance settings easier to access.

* **Refactor**
  * Updated related transaction, sweep, and wallet workflows to use the consolidated parameter structures without changing their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->