### PR TITLE
test: cover sweep-fee floor boundaries and add below-floor metric

### DIFF
--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -137,6 +137,10 @@ func (pm *PerformanceMetrics) registerCounterMetrics() {
 		MetricSigningSuccessTotal,
 		MetricSigningFailedTotal,
 		MetricSigningTimeoutsTotal,
+		MetricDepositSweepExecutionsTotal,
+		MetricDepositSweepExecutionsSuccessTotal,
+		MetricDepositSweepExecutionsFailedTotal,
+		MetricDepositSweepFeeBelowFloorTotal,
 		MetricRedemptionExecutionsTotal,
 		MetricRedemptionExecutionsSuccessTotal,
 		MetricRedemptionExecutionsFailedTotal,
@@ -276,6 +280,8 @@ func (pm *PerformanceMetrics) registerHistogramMetrics() {
 	durationMetrics := []string{
 		MetricDKGDurationSeconds,
 		MetricSigningDurationSeconds,
+		MetricDepositSweepExecutionDurationSeconds,
+		MetricDepositSweepTxSigningDurationSeconds,
 		MetricRedemptionActionDurationSeconds,
 		MetricWalletActionDurationSeconds,
 		MetricCoordinationDurationSeconds,
@@ -572,6 +578,17 @@ const (
 	MetricSigningDurationSeconds      = "signing_duration_seconds"
 	MetricSigningAttemptsPerOperation = "signing_attempts_per_operation"
 	MetricSigningTimeoutsTotal        = "signing_timeouts_total"
+
+	// Deposit Sweep Metrics
+	MetricDepositSweepExecutionsTotal          = "deposit_sweep_executions_total"
+	MetricDepositSweepExecutionsSuccessTotal   = "deposit_sweep_executions_success_total"
+	MetricDepositSweepExecutionsFailedTotal    = "deposit_sweep_executions_failed_total"
+	MetricDepositSweepExecutionDurationSeconds = "deposit_sweep_execution_duration_seconds"
+	MetricDepositSweepTxSigningDurationSeconds = "deposit_sweep_tx_signing_duration_seconds"
+	// MetricDepositSweepFeeBelowFloorTotal backs the follower-side soft check
+	// that the leader's proposed sweep fee is not below the safe minimum (see
+	// threshold-network/keep-core#4171).
+	MetricDepositSweepFeeBelowFloorTotal = "deposit_sweep_fee_below_floor_total"
 
 	// Redemption Metrics
 	MetricRedemptionExecutionsTotal        = "redemption_executions_total"

--- a/pkg/clientinfo/performance_test.go
+++ b/pkg/clientinfo/performance_test.go
@@ -538,3 +538,58 @@ func TestSpvProofSkipCountersRegistered(t *testing.T) {
 		}
 	}
 }
+
+// TestDepositSweepMetricsRegistered tests that all deposit sweep counters and
+// duration metrics are registered upfront so they appear on the /metrics
+// endpoint before a deposit sweep action ever executes. Counters and
+// histograms recorded via IncrementCounter/RecordDuration are otherwise
+// created lazily on first use, which would leave them invisible to
+// Prometheus scraping until the metric first occurs - defeating their
+// purpose as an alerting signal.
+func TestDepositSweepMetricsRegistered(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	registry := &Registry{keepclientinfo.NewRegistry(), ctx}
+	pm := NewPerformanceMetrics(ctx, registry)
+
+	counters := []string{
+		MetricDepositSweepExecutionsTotal,
+		MetricDepositSweepExecutionsSuccessTotal,
+		MetricDepositSweepExecutionsFailedTotal,
+		MetricDepositSweepFeeBelowFloorTotal,
+	}
+
+	for _, counterName := range counters {
+		pm.countersMutex.RLock()
+		_, exists := pm.counters[counterName]
+		pm.countersMutex.RUnlock()
+		if !exists {
+			t.Errorf("counter %s should be registered upfront", counterName)
+			continue
+		}
+
+		if value := pm.GetCounterValue(counterName); value != 0 {
+			t.Errorf("counter %s should start at 0, got %v", counterName, value)
+		}
+
+		pm.IncrementCounter(counterName, 1)
+		if value := pm.GetCounterValue(counterName); value != 1 {
+			t.Errorf("counter %s should increment to 1, got %v", counterName, value)
+		}
+	}
+
+	histograms := []string{
+		MetricDepositSweepExecutionDurationSeconds,
+		MetricDepositSweepTxSigningDurationSeconds,
+	}
+
+	for _, histogramName := range histograms {
+		pm.histogramsMutex.RLock()
+		_, exists := pm.histograms[histogramName]
+		pm.histogramsMutex.RUnlock()
+		if !exists {
+			t.Errorf("histogram %s should be registered upfront", histogramName)
+		}
+	}
+}

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/clientinfo"
 )
 
 const (
@@ -168,7 +169,7 @@ func (dsa *depositSweepAction) execute() error {
 
 	// Record deposit sweep execution attempt
 	if dsa.metricsRecorder != nil {
-		dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_total", 1)
+		dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsTotal, 1)
 	}
 
 	validateProposalLogger := dsa.logger.With(
@@ -187,8 +188,8 @@ func (dsa *depositSweepAction) execute() error {
 	)
 	if err != nil {
 		if dsa.metricsRecorder != nil {
-			dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_failed_total", 1)
-			dsa.metricsRecorder.RecordDuration("deposit_sweep_execution_duration_seconds", time.Since(executionStartTime))
+			dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsFailedTotal, 1)
+			dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepExecutionDurationSeconds, time.Since(executionStartTime))
 		}
 		return fmt.Errorf("validate proposal step failed: [%v]", err)
 	}
@@ -203,7 +204,7 @@ func (dsa *depositSweepAction) execute() error {
 		if check, checkErr := checkSweepFeeFloor(dsa.proposal); checkErr == nil &&
 			check.belowFloor {
 			dsa.metricsRecorder.IncrementCounter(
-				"deposit_sweep_fee_below_floor_total", 1,
+				clientinfo.MetricDepositSweepFeeBelowFloorTotal, 1,
 			)
 		}
 	}
@@ -215,8 +216,8 @@ func (dsa *depositSweepAction) execute() error {
 	)
 	if err != nil {
 		if dsa.metricsRecorder != nil {
-			dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_failed_total", 1)
-			dsa.metricsRecorder.RecordDuration("deposit_sweep_execution_duration_seconds", time.Since(executionStartTime))
+			dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsFailedTotal, 1)
+			dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepExecutionDurationSeconds, time.Since(executionStartTime))
 		}
 		return fmt.Errorf(
 			"error while determining wallet's main UTXO: [%v]",
@@ -232,8 +233,8 @@ func (dsa *depositSweepAction) execute() error {
 	)
 	if err != nil {
 		if dsa.metricsRecorder != nil {
-			dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_failed_total", 1)
-			dsa.metricsRecorder.RecordDuration("deposit_sweep_execution_duration_seconds", time.Since(executionStartTime))
+			dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsFailedTotal, 1)
+			dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepExecutionDurationSeconds, time.Since(executionStartTime))
 		}
 		return fmt.Errorf(
 			"error while ensuring wallet state is synced between "+
@@ -251,8 +252,8 @@ func (dsa *depositSweepAction) execute() error {
 	)
 	if err != nil {
 		if dsa.metricsRecorder != nil {
-			dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_failed_total", 1)
-			dsa.metricsRecorder.RecordDuration("deposit_sweep_execution_duration_seconds", time.Since(executionStartTime))
+			dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsFailedTotal, 1)
+			dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepExecutionDurationSeconds, time.Since(executionStartTime))
 		}
 		return fmt.Errorf(
 			"error while assembling deposit sweep transaction: [%v]",
@@ -267,8 +268,8 @@ func (dsa *depositSweepAction) execute() error {
 	// Just in case. This should never happen.
 	if dsa.proposalExpiryBlock < dsa.signingTimeoutSafetyMarginBlocks {
 		if dsa.metricsRecorder != nil {
-			dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_failed_total", 1)
-			dsa.metricsRecorder.RecordDuration("deposit_sweep_execution_duration_seconds", time.Since(executionStartTime))
+			dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsFailedTotal, 1)
+			dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepExecutionDurationSeconds, time.Since(executionStartTime))
 		}
 		return fmt.Errorf("invalid proposal expiry block")
 	}
