### PR TITLE
Add follower-side soft check for below-floor sweep fees

### DIFF
--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -50,14 +50,15 @@ const (
 	// the transaction is known on the Bitcoin chain. This delay is needed
 	// as spreading the transaction over the Bitcoin network takes time.
 	depositSweepBroadcastCheckDelay = 1 * time.Minute
-	// minSweepTxSatPerVByteFee mirrors tbtcpg.minWalletTxSatPerVByteFee, the safe
+	// minSweepTxSatPerVByteFee mirrors tbtcpg.MinWalletTxSatPerVByteFee, the safe
 	// minimum sweep fee rate. It is duplicated here because pkg/tbtcpg imports
 	// pkg/tbtc, so this package cannot import the canonical constant without a
-	// dependency cycle; keep the two in sync. It backs a follower-side soft
-	// (log-only) check that the leader's proposed sweep fee is not below the
-	// floor (see threshold-network/keep-core#4171).
+	// dependency cycle; keep the two in sync (guarded by TestSweepFeeConstants
+	// MirrorTbtcpg). It backs a follower-side soft (log-only) check that the
+	// leader's proposed sweep fee is not below the floor (see
+	// threshold-network/keep-core#4171).
 	minSweepTxSatPerVByteFee = 5
-	// depositScriptByteSize mirrors tbtcpg.depositScriptByteSize, the worst-case
+	// depositScriptByteSize mirrors tbtcpg.DepositScriptByteSize, the worst-case
 	// deposit script size used to estimate the sweep transaction virtual size.
 	depositScriptByteSize = 126
 )

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -50,6 +50,16 @@ const (
 	// the transaction is known on the Bitcoin chain. This delay is needed
 	// as spreading the transaction over the Bitcoin network takes time.
 	depositSweepBroadcastCheckDelay = 1 * time.Minute
+	// minSweepTxSatPerVByteFee mirrors tbtcpg.minWalletTxSatPerVByteFee, the safe
+	// minimum sweep fee rate. It is duplicated here because pkg/tbtcpg imports
+	// pkg/tbtc, so this package cannot import the canonical constant without a
+	// dependency cycle; keep the two in sync. It backs a follower-side soft
+	// (log-only) check that the leader's proposed sweep fee is not below the
+	// floor (see threshold-network/keep-core#4171).
+	minSweepTxSatPerVByteFee = 5
+	// depositScriptByteSize mirrors tbtcpg.depositScriptByteSize, the worst-case
+	// deposit script size used to estimate the sweep transaction virtual size.
+	depositScriptByteSize = 126
 )
 
 // DepositSweepProposal represents a deposit sweep proposal issued by a
