### PR TITLE
docs: update keep-core repository links

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -9,10 +9,10 @@ propose changes to this document in a pull request.
 
 == Getting started
 
-1. Fork https://github.com/keep-network/keep-core[`keep-network/keep-core`]
+1. Fork https://github.com/threshold-network/keep-core[`threshold-network/keep-core`]
 2. Clone your fork
 3. Follow the
-   https://github.com/keep-network/keep-core/tree/main/docs/development[installation
+   https://github.com/threshold-network/keep-core/tree/main/docs/development[installation
    & build steps] in the developer documentation.
 4. Set up the <<Development Tooling>>.
 5. Open a PR against the `main` branch and describe the change you
@@ -23,7 +23,7 @@ Before marking the PR as ready for review, make sure:
 * It passes the linter checks (run `npm run lint` from `solidity/ecdsa` or
   `solidity/random-beacon` as appropriate; see <<Pre-commit>> to make this
   automatic).
-* It passes the https://github.com/keep-network/keep-core/actions[continuous
+* It passes the https://github.com/threshold-network/keep-core/actions[continuous
   integration tests].
 * Your changes have sufficient test coverage (e.g regression tests have
   been added for bug fixes, unit tests for new features)
@@ -36,7 +36,7 @@ be signed].
 
 === Continuous Integration
 
-Keep uses https://github.com/keep-network/keep-core/actions[Github Actions] for
+Keep uses https://github.com/threshold-network/keep-core/actions[Github Actions] for
 continuous integration. All jobs must be green to merge a PR.
 
 === Pre-commit

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
 = keep-core
 
-https://github.com/keep-network/keep-core/actions/workflows/contracts-ecdsa.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/contracts-ecdsa.yml?branch=main&event=push&label=ECDSA%20contracts%20build[ECDSA contracts build status]]
-https://github.com/keep-network/keep-core/actions/workflows/contracts-random-beacon.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/contracts-random-beacon.yml?branch=main&event=push&label=Random%20Beacon%20contracts%20build[Random Beacon contracts build status]]
-https://github.com/keep-network/keep-core/actions/workflows/client.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/client.yml?branch=main&event=push&label=Client build[Go client build status]]
+https://github.com/threshold-network/keep-core/actions/workflows/contracts-ecdsa.yml[image:https://img.shields.io/github/actions/workflow/status/threshold-network/keep-core/contracts-ecdsa.yml?branch=main&event=push&label=ECDSA%20contracts%20build[ECDSA contracts build status]]
+https://github.com/threshold-network/keep-core/actions/workflows/contracts-random-beacon.yml[image:https://img.shields.io/github/actions/workflow/status/threshold-network/keep-core/contracts-random-beacon.yml?branch=main&event=push&label=Random%20Beacon%20contracts%20build[Random Beacon contracts build status]]
+https://github.com/threshold-network/keep-core/actions/workflows/client.yml[image:https://img.shields.io/github/actions/workflow/status/threshold-network/keep-core/client.yml?branch=main&event=push&label=Client build[Go client build status]]
 https://docs.threshold.network[image:https://img.shields.io/badge/docs-website-green.svg[Docs]]
 https://discord.gg/threshold[image:https://img.shields.io/badge/chat-Discord-5865f2.svg[Chat with us on Discord]]
 
@@ -41,7 +41,7 @@ A good place to start is link:docs/[the docs directory].
 To run your own node in the Keep Network, follow the
 link:docs/run-keep-node.adoc[Run Keep Node] doc. Feedback
 on this process and the documentation
-https://github.com/keep-network/keep-core/issues[is appreciated!]
+https://github.com/threshold-network/keep-core/issues[is appreciated!]
 
 === Moving to a new random beacon
 

--- a/docs/dev-ops.adoc
+++ b/docs/dev-ops.adoc
@@ -16,4 +16,4 @@ we use the following pattern for each of our environments:
 - A LoadBalancer Service for each client.
 - A StatefulSet for each client.
 
-You can see our Testnet Kubernetes configurations link:https://github.com/keep-network/keep-core/tree/main/infrastructure/kube/keep-test[here].
+You can see our Testnet Kubernetes configurations link:https://github.com/threshold-network/keep-core/tree/main/infrastructure/kube/keep-test[here].

--- a/docs/rfc/rfc-19-random-beacon-v2.adoc
+++ b/docs/rfc/rfc-19-random-beacon-v2.adoc
@@ -13,7 +13,7 @@
 
 The last release of the random beacon got its genesis Sep 16th 2020 and worked
 until November 11th when it was stopped with a panic button as a result of an
-unannounced https://github.com/keep-network/keep-core/blob/main/docs/status-reports/2020-11-11-retro-geth-hardfork.adoc[Ethereum
+unannounced https://github.com/threshold-network/keep-core-v1/blob/main/docs/status-reports/2020-11-11-retro-geth-hardfork.adoc[Ethereum
 hard fork].
 
 For the time it was working, the beacon produced more than 1700 relay entries