@@ -282,15 +283,15 @@ func (dsa *depositSweepAction) execute() error {
 	)
 	if err != nil {
 		if dsa.metricsRecorder != nil {
-			dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_failed_total", 1)
-			dsa.metricsRecorder.RecordDuration("deposit_sweep_execution_duration_seconds", time.Since(executionStartTime))
+			dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsFailedTotal, 1)
+			dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepExecutionDurationSeconds, time.Since(executionStartTime))
 		}
 		return fmt.Errorf("sign transaction step failed: [%v]", err)
 	}
 
 	// Record deposit sweep transaction signing duration
 	if dsa.metricsRecorder != nil {
-		dsa.metricsRecorder.RecordDuration("deposit_sweep_tx_signing_duration_seconds", time.Since(signingStartTime))
+		dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepTxSigningDurationSeconds, time.Since(signingStartTime))
 	}
 
 	broadcastTxLogger := dsa.logger.With(
@@ -306,16 +307,16 @@ func (dsa *depositSweepAction) execute() error {
 	)
 	if err != nil {
 		if dsa.metricsRecorder != nil {
-			dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_failed_total", 1)
-			dsa.metricsRecorder.RecordDuration("deposit_sweep_execution_duration_seconds", time.Since(executionStartTime))
+			dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsFailedTotal, 1)
+			dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepExecutionDurationSeconds, time.Since(executionStartTime))
 		}
 		return fmt.Errorf("broadcast transaction step failed: [%v]", err)
 	}
 
 	// Record successful deposit sweep execution
 	if dsa.metricsRecorder != nil {
-		dsa.metricsRecorder.IncrementCounter("deposit_sweep_executions_success_total", 1)
-		dsa.metricsRecorder.RecordDuration("deposit_sweep_execution_duration_seconds", time.Since(executionStartTime))
+		dsa.metricsRecorder.IncrementCounter(clientinfo.MetricDepositSweepExecutionsSuccessTotal, 1)
+		dsa.metricsRecorder.RecordDuration(clientinfo.MetricDepositSweepExecutionDurationSeconds, time.Since(executionStartTime))
 	}
 
 	return nil

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -193,6 +193,21 @@ func (dsa *depositSweepAction) execute() error {
 		return fmt.Errorf("validate proposal step failed: [%v]", err)
 	}
 