@@ -465,6 +475,41 @@ func ValidateDepositSweepProposal(
 	validateProposalLogger.Infof(
 		"deposit sweep proposal is valid",
 	)
+
+	// Follower-side soft check on the proposed fee. The on-chain
+	// WalletProposalValidator only bounds the sweep fee from above, not below,
+	// so a misbehaving or unpatched leader can propose a fee at the ~1 sat/vByte
+	// relay floor that this node would otherwise sign - the same underpricing
+	// that jams the wallet (see threshold-network/keep-core#4171). We recompute
+	// the safe minimum and warn if the proposal is below it.
+	//
+	// This is intentionally log-only, not a rejection: rejecting a below-floor
+	// proposal here would, during a mixed-version rollout, split signers (patched
+	// nodes reject, unpatched nodes sign) and could stall signing. Hard
+	// enforcement belongs on-chain in the WalletProposalValidator, or behind a
+	// coordinated all-nodes upgrade.
+	if sweepTxSize, sizeErr := bitcoin.NewTransactionSizeEstimator().
+		AddPublicKeyHashInputs(1, true).
+		AddScriptHashInputs(len(proposal.DepositsKeys), depositScriptByteSize, true).
+		AddPublicKeyHashOutputs(1, true).
+		VirtualSize(); sizeErr != nil {
+		validateProposalLogger.Warnf(
+			"cannot estimate sweep tx size for the fee sanity check: [%v]",
+			sizeErr,
+		)
+	} else if minSweepTxFee := int64(minSweepTxSatPerVByteFee) * sweepTxSize; proposal.SweepTxFee != nil &&
+		proposal.SweepTxFee.Int64() < minSweepTxFee {
+		validateProposalLogger.Warnf(
+			"proposed sweep tx fee [%v] is below the safe minimum [%d] "+
+				"([%d] sat/vByte * [%d] vByte); the leader may be underpricing "+
+				"the sweep, which risks it getting stuck in the mempool and "+
+				"jamming the wallet",
+			proposal.SweepTxFee,
+			minSweepTxFee,
+			minSweepTxSatPerVByteFee,
+			sweepTxSize,
+		)
+	}
 
 	deposits := make([]*Deposit, len(depositExtraInfo))
 	for i, dei := range depositExtraInfo {

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -50,17 +50,20 @@ const (
 	// the transaction is known on the Bitcoin chain. This delay is needed
 	// as spreading the transaction over the Bitcoin network takes time.
 	depositSweepBroadcastCheckDelay = 1 * time.Minute
-	// minSweepTxSatPerVByteFee mirrors tbtcpg.MinWalletTxSatPerVByteFee, the safe
+	// MinSweepTxSatPerVByteFee mirrors tbtcpg.MinWalletTxSatPerVByteFee, the safe
 	// minimum sweep fee rate. It is duplicated here because pkg/tbtcpg imports
 	// pkg/tbtc, so this package cannot import the canonical constant without a
-	// dependency cycle; keep the two in sync (guarded by TestSweepFeeConstants
-	// MirrorTbtcpg). It backs a follower-side soft (log-only) check that the
-	// leader's proposed sweep fee is not below the floor (see
-	// threshold-network/keep-core#4171).
-	minSweepTxSatPerVByteFee = 5
-	// depositScriptByteSize mirrors tbtcpg.DepositScriptByteSize, the worst-case
+	// dependency cycle; keep the two in sync. It is exported so the external
+	// tbtc_test package can compare it against the canonical tbtcpg value
+	// (guarded by TestSweepFeeConstantsMirrorTbtcpg). It backs a follower-side
+	// soft (log-only) check that the leader's proposed sweep fee is not below
+	// the floor (see threshold-network/keep-core#4171).
+	MinSweepTxSatPerVByteFee = 5
+	// DepositScriptByteSize mirrors tbtcpg.DepositScriptByteSize, the worst-case
 	// deposit script size used to estimate the sweep transaction virtual size.
-	depositScriptByteSize = 126
+	// Exported alongside MinSweepTxSatPerVByteFee for the same cross-package
+	// drift guard.
+	DepositScriptByteSize = 126
 )
 
 // DepositSweepProposal represents a deposit sweep proposal issued by a
@@ -491,25 +494,37 @@ func ValidateDepositSweepProposal(
 	// coordinated all-nodes upgrade.
 	if sweepTxSize, sizeErr := bitcoin.NewTransactionSizeEstimator().
 		AddPublicKeyHashInputs(1, true).
-		AddScriptHashInputs(len(proposal.DepositsKeys), depositScriptByteSize, true).
+		AddScriptHashInputs(len(proposal.DepositsKeys), DepositScriptByteSize, true).
 		AddPublicKeyHashOutputs(1, true).
 		VirtualSize(); sizeErr != nil {
 		validateProposalLogger.Warnf(
 			"cannot estimate sweep tx size for the fee sanity check: [%v]",
 			sizeErr,
 		)
-	} else if minSweepTxFee := int64(minSweepTxSatPerVByteFee) * sweepTxSize; proposal.SweepTxFee != nil &&
-		proposal.SweepTxFee.Int64() < minSweepTxFee {
-		validateProposalLogger.Warnf(
-			"proposed sweep tx fee [%v] is below the safe minimum [%d] "+
-				"([%d] sat/vByte * [%d] vByte); the leader may be underpricing "+
-				"the sweep, which risks it getting stuck in the mempool and "+
-				"jamming the wallet",
-			proposal.SweepTxFee,
-			minSweepTxFee,
-			minSweepTxSatPerVByteFee,
-			sweepTxSize,
-		)
+	} else {
+		minSweepTxFee := big.NewInt(int64(MinSweepTxSatPerVByteFee) * sweepTxSize)
+
+		switch {
+		case proposal.SweepTxFee == nil:
+			validateProposalLogger.Warnf(
+				"proposal has no sweep tx fee set; expected at least the safe "+
+					"minimum [%d] ([%d] sat/vByte * [%d] vByte)",
+				minSweepTxFee,
+				MinSweepTxSatPerVByteFee,
+				sweepTxSize,
+			)
+		case proposal.SweepTxFee.Cmp(minSweepTxFee) < 0:
+			validateProposalLogger.Warnf(
+				"proposed sweep tx fee [%v] is below the safe minimum [%d] "+
+					"([%d] sat/vByte * [%d] vByte); the leader may be underpricing "+
+					"the sweep, which risks it getting stuck in the mempool and "+
+					"jamming the wallet",
+				proposal.SweepTxFee,
+				minSweepTxFee,
+				MinSweepTxSatPerVByteFee,
+				sweepTxSize,
+			)
+		}
 	}
 
 	deposits := make([]*Deposit, len(depositExtraInfo))

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -505,6 +505,14 @@ func ValidateDepositSweepProposal(
 		minSweepTxFee := big.NewInt(int64(MinSweepTxSatPerVByteFee) * sweepTxSize)
 
 		switch {
+		// This branch is defense-in-depth for test/mock chain implementations
+		// and is not expected to be reachable on the real production path: by
+		// the time control reaches this point, chain.ValidateDepositSweepProposal
+		// above has already ABI-packed proposal.SweepTxFee to call the on-chain
+		// WalletProposalValidator, which panics on a nil *big.Int before this
+		// code ever runs. Likewise, a proposal decoded off the wire
+		// (DepositSweepProposal.Unmarshal in marshaling.go) always constructs
+		// SweepTxFee via new(big.Int).SetBytes(...), which never yields nil.
 		case proposal.SweepTxFee == nil:
 			validateProposalLogger.Warnf(
 				"proposal has no sweep tx fee set; expected at least the safe "+

--- a/pkg/tbtc/deposit_sweep_test.go
+++ b/pkg/tbtc/deposit_sweep_test.go
@@ -319,3 +319,141 @@ func TestAssembleDepositSweepTransaction(t *testing.T) {
 		})
 	}
 }
+
+// capturingLogger wraps testutils.MockLogger and records Warnf calls for
+// assertions.
+type capturingLogger struct {
+	testutils.MockLogger
+	warnings []string
+}
+
+func (cl *capturingLogger) Warnf(format string, args ...interface{}) {
+	cl.warnings = append(cl.warnings, fmt.Sprintf(format, args...))
+}
+
+// depositSweepFeeCheckChain is a minimal stub satisfying the chain interface
+// ValidateDepositSweepProposal requires. Its ValidateDepositSweepProposal
+// unconditionally reports the proposal as valid, and its other two methods
+// are never invoked for a proposal with no deposits. This isolates the
+// follower-side sweep-fee soft check (deposit_sweep.go, below the
+// "calling chain for proposal validation" log line) from on-chain proposal
+// validation and deposit-lookup concerns that the soft check does not
+// depend on.
+type depositSweepFeeCheckChain struct{}
+
+func (depositSweepFeeCheckChain) PastDepositRevealedEvents(
+	*DepositRevealedEventFilter,
+) ([]*DepositRevealedEvent, error) {
+	return nil, nil
+}
+
+func (depositSweepFeeCheckChain) ValidateDepositSweepProposal(
+	[20]byte,
+	*DepositSweepProposal,
+	[]struct {
+		*Deposit
+		FundingTx *bitcoin.Transaction
+	},
+) error {
+	return nil
+}
+
+func (depositSweepFeeCheckChain) GetDepositRequest(
+	bitcoin.Hash,
+	uint32,
+) (*DepositChainRequest, bool, error) {
+	return nil, false, nil
+}
+
+// TestValidateDepositSweepProposal_SweepFeeSoftCheck exercises the
+// follower-side soft check on the leader-proposed sweep fee. The check is
+// log-only by design (see threshold-network/keep-core#4171): it must warn
+// about an unsafe fee but must never fail proposal validation because of it.
+func TestValidateDepositSweepProposal_SweepFeeSoftCheck(t *testing.T) {
+	var walletPublicKeyHash [20]byte
+	stubChain := depositSweepFeeCheckChain{}
+	btcChain := newLocalBitcoinChain()
+
+	// Compute the exact safe-minimum fee for a proposal with no deposits
+	// using the same estimator call the soft check itself performs
+	// (deposit_sweep.go), so the boundary between "below" and "at/above" the
+	// floor is derived rather than hardcoded.
+	sweepTxSize, err := bitcoin.NewTransactionSizeEstimator().
+		AddPublicKeyHashInputs(1, true).
+		AddScriptHashInputs(0, DepositScriptByteSize, true).
+		AddPublicKeyHashOutputs(1, true).
+		VirtualSize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	minSweepTxFee := big.NewInt(int64(MinSweepTxSatPerVByteFee) * sweepTxSize)
+
+	scenarios := map[string]struct {
+		fee        *big.Int
+		expectWarn bool
+	}{
+		"fee below the safe minimum": {
+			fee:        new(big.Int).Sub(minSweepTxFee, big.NewInt(1)),
+			expectWarn: true,
+		},
+		"fee at the safe minimum": {
+			fee:        minSweepTxFee,
+			expectWarn: false,
+		},
+		"fee above the safe minimum": {
+			fee:        new(big.Int).Add(minSweepTxFee, big.NewInt(1000)),
+			expectWarn: false,
+		},
+		// A nil SweepTxFee cannot occur on the real production path (see the
+		// comment on the nil case in deposit_sweep.go): the on-chain
+		// WalletProposalValidator call a few lines above the soft check
+		// already ABI-packs the fee and panics first, and wire
+		// deserialization always constructs a non-nil value. This scenario
+		// exists to lock in the defense-in-depth behavior for callers, like
+		// this test's stub chain, that can hand the soft check a nil fee
+		// directly.
+		"nil fee from a test/mock caller": {
+			fee:        nil,
+			expectWarn: true,
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			proposal := &DepositSweepProposal{
+				SweepTxFee: scenario.fee,
+			}
+
+			logger := &capturingLogger{}
+
+			_, err := ValidateDepositSweepProposal(
+				logger,
+				walletPublicKeyHash,
+				proposal,
+				0,
+				stubChain,
+				btcChain,
+			)
+			if err != nil {
+				t.Fatalf(
+					"expected the log-only soft check to never fail "+
+						"validation; got error: [%v]",
+					err,
+				)
+			}
+
+			gotWarn := len(logger.warnings) > 0
+			if gotWarn != scenario.expectWarn {
+				t.Errorf(
+					"unexpected warning presence for fee [%v]\n"+
+						"expected warning: %v\nactual warning:   %v\n"+
+						"captured warnings: %v",
+					scenario.fee,
+					scenario.expectWarn,
+					gotWarn,
+					logger.warnings,
+				)
+			}
+		})
+	}
+}

--- a/pkg/tbtc/sweep_fee_sync_test.go
+++ b/pkg/tbtc/sweep_fee_sync_test.go
@@ -1,0 +1,46 @@
+package tbtc_test
+
+import (
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/tbtcpg"
+)
+
+// TestSweepFeeConstantsMirrorTbtcpg guards the sweep-fee constants that
+// pkg/tbtc/deposit_sweep.go duplicates from pkg/tbtcpg. The follower-side soft
+// check (threshold-network/keep-core#4171) recomputes the safe minimum sweep
+// fee, but pkg/tbtcpg imports pkg/tbtc, so pkg/tbtc cannot import the canonical
+// constants without a dependency cycle and hand-copies them instead.
+//
+// This test lives in the external tbtc_test package precisely because that
+// package can import pkg/tbtcpg without forming the cycle. It pins the canonical
+// tbtcpg values to the literals mirrored in pkg/tbtc/deposit_sweep.go
+// (minSweepTxSatPerVByteFee and depositScriptByteSize). If the canonical values
+// drift, this test fails, forcing the pkg/tbtc mirrors - and these expected
+// literals - to be updated together.
+func TestSweepFeeConstantsMirrorTbtcpg(t *testing.T) {
+	// Mirrored by pkg/tbtc/deposit_sweep.go:minSweepTxSatPerVByteFee.
+	const expectedMinWalletTxSatPerVByteFee = 5
+	// Mirrored by pkg/tbtc/deposit_sweep.go:depositScriptByteSize.
+	const expectedDepositScriptByteSize = 126
+
+	if tbtcpg.MinWalletTxSatPerVByteFee != expectedMinWalletTxSatPerVByteFee {
+		t.Errorf(
+			"tbtcpg.MinWalletTxSatPerVByteFee is [%d]; the pkg/tbtc mirror "+
+				"minSweepTxSatPerVByteFee [%d] is now stale and must be updated "+
+				"along with this test",
+			tbtcpg.MinWalletTxSatPerVByteFee,
+			expectedMinWalletTxSatPerVByteFee,
+		)
+	}
+
+	if tbtcpg.DepositScriptByteSize != expectedDepositScriptByteSize {
+		t.Errorf(
+			"tbtcpg.DepositScriptByteSize is [%d]; the pkg/tbtc mirror "+
+				"depositScriptByteSize [%d] is now stale and must be updated "+
+				"along with this test",
+			tbtcpg.DepositScriptByteSize,
+			expectedDepositScriptByteSize,
+		)
+	}
+}

--- a/pkg/tbtc/sweep_fee_sync_test.go
+++ b/pkg/tbtc/sweep_fee_sync_test.go
@@ -3,44 +3,41 @@ package tbtc_test
 import (
 	"testing"
 
+	"github.com/keep-network/keep-core/pkg/tbtc"
 	"github.com/keep-network/keep-core/pkg/tbtcpg"
 )
 
-// TestSweepFeeConstantsMirrorTbtcpg guards the sweep-fee constants that
-// pkg/tbtc/deposit_sweep.go duplicates from pkg/tbtcpg. The follower-side soft
-// check (threshold-network/keep-core#4171) recomputes the safe minimum sweep
-// fee, but pkg/tbtcpg imports pkg/tbtc, so pkg/tbtc cannot import the canonical
-// constants without a dependency cycle and hand-copies them instead.
+// TestSweepFeeConstantsMirrorTbtcpg guards the sweep-fee constants that pkg/tbtc
+// duplicates from pkg/tbtcpg. The follower-side soft check
+// (threshold-network/keep-core#4171) recomputes the safe minimum sweep fee, but
+// pkg/tbtcpg imports pkg/tbtc, so pkg/tbtc cannot import the canonical constants
+// without a dependency cycle and hand-copies them instead.
 //
 // This test lives in the external tbtc_test package precisely because that
-// package can import pkg/tbtcpg without forming the cycle. It pins the canonical
-// tbtcpg values to the literals mirrored in pkg/tbtc/deposit_sweep.go
-// (minSweepTxSatPerVByteFee and depositScriptByteSize). If the canonical values
-// drift, this test fails, forcing the pkg/tbtc mirrors - and these expected
-// literals - to be updated together.
+// package can import both pkg/tbtc and pkg/tbtcpg without forming the cycle. It
+// compares the two actual constants directly - not against hand-copied literals
+// - so it fails whenever the pkg/tbtc mirror and the canonical tbtcpg value
+// drift apart, regardless of which side was changed. A literal-based guard
+// could be defeated by updating tbtcpg and the literal together while forgetting
+// the pkg/tbtc mirror; comparing the live values closes that gap.
 func TestSweepFeeConstantsMirrorTbtcpg(t *testing.T) {
-	// Mirrored by pkg/tbtc/deposit_sweep.go:minSweepTxSatPerVByteFee.
-	const expectedMinWalletTxSatPerVByteFee = 5
-	// Mirrored by pkg/tbtc/deposit_sweep.go:depositScriptByteSize.
-	const expectedDepositScriptByteSize = 126
-
-	if tbtcpg.MinWalletTxSatPerVByteFee != expectedMinWalletTxSatPerVByteFee {
+	if tbtc.MinSweepTxSatPerVByteFee != tbtcpg.MinWalletTxSatPerVByteFee {
 		t.Errorf(
-			"tbtcpg.MinWalletTxSatPerVByteFee is [%d]; the pkg/tbtc mirror "+
-				"minSweepTxSatPerVByteFee [%d] is now stale and must be updated "+
-				"along with this test",
+			"tbtc.MinSweepTxSatPerVByteFee [%d] has drifted from the canonical "+
+				"tbtcpg.MinWalletTxSatPerVByteFee [%d]; the follower soft check "+
+				"would warn at the wrong threshold",
+			tbtc.MinSweepTxSatPerVByteFee,
 			tbtcpg.MinWalletTxSatPerVByteFee,
-			expectedMinWalletTxSatPerVByteFee,
 		)
 	}
 
-	if tbtcpg.DepositScriptByteSize != expectedDepositScriptByteSize {
+	if tbtc.DepositScriptByteSize != tbtcpg.DepositScriptByteSize {
 		t.Errorf(
-			"tbtcpg.DepositScriptByteSize is [%d]; the pkg/tbtc mirror "+
-				"depositScriptByteSize [%d] is now stale and must be updated "+
-				"along with this test",
+			"tbtc.DepositScriptByteSize [%d] has drifted from the canonical "+
+				"tbtcpg.DepositScriptByteSize [%d]; the follower soft check would "+
+				"estimate the sweep tx size incorrectly",
+			tbtc.DepositScriptByteSize,
 			tbtcpg.DepositScriptByteSize,
-			expectedDepositScriptByteSize,
 		)
 	}
 }

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -18,9 +18,10 @@ import (
 	"github.com/keep-network/keep-core/pkg/tbtc"
 )
 
-// Use the worst-case 126-byte deposit script with embedded extra data for estimation.
-// This will ensure that deposit sweep transaction fees are not underestimated.
-const depositScriptByteSize = 126
+// DepositScriptByteSize is the worst-case 126-byte deposit script with embedded
+// extra data used for transaction size estimation. This ensures that deposit
+// sweep transaction fees are not underestimated.
+const DepositScriptByteSize = 126
 
 // DepositSweepLookBackBlocks is the look-back period in blocks used
 // when searching for submitted deposit-related events. It's equal to
@@ -495,7 +496,7 @@ func (dst *DepositSweepTask) ProposeDepositsSweep(
 			// the deposits stay unswept. Log it distinctly at WARN so operators
 			// can tell this apart from a benign "no deposits to sweep" outcome;
 			// in particular, a safe-minimum-fee abort (see
-			// minWalletTxSatPerVByteFee) can indicate a misconfigured, too-low
+			// MinWalletTxSatPerVByteFee) can indicate a misconfigured, too-low
 			// per-deposit maximum fee that will strand deposits until governance
 			// raises it.
 			taskLogger.Warnf("cannot estimate sweep transaction fee: [%v]", err)
@@ -565,7 +566,7 @@ func (dst *DepositSweepTask) ProposeDepositsSweep(
 //   - 1 P2WPKH output
 //
 // An error is returned if any estimated fee exceeds the maximum fee allowed by
-// the Bridge contract, or if the minimum safe fee (see minWalletTxSatPerVByteFee)
+// the Bridge contract, or if the minimum safe fee (see MinWalletTxSatPerVByteFee)
 // required to avoid a stuck, unbumpable sweep would itself exceed that Bridge
 // maximum.
 func EstimateDepositsSweepFee(
@@ -639,7 +640,7 @@ func estimateDepositsSweepFee(
 		// 1 P2WPKH main UTXO input.
 		AddPublicKeyHashInputs(1, true).
 		// depositsCount P2WSH deposit inputs.
-		AddScriptHashInputs(depositsCount, depositScriptByteSize, true).
+		AddScriptHashInputs(depositsCount, DepositScriptByteSize, true).
 		// 1 P2WPKH output.
 		AddPublicKeyHashOutputs(1, true).
 		VirtualSize()

--- a/pkg/tbtcpg/deposit_sweep_fee_test.go
+++ b/pkg/tbtcpg/deposit_sweep_fee_test.go
@@ -12,7 +12,7 @@ import (
 // with the given number of deposit inputs, mirroring the sizing that
 // EstimateDepositsSweepFee performs internally: 1 P2WPKH main-UTXO input,
 // depositsCount P2WSH deposit inputs, and 1 P2WPKH output. 126 ==
-// depositScriptByteSize.
+// DepositScriptByteSize.
 func sweepVirtualSize(t *testing.T, depositsCount int) int64 {
 	t.Helper()
 	size, err := bitcoin.NewTransactionSizeEstimator().

--- a/pkg/tbtcpg/fee.go
+++ b/pkg/tbtcpg/fee.go
@@ -14,7 +14,7 @@ var ErrMaxFeeTooLow = errors.New(
 	"minimum safe transaction fee exceeds the maximum fee",
 )
 
-// minWalletTxSatPerVByteFee is the minimum fee rate, in sat/vByte, applied to
+// MinWalletTxSatPerVByteFee is the minimum fee rate, in sat/vByte, applied to
 // wallet Bitcoin transactions (deposit sweeps, redemptions, moving funds, moved
 // funds sweeps). A fee oracle can return an unusably low estimate (down to the
 // 1 sat/vByte relay floor enforced by the Electrum client) in an uncongested
@@ -34,13 +34,13 @@ var ErrMaxFeeTooLow = errors.New(
 // revisited rather than carried forward unchanged: the defensive buffer can be
 // dropped and the floor relaxed toward the live estimate, keeping only a small
 // relay-propagation minimum.
-const minWalletTxSatPerVByteFee = 5
+const MinWalletTxSatPerVByteFee = 5
 
 // applyWalletTxFeeFloor raises a raw oracle fee estimate to a safe value for a
 // non-RBF wallet transaction. It:
 //   - adds a 25% buffer over the oracle estimate so there is margin during the
 //     estimate-to-broadcast delay and the fee stays adaptive under congestion,
-//   - enforces a floor of minWalletTxSatPerVByteFee sat/vByte, and
+//   - enforces a floor of MinWalletTxSatPerVByteFee sat/vByte, and
 //   - bounds the result by maxTotalFee (the Bridge maximum total fee for the
 //     transaction).
 //
@@ -79,19 +79,19 @@ func applyWalletTxFeeFloor(
 
 	// If even the minimum floor exceeds the Bridge maximum, a safe transaction
 	// cannot be constructed; error rather than silently broadcast underpriced.
-	if uint64(minWalletTxSatPerVByteFee*txVsize) > maxTotalFee {
+	if uint64(MinWalletTxSatPerVByteFee*txVsize) > maxTotalFee {
 		return 0, fmt.Errorf(
 			"%w: minimum fee [%d], maximum fee [%d]",
 			ErrMaxFeeTooLow,
-			minWalletTxSatPerVByteFee*txVsize,
+			MinWalletTxSatPerVByteFee*txVsize,
 			maxTotalFee,
 		)
 	}
 
 	rate := estimatedFee / txVsize
 	rate = (rate*5 + 3) / 4 // ceil(rate * 1.25)
-	if rate < minWalletTxSatPerVByteFee {
-		rate = minWalletTxSatPerVByteFee
+	if rate < MinWalletTxSatPerVByteFee {
+		rate = MinWalletTxSatPerVByteFee
 	}
 
 	// Clamp down to the Bridge maximum total fee. This can never drop the fee

--- a/pkg/tbtcpg/redemptions_test.go
+++ b/pkg/tbtcpg/redemptions_test.go
@@ -316,16 +316,31 @@ func TestRedemptionAction_ProposeRedemption_PerRequestFeeWarning(t *testing.T) {
 
 	var tests = map[string]struct {
 		txMaxFee      uint64
+		txMaxTotalFee uint64
+		expectedFee   int64
 		expectWarning bool
 	}{
 		"worst-case share within the per-request cap": {
-			txMaxFee:      3000, // 2166 <= 3000
+			// Aggregate cap = txMaxFee*count = 3000*3 = 9000, looser than
+			// txMaxTotalFee (8000), so the total-fee cap governs and the fee
+			// is unclamped; 2166 <= 3000 so no warning either.
+			txMaxFee:      3000,
+			txMaxTotalFee: 8000,
+			expectedFee:   6496,
 			expectWarning: false,
 		},
-		"even share at the cap but last-request share exceeds it": {
-			// The even share 2165 equals the cap (a floor-division check would
-			// not warn), but the last request pays 2166 and would be rejected.
+		"total-fee cap clamps to a value whose remainder exceeds the per-request cap": {
+			// The aggregate per-request ceiling (txMaxFee*count = 2165*3 =
+			// 6495) is looser than txMaxTotalFee (6494), so txMaxTotalFee
+			// governs and the buffered fee (6496) is clamped down to 6494 -
+			// not a multiple of count, so the remainder still lands
+			// unevenly. The even share is floor(6494/3) = 2164 and the last
+			// request pays 2164 + 6494%3 = 2166, which exceeds txMaxFee
+			// (2165) even though the aggregate cap alone would not have
+			// forced an uneven split.
 			txMaxFee:      2165,
+			txMaxTotalFee: 6494,
+			expectedFee:   6494,
 			expectWarning: true,
 		},
 	}
@@ -337,9 +352,8 @@ func TestRedemptionAction_ProposeRedemption_PerRequestFeeWarning(t *testing.T) {
 
 			btcChain.SetEstimateSatPerVByteFee(1, 25)
 
-			// txMaxFee at index 2; txMaxTotalFee at index 3, set comfortably
-			// above the estimated total (6496) so it does not bound the fee.
-			tbtcChain.SetRedemptionParameters(0, 0, test.txMaxFee, 8000, 0, nil, 0)
+			// txMaxFee at index 2; txMaxTotalFee at index 3.
+			tbtcChain.SetRedemptionParameters(0, 0, test.txMaxFee, test.txMaxTotalFee, 0, nil, 0)
 
 			for _, script := range redeemersOutputScripts {
 				tbtcChain.SetPendingRedemptionRequest(
@@ -352,7 +366,7 @@ func TestRedemptionAction_ProposeRedemption_PerRequestFeeWarning(t *testing.T) {
 
 			expectedProposal := &tbtc.RedemptionProposal{
 				RedeemersOutputScripts: redeemersOutputScripts,
-				RedemptionTxFee:        big.NewInt(6496),
+				RedemptionTxFee:        big.NewInt(test.expectedFee),
 			}
 
 			err := tbtcChain.SetRedemptionProposalValidationResult(


### PR DESCRIPTION
## Summary

Adds a follower-side soft (log-only) check that the leader's proposed deposit
sweep fee is not below the safe minimum. The on-chain `WalletProposalValidator`
only bounds the sweep fee from above, so a misbehaving or unpatched leader can
propose a fee at the ~1 sat/vByte relay floor that would otherwise be signed -
the same underpricing that jams the wallet (threshold-network/keep-core#4171).
Each node recomputes the safe minimum and logs a warning when the proposal is
below it.

The check is intentionally **log-only, not a rejection**: rejecting a
below-floor proposal would, during a mixed-version rollout, split signers
(patched nodes reject, unpatched nodes sign) and could stall signing. Hard
enforcement belongs on-chain in the `WalletProposalValidator` or behind a
coordinated all-nodes upgrade.

## Contents

This branch is rebased on current `main` and, in addition to the soft check,
carries the safe-minimum sweep-fee floor applied to all wallet transactions
(the `feat/floor-all-wallet-tx-fees` work, also open as #4179 / #4192). The
floor commit is bundled here so the branch builds and passes CI against `main`;
if the floor lands separately first, this branch should be rebased to drop it.

## Review follow-ups addressed

Incorporates the multi-agent review of the soft check:

- Warn when `SweepTxFee` is `nil` instead of silently skipping the check; a
  missing fee gets its own distinct log line.
- Compare the proposed fee with `big.Int.Cmp` instead of `Int64()`, which is
  undefined above `MaxInt64`.
- Replace the literal-pinned constant drift guard with a direct comparison of
  the (now exported) `pkg/tbtc` mirrors against the canonical `pkg/tbtcpg`
  constants, so drift is caught regardless of which side changes. A
  literal-based guard could be defeated by updating `tbtcpg` and the literal
  together while forgetting the mirror; comparing the live values closes that
  gap.

## Supersedes

Replaces #4180, whose head lived on a fork branch that had drifted onto an old
`main` and become `CONFLICTING`. This PR is the same work rebased clean onto
current `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced minimum-fee enforcement across wallet, moving-funds, and redemption transactions, including a safety buffer and caps for maximum fees.
  - Deposit sweep proposals now emit warnings when the provided sweep fee is missing or below the recommended minimum.
  - Fee sizing now uses a consistent worst-case estimate to keep fee calculations aligned.
- **Bug Fixes**
  - Updated fee estimation to better prevent proposals that could otherwise be constructed with unsafe or capped-out fee values.
  - Improved validation behavior for edge cases such as invalid fee sizes or nil fee inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->