### PR TITLE
build(solidity): raise TypeScript to 6.0.3 in both packages

### DIFF
--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -69,7 +69,7 @@
     "solidity-docgen": "^0.6.0-beta.35",
     "ts-node": "^10.4.0",
     "typechain": "^6.1.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@keep-network/random-beacon": "development",

--- a/solidity/ecdsa/tsconfig.json
+++ b/solidity/ecdsa/tsconfig.json
@@ -2,6 +2,22 @@
   "files": ["./hardhat.config.ts"],
   "include": ["./deploy", "./tasks", "./test", "./typechain", "./types"],
   "compilerOptions": {
+    // TypeScript 6 turns `strict` on by default. Pinned off so the bump stays
+    // behaviour-preserving; this package has not been through strict yet.
+    "strict": false,
+    // TypeScript 6 stopped including every `node_modules/@types` package
+    // automatically, which silently drops the mocha and chai globals. These
+    // are the four that contribute globals here.
+    "types": ["mocha", "chai", "chai-as-promised", "node"],
+    // Required by TypeScript 6 once a project spans several top-level
+    // directories. `--noEmit` does not need it, but ts-node's emit path does,
+    // so hardhat will not start without it.
+    "rootDir": ".",
+    // `target: es5` is deprecated in 6 and removed in 7. tsconfig.export.json
+    // builds the published `export/` bundle at that target, and `prepare` runs
+    // it on install, so silencing it here keeps both working. Raising the
+    // export target is required before TypeScript 7 and is its own change.
+    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "skipLibCheck": true
   }

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -1297,7 +1297,7 @@ __metadata:
     solidity-docgen: "npm:^0.6.0-beta.35"
     ts-node: "npm:^10.4.0"
     typechain: "npm:^6.1.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -11136,23 +11136,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -71,7 +71,7 @@
     "solidity-docgen": "^0.6.0-beta.35",
     "ts-node": "^10.2.1",
     "typechain": "^8.3.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/solidity/random-beacon/tsconfig.json
+++ b/solidity/random-beacon/tsconfig.json
@@ -10,6 +10,26 @@
     "./tasks"
   ],
   "compilerOptions": {
+    // TypeScript 6 turns `strict` on by default. Pinned off so the bump stays
+    // behaviour-preserving. `noImplicitAny` below is the one strict flag this
+    // package had already opted into, and it is kept.
+    "strict": false,
+    // TypeScript 6 stopped including every `node_modules/@types` package
+    // automatically, which silently drops the mocha and chai globals. These
+    // are the three that contribute globals here.
+    "types": ["mocha", "chai", "node"],
+    // Required by TypeScript 6 once a project spans several top-level
+    // directories. `--noEmit` does not need it, but ts-node's emit path does,
+    // so hardhat will not start without it.
+    "rootDir": ".",
+    // Two deprecations are silenced here, both belonging to the published
+    // `export/` bundle that `prepack` builds through tsconfig.export.json:
+    // `target: es5` itself, and `downlevelIteration`, which still changes
+    // emit at that target. Both are removed in TypeScript 7, so the export
+    // target has to be raised before then; doing it is its own change, and
+    // guessing that the option is inert would alter an artifact downstream
+    // packages consume.
+    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "noImplicitAny": true,
     "downlevelIteration": true,

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -1206,7 +1206,7 @@ __metadata:
     solidity-docgen: "npm:^0.6.0-beta.35"
     ts-node: "npm:^10.2.1"
     typechain: "npm:^8.3.2"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -13560,23 +13560,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Stacked on #4207.

**6.0.3 is the last TypeScript release with a JavaScript API.** I checked what 7.x actually ships:

```
node_modules/typescript/lib/  →  getExePath.js  tsc.js  version.cjs
require("typescript").transpileModule       → undefined
require("typescript").createProgram         → undefined
require("typescript").createLanguageService → undefined
```

There is no `lib/typescript.js` — the 7.x package is a launcher for the Go binary. ts-node (which hardhat 2 uses to run `hardhat.config.ts` and the tests), `@typescript-eslint`, typechain and prettier's TS parser all drive that API, so installing 7 today would break the build, the linter and codegen at once. 6.x is where this stops until those ship tsgo support.

## Three defaults changed, all pinned back

This is a version bump, not a tightening, so each new default is pinned to what the packages already do:

| Default | Effect if left alone | Pinned to |
| --- | --- | --- |
| `strict` now on | strict debt in both packages | `"strict": false` (random-beacon keeps its existing `noImplicitAny`) |
| `@types/*` no longer auto-included | mocha/chai globals vanish — **1 732 diagnostics in ecdsa alone** | `"types": [...]` naming the packages that contribute globals |
| `rootDir` required for multi-directory projects | hardhat refuses to start | `"rootDir": "."` |

The `rootDir` one is the reason to run more than the type checker: `tsc --noEmit` stays perfectly green while `hardhat test` dies with `TS5011`.

Turning `strict` on is real work and belongs in its own PR.

## The ES5 export bundle is on borrowed time

Both packages publish an `export/` bundle built through `tsconfig.export.json` at **`target: es5`**. In TypeScript 6, *both* that target (`TS5107`) and `downlevelIteration` (`TS5101`) are deprecated, and **both are removed in TypeScript 7**.

They are silenced here with `"ignoreDeprecations": "6.0"` rather than removed, because at `target: es5` `downlevelIteration` genuinely changes emit for `for…of` over non-array iterables, and that bundle is consumed by downstream packages. In `ecdsa` this also matters for `prepare`, which runs the same build on install — so getting it wrong breaks `yarn install`, not just publishing.

**Raising the export target off ES5 is a prerequisite for TypeScript 7** and is tracked separately.

## Verification

Both packages, on 6.0.3:

| | random-beacon | ecdsa |
| --- | --- | --- |
| `tsc --noEmit` | 0 errors | 0 errors |
| `tsc -p tsconfig.export.json` | builds | builds |
| `yarn lint` | 0 errors | 0 errors |
| `yarn test` | **955 passing / 0 failing** | **673 passing / 0 failing** |

Lockfile churn is 18 lines per package, all `typescript`.