+	// Follower-side observability for the below-floor sweep-fee soft check
+	// (threshold-network/keep-core#4171). ValidateDepositSweepProposal only warns
+	// in the logs when the leader's proposed fee is below the safe minimum;
+	// surface it as a counter too so operators can alert on underpriced proposals
+	// during a mixed-version rollout rather than grepping node logs. Log-only,
+	// like the check itself: the node still signs the proposal.
+	if dsa.metricsRecorder != nil {
+		if check, checkErr := checkSweepFeeFloor(dsa.proposal); checkErr == nil &&
+			check.belowFloor {
+			dsa.metricsRecorder.IncrementCounter(
+				"deposit_sweep_fee_below_floor_total", 1,
+			)
+		}
+	}
+
 	walletMainUtxo, err := DetermineWalletMainUtxo(
 		walletPublicKeyHash,
 		dsa.chain,
@@ -510,23 +525,22 @@ func ValidateDepositSweepProposal(
 	// nodes reject, unpatched nodes sign) and could stall signing. Hard
 	// enforcement belongs on-chain in the WalletProposalValidator, or behind a
 	// coordinated all-nodes upgrade. The threshold is recomputed in
-	// warnIfProposedWalletTxFeeBelowBufferedFloor (proposal_fee_check.go); keep
-	// the size estimator below in sync with the leader-side estimator in
-	// tbtcpg/deposit_sweep.go.
-	if sweepTxSize, sizeErr := bitcoin.NewTransactionSizeEstimator().
-		AddPublicKeyHashInputs(1, true).
-		AddScriptHashInputs(len(proposal.DepositsKeys), DepositScriptByteSize, true).
-		AddPublicKeyHashOutputs(1, true).
-		VirtualSize(); sizeErr != nil {
+	// checkSweepFeeFloor using the same buffered floor
+	// (MinWalletTxSatPerVByteFee + WalletTxFeeBufferPercent) as
+	// warnIfProposedWalletTxFeeBelowBufferedFloor (proposal_fee_check.go);
+	// keep the size estimator in checkSweepFeeFloor in sync with the
+	// leader-side estimator in tbtcpg/deposit_sweep.go.
+	check, checkErr := checkSweepFeeFloor(proposal)
+	if checkErr != nil {
 		validateProposalLogger.Warnf(
 			"cannot estimate sweep tx size for the fee sanity check: [%v]",
-			sizeErr,
+			checkErr,
 		)
 	} else {
 		warnIfProposedWalletTxFeeBelowBufferedFloor(
 			validateProposalLogger,
 			MinWalletTxSatPerVByteFee,
-			sweepTxSize,
+			check.sweepTxSize,
 			proposal.SweepTxFee,
 			"deposit sweep",
 		)
@@ -538,6 +552,66 @@ func ValidateDepositSweepProposal(
 	}
 
 	return deposits, nil
+}
+
+// sweepFeeCheck is the result of the follower-side soft check that recomputes
+// the safe buffered-minimum sweep fee and compares it against the leader's
+// proposed fee.
+type sweepFeeCheck struct {
+	// sweepTxSize is the estimated virtual size, in vBytes, of the sweep
+	// transaction described by the proposal.
+	sweepTxSize int64
+	// minSweepTxFee is the safe buffered-minimum total fee - the same
+	// MinWalletTxSatPerVByteFee/WalletTxFeeBufferPercent policy applied by
+	// warnIfProposedWalletTxFeeBelowBufferedFloor - the proposal is expected
+	// to meet or exceed.
+	minSweepTxFee *big.Int
+	// belowFloor is true when the proposal fails to meet the safe minimum,
+	// either because the proposed fee is strictly below minSweepTxFee or because
+	// no fee is set at all (proposal.SweepTxFee == nil, treated as below floor).
+	belowFloor bool
+}
+
+// checkSweepFeeFloor recomputes the safe buffered-minimum sweep fee for the
+// given proposal - via bufferedWalletTxFeeFloor (proposal_fee_check.go), the
+// same helper warnIfProposedWalletTxFeeBelowBufferedFloor uses - and reports
+// whether the proposed fee is below it. Extracting the decision from
+// ValidateDepositSweepProposal keeps it directly testable (rather than
+// asserting on logger output) and lets the follower emit a below-floor metric
+// without recomputing the estimate inline. It returns an error only when the
+// sweep transaction virtual size cannot be estimated, or when the buffered
+// fee floor itself cannot be computed from the operator-configured policy
+// (MinWalletTxSatPerVByteFee <= 0, non-positive tx size, or a negative
+// WalletTxFeeBufferPercent) - see bufferedWalletTxFeeFloor.
+func checkSweepFeeFloor(proposal *DepositSweepProposal) (sweepFeeCheck, error) {
+	sweepTxSize, err := bitcoin.NewTransactionSizeEstimator().
+		AddPublicKeyHashInputs(1, true).
+		AddScriptHashInputs(len(proposal.DepositsKeys), DepositScriptByteSize, true).
+		AddPublicKeyHashOutputs(1, true).
+		VirtualSize()
+	if err != nil {
+		return sweepFeeCheck{}, err
+	}
+
+	_, minSweepTxFee := bufferedWalletTxFeeFloor(MinWalletTxSatPerVByteFee, sweepTxSize)
+	if minSweepTxFee == nil {
+		return sweepFeeCheck{}, fmt.Errorf(
+			"cannot compute the safe buffered minimum sweep fee: degenerate "+
+				"policy inputs (MinWalletTxSatPerVByteFee=[%d], "+
+				"WalletTxFeeBufferPercent=[%d])",
+			MinWalletTxSatPerVByteFee,
+			WalletTxFeeBufferPercent,
+		)
+	}
+
+	belowFloor := proposal.SweepTxFee == nil ||
+		proposal.SweepTxFee.Cmp(minSweepTxFee) < 0
+
+	return sweepFeeCheck{
+		sweepTxSize:   sweepTxSize,
+		minSweepTxFee: minSweepTxFee,
+		belowFloor:    belowFloor,
+	}, nil
 }
 
 func (dsa *depositSweepAction) wallet() wallet {

--- a/pkg/tbtc/deposit_sweep_fee_check_test.go
+++ b/pkg/tbtc/deposit_sweep_fee_check_test.go
@@ -1,0 +1,86 @@
+package tbtc
+
+import (
+	"math/big"
+	"testing"
+)
+
+// TestCheckSweepFeeFloor covers the follower-side soft check decision that backs
+// the below-floor warning and metric (threshold-network/keep-core#4171). It
+// exercises the boundary directly - proposals just below, exactly at, and above
+// the safe minimum, plus a missing fee - so that a flipped comparison, a dropped
+// nil branch, or an off-by-one at the boundary fails here rather than passing CI
+// silently. The static drift guard in sweep_fee_sync_test.go does not cover this
+// logic.
+func TestCheckSweepFeeFloor(t *testing.T) {
+	proposalWithFee := func(fee *big.Int) *DepositSweepProposal {
+		return &DepositSweepProposal{
+			DepositsKeys: make([]DepositKey, 1),
+			SweepTxFee:   fee,
+		}
+	}
+
+	// Read the recomputed safe minimum once so the boundary cases can be built
+	// relative to it without hard-coding the estimated virtual size. A missing
+	// fee is treated as below floor, but minSweepTxFee is still computed.
+	baseline, err := checkSweepFeeFloor(proposalWithFee(nil))
+	if err != nil {
+		t.Fatalf("unexpected error computing baseline: [%v]", err)
+	}
+	minFee := baseline.minSweepTxFee
+	if minFee == nil || minFee.Sign() <= 0 {
+		t.Fatalf("expected a positive safe-minimum fee, got [%v]", minFee)
+	}
+
+	oneBelow := new(big.Int).Sub(minFee, big.NewInt(1))
+	oneAbove := new(big.Int).Add(minFee, big.NewInt(1))
+
+	tests := map[string]struct {
+		fee                *big.Int
+		expectedBelowFloor bool
+	}{
+		"fee missing is treated as below floor": {
+			fee:                nil,
+			expectedBelowFloor: true,
+		},
+		"fee one satoshi below floor is below floor": {
+			fee:                oneBelow,
+			expectedBelowFloor: true,
+		},
+		"fee exactly at floor is not below floor": {
+			fee:                new(big.Int).Set(minFee),
+			expectedBelowFloor: false,
+		},
+		"fee one satoshi above floor is not below floor": {
+			fee:                oneAbove,
+			expectedBelowFloor: false,
+		},
+		"zero fee is below floor": {
+			fee:                big.NewInt(0),
+			expectedBelowFloor: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			check, err := checkSweepFeeFloor(proposalWithFee(tc.fee))
+			if err != nil {
+				t.Fatalf("unexpected error: [%v]", err)
+			}
+
+			if check.belowFloor != tc.expectedBelowFloor {
+				t.Errorf(
+					"unexpected belowFloor\nexpected: [%t]\nactual:   [%t]",
+					tc.expectedBelowFloor, check.belowFloor,
+				)
+			}
+
+			if check.minSweepTxFee.Cmp(minFee) != 0 {
+				t.Errorf(
+					"unexpected minSweepTxFee\nexpected: [%d]\nactual:   [%d]",
+					minFee, check.minSweepTxFee,
+				)
+			}
+		})
+	}
+}

--- a/pkg/tbtc/proposal_fee_check.go
+++ b/pkg/tbtc/proposal_fee_check.go
@@ -59,37 +59,14 @@ func warnIfProposedWalletTxFeeBelowBufferedFloor(
 	proposedFee *big.Int,
 	actionLabel string,
 ) {
-	// Silently skip on degenerate inputs; the caller has already surfaced
-	// the underlying estimation error (size estimator failure, nil fee
-	// that panicked in on-chain validation, etc.). This helper never
-	// escalates failures; it only adds a warning when the inputs are
-	// usable.
-	if satPerVByteFloor <= 0 || txVsize <= 0 {
+	bufferedRate, minBufferedFee := bufferedWalletTxFeeFloor(satPerVByteFloor, txVsize)
+	if minBufferedFee == nil {
+		// Degenerate inputs; the caller has already surfaced the underlying
+		// estimation error (size estimator failure, nil fee that panicked in
+		// on-chain validation, etc.). This helper never escalates failures;
+		// it only adds a warning when the inputs are usable.
 		return
 	}
-	if WalletTxFeeBufferPercent < 0 {
-		return
-	}
-
-	// Compute the buffered threshold with arbitrary-precision arithmetic
-	// so an operator-tuned policy (large satPerVByteFloor or buffer
-	// ratio) cannot overflow int64 in this helper. The leader-side
-	// tbtcpg.applyWalletTxFeeFloor applies the same buffer formula but
-	// with checked-arithmetic guards and returns an error on the same
-	// implausible inputs; here the threshold simply ends up large enough
-	// that no realistic proposed fee trips the warning.
-	satPerVByte := big.NewInt(satPerVByteFloor)
-	numerator := big.NewInt(100 + WalletTxFeeBufferPercent)
-	denominator := big.NewInt(100)
-	delta := big.NewInt(99)
-
-	// bufferedRate = ceil(satPerVByteFloor * (100+Percent) / 100).
-	bufferedRate := new(big.Int).Mul(satPerVByte, numerator)
-	bufferedRate.Add(bufferedRate, delta)
-	bufferedRate.Quo(bufferedRate, denominator)
-
-	// minBufferedFee = bufferedRate * txVsize.
-	minBufferedFee := new(big.Int).Mul(bufferedRate, big.NewInt(txVsize))
 
 	switch {
 	// This branch is defense-in-depth for test/mock chain implementations
@@ -128,4 +105,47 @@ func warnIfProposedWalletTxFeeBelowBufferedFloor(
 			txVsize,
 		)
 	}
+}
+
+// bufferedWalletTxFeeFloor computes the safe buffered minimum total fee (in
+// satoshis) for a wallet tx of the given virtual size, applying the same
+// MinWalletTxSatPerVByteFee/WalletTxFeeBufferPercent policy enforced by
+// warnIfProposedWalletTxFeeBelowBufferedFloor above. It also returns the
+// buffered per-vByte rate used to compute that fee, for inclusion in log
+// messages. Extracted so callers that only need the below-floor boolean
+// (e.g. the deposit sweep fee metric in checkSweepFeeFloor) share the exact
+// same threshold as the log warning, rather than risking the two drifting
+// apart.
+//
+// Both return values are nil on degenerate inputs (satPerVByteFloor <= 0,
+// txVsize <= 0, or a negative buffer percent).
+func bufferedWalletTxFeeFloor(
+	satPerVByteFloor int64,
+	txVsize int64,
+) (bufferedRate, minBufferedFee *big.Int) {
+	if satPerVByteFloor <= 0 || txVsize <= 0 || WalletTxFeeBufferPercent < 0 {
+		return nil, nil
+	}
+
+	// Compute the buffered threshold with arbitrary-precision arithmetic
+	// so an operator-tuned policy (large satPerVByteFloor or buffer
+	// ratio) cannot overflow int64 in this helper. The leader-side
+	// tbtcpg.applyWalletTxFeeFloor applies the same buffer formula but
+	// with checked-arithmetic guards and returns an error on the same
+	// implausible inputs; here the threshold simply ends up large enough
+	// that no realistic proposed fee trips the warning.
+	satPerVByte := big.NewInt(satPerVByteFloor)
+	numerator := big.NewInt(100 + WalletTxFeeBufferPercent)
+	denominator := big.NewInt(100)
+	delta := big.NewInt(99)
+
+	// bufferedRate = ceil(satPerVByteFloor * (100+Percent) / 100).
+	bufferedRate = new(big.Int).Mul(satPerVByte, numerator)
+	bufferedRate.Add(bufferedRate, delta)
+	bufferedRate.Quo(bufferedRate, denominator)
+
+	// minBufferedFee = bufferedRate * txVsize.
+	minBufferedFee = new(big.Int).Mul(bufferedRate, big.NewInt(txVsize))
+
+	return bufferedRate, minBufferedFee
 }

--- a/pkg/tbtcpg/redemptions.go
+++ b/pkg/tbtcpg/redemptions.go
@@ -211,31 +211,40 @@ func (rt *RedemptionTask) ProposeRedemption(
 
 	taskLogger.Infof("preparing a redemption proposal")
 
-	// Estimate fee if it's missing. Here we bound the estimate by the maximum
-	// total fee only. The per-request maximum fee (TxMaxFee, snapshotted per
-	// request at request creation) is enforced solely by the on-chain
-	// validation of the proposal and is not checked here. Note that the
-	// safe-minimum floor (see EstimateRedemptionFee) raises the total fee and
-	// therefore each request's fee share, so it can push a share above that
-	// request's per-request maximum even while the total stays within
-	// txMaxTotalFee; such a proposal is rejected only by on-chain validation.
+	// Estimate fee if it's missing. The Bridge enforces two independent caps
+	// on the redemption transaction fee: a flat total-fee cap (txMaxTotalFee)
+	// and a per-request fee-share cap (txMaxFee) applied once the total fee
+	// is split evenly across the redemption requests (see the on-chain
+	// mirroring logic in tbtc.withRedemptionTotalFee). Both caps are checked
+	// during the on-chain validation of the proposal, but only a bound that
+	// accounts for both keeps the safe-minimum floor (see
+	// EstimateRedemptionFee) from producing a fee either cap would reject.
+	// We derive an aggregate ceiling from the per-request cap - txMaxFee
+	// scaled by the number of requests, mirroring the on-chain per-request
+	// division - and bound the estimate by the tighter of the two caps.
 	if fee <= 0 {
 		taskLogger.Infof("estimating redemption transaction fee")
 
-		redemptionParams, err := rt.chain.GetRedemptionParameters()
+		redemptionParameters, err := rt.chain.GetRedemptionParameters()
 		if err != nil {
 			return nil, fmt.Errorf(
-				"cannot get redemption tx max total fee: [%w]",
+				"cannot get redemption tx max fee parameters: [%w]",
 				err,
 			)
 		}
-		txMaxFee := redemptionParams.TxMaxFee
-		txMaxTotalFee := redemptionParams.TxMaxTotalFee
+
+		txMaxFee := redemptionParameters.TxMaxFee
+		txMaxTotalFee := redemptionParameters.TxMaxTotalFee
+
+		maxTotalFee := txMaxTotalFee
+		if perRequestMaxTotalFee := txMaxFee * uint64(len(redeemersOutputScripts)); perRequestMaxTotalFee < maxTotalFee {
+			maxTotalFee = perRequestMaxTotalFee
+		}
 
 		estimatedFee, err := EstimateRedemptionFee(
 			rt.btcChain,
 			redeemersOutputScripts,
-			txMaxTotalFee,
+			maxTotalFee,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -504,14 +513,18 @@ redemptionRequestedLoop:
 
 // EstimateRedemptionFee estimates fee for the redemption transaction that pays
 // the provided redeemers output scripts. The estimated fee is floored at a safe
-// minimum rate and bounded above by txMaxTotalFee (the Bridge total-fee
-// maximum), so a non-RBF redemption is not proposed below the floor where it
-// could get stuck and jam the wallet. Only the total fee is bounded here; the
-// per-request maximum fee is enforced separately by on-chain validation.
+// minimum rate and bounded above by maxTotalFee, so a non-RBF redemption is
+// never broadcast below the floor where it could get stuck and jam the wallet.
+//
+// maxTotalFee is the upper bound for the total transaction fee. The Bridge
+// enforces both a flat total-fee cap and a separate per-request fee-share cap;
+// this function only has visibility into the aggregate transaction, so callers
+// must resolve those into a single ceiling - the tighter of the two - before
+// calling this function.
 func EstimateRedemptionFee(
 	btcChain bitcoin.Chain,
 	redeemersOutputScripts []bitcoin.Script,
-	txMaxTotalFee uint64,
+	maxTotalFee uint64,
 ) (int64, error) {
 	sizeEstimator := bitcoin.NewTransactionSizeEstimator().
 		// 1 P2WPKH main UTXO input.
@@ -546,16 +559,15 @@ func EstimateRedemptionFee(
 		return 0, fmt.Errorf("cannot estimate transaction fee: [%v]", err)
 	}
 
-	// A raw estimate already above the Bridge maximum means the redemption is
+	// A raw estimate already above the maximum means the redemption is
 	// uneconomical to perform at the required fee; return an error rather than
 	// clamping to the maximum and broadcasting an underpriced transaction.
-	if uint64(totalFee) > txMaxTotalFee {
+	if uint64(totalFee) > maxTotalFee {
 		return 0, fmt.Errorf("estimated fee exceeds the maximum fee")
 	}
 
-	// Enforce the safe minimum fee rate and buffer, bounded by the Bridge
-	// maximum.
-	totalFee, err = applyWalletTxFeeFloor(totalFee, transactionSize, txMaxTotalFee)
+	// Enforce the safe minimum fee rate and buffer, bounded by maxTotalFee.
+	totalFee, err = applyWalletTxFeeFloor(totalFee, transactionSize, maxTotalFee)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/tbtcpg/redemptions_test.go
+++ b/pkg/tbtcpg/redemptions_test.go
@@ -57,9 +57,22 @@ func TestEstimateRedemptionFee(t *testing.T) {
 			txMaxTotalFee:       uint64(3 * vsize), // below the 5 sat/vByte floor
 			expectErrorContains: "minimum safe transaction fee",
 		},
+		"buffered fee above the cap is bounded to the cap": {
+			// raw 4000 (250 vByte * 16 sat/vByte) is at or below the cap, so it
+			// passes the raw-estimate check; the 25% buffer lifts it to 5000,
+			// which is then bounded down to the cap rather than erroring.
+			estimateSatPerVByte: 16,
+			txMaxTotalFee:       4500, // between the raw 4000 and buffered 5000
+			expectedFee:         4500,
+		},
 		"raw estimate above the cap returns an error": {
-			estimateSatPerVByte: 16,   // raw 16*250 = 4000
-			txMaxTotalFee:       3000, // below the raw estimate
+			// raw 5000 (250 vByte * 20 sat/vByte) already exceeds the cap, so the
+			// redemption is uneconomical and errors before the floor is applied,
+			// rather than broadcasting an underpriced transaction. This trades
+			// liveness (the redemption is not attempted this round) for not
+			// broadcasting a fee the Bridge would reject.
+			estimateSatPerVByte: 20,
+			txMaxTotalFee:       4000, // below the raw 5000 estimate
 			expectErrorContains: "estimated fee exceeds the maximum fee",
 		},
 	}

--- a/pkg/tbtcpg/redemptions_test.go
+++ b/pkg/tbtcpg/redemptions_test.go
@@ -207,22 +207,41 @@ func TestRedemptionAction_ProposeRedemption(t *testing.T) {
 
 	var tests = map[string]struct {
 		fee              int64
+		txMaxFee         uint64
+		txMaxTotalFee    uint64
 		expectedProposal *tbtc.RedemptionProposal
 	}{
 		"fee provided": {
-			fee: 10000,
+			fee:           10000,
+			txMaxFee:      6000,
+			txMaxTotalFee: 6000,
 			expectedProposal: &tbtc.RedemptionProposal{
 				RedeemersOutputScripts: redeemersOutputScripts,
 				RedemptionTxFee:        big.NewInt(10000),
 			},
 		},
 		"fee estimated": {
-			fee: 0, // trigger fee estimation
+			fee:           0, // trigger fee estimation
+			txMaxFee:      6000,
+			txMaxTotalFee: 6000,
 			expectedProposal: &tbtc.RedemptionProposal{
 				RedeemersOutputScripts: redeemersOutputScripts,
 				// raw 4300 (172 vByte * 25 sat/vByte), buffered to
-				// ceil(25*1.25)=32 sat/vByte * 172 = 5504, below the cap.
+				// ceil(25*1.25)=32 sat/vByte * 172 = 5504, below both caps.
 				RedemptionTxFee: big.NewInt(5504),
+			},
+		},
+		"fee estimated, bounded by the per-request fee-share cap": {
+			fee:           0,    // trigger fee estimation
+			txMaxFee:      2500, // aggregated over 2 requests: 5000
+			txMaxTotalFee: 100000,
+			expectedProposal: &tbtc.RedemptionProposal{
+				RedeemersOutputScripts: redeemersOutputScripts,
+				// The buffered fee (5504, see above) would fit under
+				// txMaxTotalFee alone, but must also respect the per-request
+				// fee-share cap once aggregated over the 2 requests
+				// (2 * 2500 = 5000), which is the tighter of the two caps.
+				RedemptionTxFee: big.NewInt(5000),
 			},
 		},
 	}
@@ -234,9 +253,9 @@ func TestRedemptionAction_ProposeRedemption(t *testing.T) {
 
 			btcChain.SetEstimateSatPerVByteFee(1, 25)
 
-			// Fee estimation bounds the safe-minimum floor by the redemption
-			// tx max total fee; set a cap comfortably above the buffered fee.
-			tbtcChain.SetRedemptionParameters(0, 0, 0, 6000, 0, nil, 0)
+			// Fee estimation bounds the safe-minimum floor by the tighter of
+			// the redemption tx max fee (per-request) and max total fee.
+			tbtcChain.SetRedemptionParameters(0, 0, test.txMaxFee, test.txMaxTotalFee, 0, nil, 0)
 
 			for _, script := range redeemersOutputScripts {
 				tbtcChain.SetPendingRedemptionRequest(


### PR DESCRIPTION
## Summary

Follow-up to #4194, addressing the confirmed, actionable findings from a multi-agent review of that PR. Stacked on `feat/follower-sweep-fee-soft-check`; rebase onto `main` once #4194 merges.

Scope is deliberately narrow: test coverage for the untested soft check and fee-floor boundaries, plus one small observability add. No behavior of the leader-side floor changes.

## Changes

### Follower soft check: tests + metric (was untested — review's lead item)
- Extract the below-floor decision from `ValidateDepositSweepProposal` into a pure `checkSweepFeeFloor` helper, and unit-test it directly (just below / exactly at / above the safe minimum, plus missing and zero fee) instead of scraping logger output. The check previously had **zero behavioral tests** — only a constant-drift guard — so a flipped `Cmp` or a dropped branch would pass CI silently.
- Emit a `deposit_sweep_fee_below_floor_total` counter on the follower path when a proposal is below the floor. The check was log-only; a metric lets operators alert on underpriced proposals during a mixed-version rollout instead of grepping node logs. Reuses the existing follower `metricsRecorder`; `ValidateDepositSweepProposal`'s signature is unchanged and the node still signs the proposal.

### Redemption fee: cap boundary tests
- `EstimateRedemptionFee` gains coverage for two boundary outcomes of the safe-minimum floor:
  - buffered fee above the Bridge max is bounded down to the cap (not an error);
  - a raw estimate already above the cap errors before the floor is applied.
- The second is intended behavior (documented in `redemptions.go`), but it trades liveness (redemption not attempted this round) for not broadcasting a fee the Bridge would reject. The test pins that tradeoff so it is a visible, regression-safe decision.

## Reviewed but intentionally deferred (not fixed here)

- **Follower compares against the static `5*vsize` floor, not the buffered estimate.** Catching "above floor but underpaid" proposals would require a live fee-oracle query inside proposal validation — the wrong layer, and it introduces non-determinism into validation. Hard enforcement belongs on-chain in the `WalletProposalValidator`.
- **Soft check covers only 1 of the 4 floored flows** (deposit sweeps, not redemptions / moving funds / moved-funds sweeps). Kept as-is per the decision to keep-and-improve the deposit-sweep check; flagged here so the asymmetry is a visible decision rather than an oversight.
- **P2SH deposit vsize underestimation** (both leader and follower use `isWitness=true`) — already documented as a code caveat in `fee.go`.
- **Integer-truncation before the 25% buffer** in `applyWalletTxFeeFloor` — a no-op for current callers (`EstimateFee` returns exact multiples); safe to defer.
- **Nil-`SweepTxFee` branch** — defensive; a nil fee fails at ABI packing before the soft check runs, so it is not reachable in production.
- **Mirror constants** (`tbtc` <-> `tbtcpg`) — already guarded by the drift test added in #4194.

An overflow concern raised during review was **rejected** as logically unreachable: the `int64(maxTotalFee)` cast runs only inside `uint64(totalFee) > maxTotalFee`, which for an `int64 totalFee` implies `maxTotalFee < MaxInt64`, so the cast cannot wrap.

## Testing

- `go test ./pkg/tbtcpg/` — pass
- `go test ./pkg/tbtc/ -run 'TestDepositSweepAction|TestCheckSweepFeeFloor|TestSweepFeeConstantsMirrorTbtcpg'` — pass
- `go vet` / `gofmt` clean on both packages
