### PR TITLE
build(solidity): raise TypeScript to 5.9.3 in both packages

### DIFF
--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -68,7 +68,7 @@
     "solidity-docgen": "^0.6.0-beta.35",
     "ts-node": "^10.4.0",
     "typechain": "^6.1.0",
-    "typescript": "^4.5.4"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "@keep-network/random-beacon": "development",

--- a/solidity/ecdsa/tsconfig.json
+++ b/solidity/ecdsa/tsconfig.json
@@ -2,6 +2,7 @@
   "files": ["./hardhat.config.ts"],
   "include": ["./deploy", "./tasks", "./test", "./typechain", "./types"],
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   }
 }

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -1297,7 +1297,7 @@ __metadata:
     solidity-docgen: "npm:^0.6.0-beta.35"
     ts-node: "npm:^10.4.0"
     typechain: "npm:^6.1.0"
-    typescript: "npm:^4.5.4"
+    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -11136,23 +11136,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.5.4":
-  version: 4.5.5
-  resolution: "typescript@npm:4.5.5"
+"typescript@npm:^5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ac15b92f3dcd9a4233cab288a913ccbd96729fc488181396fa93c0297ccef3cd3c2f9a7a63340efb0d07bff3d5026028fc81b9c1ef08076029e057081eb5884b
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4.5.4#optional!builtin<compat/typescript>":
-  version: 4.5.5
-  resolution: "typescript@patch:typescript@npm%3A4.5.5#optional!builtin<compat/typescript>::version=4.5.5&hash=f1b8ea"
+"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/c699912602518eca36f101f61492608733da8305ba93a82291fbb29508da56e360b10f35f56fd9a53406db9ea2c261d30efd4ec1d9253ff45fdb5541b9d0381c
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -70,7 +70,7 @@
     "solidity-docgen": "^0.6.0-beta.35",
     "ts-node": "^10.2.1",
     "typechain": "^7.0.0",
-    "typescript": "^4.4.3"
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/solidity/random-beacon/tsconfig.json
+++ b/solidity/random-beacon/tsconfig.json
@@ -12,6 +12,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "skipLibCheck": true
   }
 }

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -1206,7 +1206,7 @@ __metadata:
     solidity-docgen: "npm:^0.6.0-beta.35"
     ts-node: "npm:^10.2.1"
     typechain: "npm:^7.0.0"
-    typescript: "npm:^4.4.3"
+    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -13549,23 +13549,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.4.3":
-  version: 4.4.3
-  resolution: "typescript@npm:4.4.3"
+"typescript@npm:^5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/91ad8993cb9292d8117b537b894501995d1d8b9473b93bdd406749b0b9d59406b97c5d79364dfdac2033e266a67aea318d9b17b1560479e628c60bbec3dcd358
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4.4.3#optional!builtin<compat/typescript>":
-  version: 4.4.3
-  resolution: "typescript@patch:typescript@npm%3A4.4.3#optional!builtin<compat/typescript>::version=4.4.3&hash=bbeadb"
+"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/9051000445e39cc44d90f2e7e1e57d4f8d8b802103b80d66971d89182696047314cc1b11eb6f59ec3244e6cbaebc3b4bb31e72944d3d3f67c7be416d6d300702
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Stacked on #4204.** Raises TypeScript in both solidity packages to **5.9.3**,
and adds `skipLibCheck`.

`ecdsa` was on `^4.5.4` and `random-beacon` on `^4.4.3` — 4.5.5 and 4.4.3
resolved, both from 2022. Neither had `skipLibCheck`, so both were type-checking
their dependencies' declarations as well as their own.

## Measured

| | before | after |
| --- | --- | --- |
| `ecdsa` | TS 4.5.5 — 1 error | TS 5.9.3 — **1 error** |
| `random-beacon` | TS 4.4.3 — 33 errors | TS 5.9.3 — **21 errors** |

**No new errors in either.** `random-beacon` drops twelve: the newer compiler
resolves inference the old one gave up on, and `skipLibCheck` takes three
library declarations out of scope (21 of the 24 without it are ours). The 21
that remain are pre-existing and untouched here.

Suites unchanged:

| | |
| --- | --- |
| `random-beacon` | **955 passing / 0 pending / 0 failing** |
| `ecdsa` | **673 passing / 44 pending / 0 failing** |

## Why now

Same reason as threshold-network/tbtc-v2#1068 — it is a prerequisite for
replacing waffle, whichever replacement is chosen:

- viem, `abitype` and `ox` declare `typescript >= 5.0.4` and their declarations
  do not parse on 4.x at all
- ethers v6 with typechain v8 needs it too: typechain types a contract method as
  `TypedContractMethod`, and a 4.x compiler cannot resolve a conditional type
  against it

## Why 5.9 and not 6 or 7

**Not 7.** It is the native Go port, and yarn 4.12.0 cannot install it here at
all — yarn applies a builtin compat patch expecting `lib/_tsc.js`, which the Go
port does not ship, so the install aborts in the fetch step. (Yarn 4.17.1
installs it fine, so that is a yarn bump rather than a TypeScript wait.)

**Not 6 yet, but that is the one to watch.** 6.0.3 is stable and is what
Hardhat 3 develops against (`hardhat@3.11.1` dev-depends on `typescript:
~6.0.3`), so TypeScript 6 is the version to pair with a Hardhat 3 move — not
something to take early and not 7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript tooling for improved compatibility across Solidity projects.
  * Streamlined type-checking by skipping validation of external library declaration files.
  * Preserved existing iteration support settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->