--- a/pkg/bitcoin/electrum/electrum_integration_test.go
+++ b/pkg/bitcoin/electrum/electrum_integration_test.go
@@ -275,7 +275,7 @@ func TestGetTransactionConfirmations_Negative_Integration(t *testing.T) {
 
 // TODO: We should uncomment this test once https://github.com/checksum0/go-electrum/issues/10
 // is fixed. This test was added to validate the fix of the following issue
-// https://github.com/keep-network/keep-core/issues/3699 but at the same time
+// https://github.com/threshold-network/keep-core/issues/3699 but at the same time
 // made `panic: assignment to entry in nil map` happen very frequently which is
 // disturbing during the development and running the existing integration tests.
 

--- a/pkg/chain/ethereum/tbtc/gen/Makefile
+++ b/pkg/chain/ethereum/tbtc/gen/Makefile
@@ -17,7 +17,7 @@ required_contracts := Bridge MaintainerProxy LightRelay LightRelayMaintainerProx
 # differently on GNU and BSD.
 #
 # TODO: Remove once go-ethereum is upgraded to v1.11. See issue:
-#       https://github.com/keep-network/keep-core/issues/3524
+#       https://github.com/threshold-network/keep-core/issues/3524
 define after_abi_hook
 	$(eval type := $(1))
 	$(if $(filter $(type),WalletProposalValidator),$(call fix_wallet_proposal_validator_collision))

--- a/pkg/net/libp2p/channel.go
+++ b/pkg/net/libp2p/channel.go
@@ -151,7 +151,7 @@ func (c *channel) Send(
 // could explore using a channel. We would avoid unnecessary hop and the
 // broadcast channel could be dropping messages if the receiving channel is full.
 //
-// See https://github.com/keep-network/keep-core/issues/3420
+// See https://github.com/threshold-network/keep-core/issues/3420
 func (c *channel) Recv(ctx context.Context, handler func(m net.Message)) {
 	messageHandler := &messageHandler{
 		ctx:     ctx,
@@ -200,7 +200,7 @@ func (c *channel) Recv(ctx context.Context, handler func(m net.Message)) {
 				// will be blocked forever. We should consider using a channel
 				// instead of a callback receiver.
 				//
-				// See https://github.com/keep-network/keep-core/issues/3420
+				// See https://github.com/threshold-network/keep-core/issues/3420
 				handleWithRetransmissions(msg)
 			}
 		}

--- a/pkg/tbtc/dkg.go
+++ b/pkg/tbtc/dkg.go
@@ -319,7 +319,7 @@ func (de *dkgExecutor) generateSigningGroup(
 
 			// TODO: This subscription has to be updated once we implement
 			//       re-submitting DKG result to the chain after a challenge.
-			//       See https://github.com/keep-network/keep-core/issues/3450
+			//       See https://github.com/threshold-network/keep-core/issues/3450
 			subscription := de.chain.OnDKGResultSubmitted(
 				func(event *DKGResultSubmittedEvent) {
 					defer cancelCtx()

--- a/solidity/ecdsa/README.adoc
+++ b/solidity/ecdsa/README.adoc
@@ -3,7 +3,7 @@
 
 = Keep ECDSA v2
 
-https://github.com/keep-network/keep-core/actions/workflows/contracts-ecdsa.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/contracts-ecdsa.yml?branch=main&event=push&label=ECDSA%20contracts%20build[ECDSA contracts build status]]
+https://github.com/threshold-network/keep-core/actions/workflows/contracts-ecdsa.yml[image:https://img.shields.io/github/actions/workflow/status/threshold-network/keep-core/contracts-ecdsa.yml?branch=main&event=push&label=ECDSA%20contracts%20build[ECDSA contracts build status]]
 
 The Keep Network offers threshold ECDSA protocol to generate ECDSA wallets
 without any single signer having access to the corresponding private key. This

--- a/solidity/ecdsa/test/WalletRegistry.Slashing.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Slashing.test.ts
@@ -192,7 +192,7 @@ describe("WalletRegistry - Slashing", () => {
       // TODO: Add a unit test ensuring `seize` call reverts if the staking
       // contract `seize` call reverts.
       // Currently blocked by https://github.com/defi-wonderland/smock/issues/101
-      // See https://github.com/keep-network/keep-core/issues/2870
+      // See https://github.com/threshold-network/keep-core/issues/2870
     })
   })
 })

--- a/solidity/random-beacon/README.adoc
+++ b/solidity/random-beacon/README.adoc
@@ -3,7 +3,7 @@
 
 = Keep Random Beacon v2
 
-https://github.com/keep-network/keep-core/actions/workflows/contracts-random-beacon.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/keep-core/contracts-random-beacon.yml?branch=main&event=push&label=Random%20Beacon%20contracts%20build[Random Beacon contracts build status]]
+https://github.com/threshold-network/keep-core/actions/workflows/contracts-random-beacon.yml[image:https://img.shields.io/github/actions/workflow/status/threshold-network/keep-core/contracts-random-beacon.yml?branch=main&event=push&label=Random%20Beacon%20contracts%20build[Random Beacon contracts build status]]
 
 The Keep Network requires a trusted source of randomness for the process of
 trustless group selection. While the network requires that randomness to function


### PR DESCRIPTION
## Summary

- update human-facing keep-core repository, Actions, issue, and badge URLs to the threshold-network organization
- fix the historical random-beacon status-report link to its live keep-core-v1 location
- leave canonical Go module/import, linker, Docker, and workflow package coordinates unchanged
- leave Solidity source provenance and generated deployment metadata unchanged so compiler metadata and artifact hashes are unaffected

## Verification

- go test ./... -run ^$
- git diff --check
- verified all 17 replacement destinations with curl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository links, CI badges, issue references, and contribution guidance to use the current project locations.
  * Refreshed links across development operations, RFC, ECDSA, and Random Beacon documentation.
* **Chores**
  * Updated references in code comments and test TODOs without changing runtime behavior or test logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->