### PR TITLE
fix(tbtc): anchor the emergency rekey, and correct what the certified floor bounds

### DIFF
--- a/docs/development/frost-anchor-rotation.adoc
+++ b/docs/development/frost-anchor-rotation.adoc
@@ -47,8 +47,8 @@ unconsumed window at once - so no seat count a wallet can award is
 excluded from signing. What is still finite is the number of inputs a
 node can actually sign between two rotations: a fault-free 21-input
 sweep consumes roughly `21 * (3 * localSeats + 2)` revisions and one to
-two generations per call, so a 4-seat node gets *six to thirteen
-full-size sweeps per anchor epoch* and a 20-seat node one to two. The
+two generations per call, so a 4-seat node gets *13-26 sweeps
+per anchor epoch* and a 20-seat node 2-7 sweeps. The
 derivation is in <<when-rotation-is-required>>.
 
 == What the anchor is, in operator terms
@@ -276,10 +276,10 @@ charged against that bound rather than against real consumption:
 |===
 | Local seats | Calls per 21-input sweep | Revisions consumed | Generations consumed
 
-| 1 | 105 | 105 | 105-210
-| 2 | 168 | 168 | 168-336
-| 3 | 231 | 231 | 231-462
-| 4 | 294 | 294 | 294-588
+| 1 | 105 | 105 | 84-105
+| 2 | 168 | 168 | 105-168
+| 3 | 231 | 231 | 126-231
+| 4 | 294 | 294 | 147-294
 |===
 
 === Cadence
@@ -304,9 +304,9 @@ full-size sweeps one at a time:
 | 2  | 105-168   | 22-36 |
 | 3  | 126-231   | 16-30 |
 | 4  | 147-294   | 13-26 |
-| 5  | 168-357   | 10-22 | the expected holder under equal weighting
-| 20 | 483-1302  | 2-7   | only reachable if the operator set shrinks to ~5
-| 100| 2163-6342 | 0-1   | not reachable under equal weighting; see below
+| 5  | 168-357   | 10-22 | the average mainnet holder
+| 20 | 483-1302  | 2-7   |
+| 100| 2163-6342 | 0-1   | the protocol maximum, reachable only when one operator holds all the stake
 |===
 
 The 100-seat row is the honest edge of the model. Such a node is
@@ -314,13 +314,18 @@ The 100-seat row is the honest edge of the model. Such a node is
 consume more window than one epoch has, so it may be refused part way
 through and need a rotation to finish. That is a throughput limit an
 offline ceremony fixes, not a permanent exclusion from the signing
-threshold, which is what the old ceiling was.
+threshold, which is what the old ceiling was. It is also not a
+configuration any real wallet produces: one operator holding all 100
+seats of a 100-seat wallet is the protocol maximum, not a sortition
+result.
 
-IMPORTANT: Seat count is `groupSize / operatorCount` because signers are
-equal-weighted, so the expected holder is around 5 seats and the high-seat
-rows are reachable only if the operator set shrinks a long way. Size
-against the 5-seat row, and treat 20 and 100 as sensitivity checks on
-operator-set size rather than as a stake-concentration tail.
+IMPORTANT: Signers are stake-weighted, so seat count tracks the operator's
+stake share. The expected holder's seat count tracks the operator's
+stake share, and the high-seat rows are reachable in the upper tail of
+the seat-count distribution - in practice, by operators with concentrated
+stake. Size against the row that matches your network's realistic stake
+concentration, and treat 20 and 100 as sensitivity checks on that
+concentration rather than as the expected case.
 
 NOTE: Two earlier sets of figures in this document are wrong and should
 not be used. An operability assessment put these at "1-2 at 4 seats,
@@ -539,11 +544,6 @@ answers.
 
 === Gaps in this area
 
-* *No metric.* Nothing anchor-related is registered with `clientinfo`,
-  so `/metrics` has no headroom gauge and no rotation warning. The only
-  scrapeable trace of a refusal is the generic
-  `wallet_action_failed_total` counter, which cannot distinguish a
-  headroom refusal from any other action failure.
 * *No log line.* Neither the readiness snapshot nor the anchor binding
   logs headroom. The first log evidence is the refusal itself, by which
   time the node is already turning work away.
@@ -677,7 +677,6 @@ full-size sweeps per epoch at the expected 5 seats, that is roughly
 *630-1400 full-size sweeps* before the chain can no longer be extended.
 Nothing in this tree implements what happens next. This is a gap, not a
 documented plan.
-+
 An earlier revision of this warning said "roughly 64-128 full-size
 sweeps", derived from the retracted 4-seat figures above; the real
 lifetime is about an order of magnitude larger. The cap is also a *size*
@@ -728,6 +727,43 @@ Consequently:
 * *Downtime is unmeasured.* The whole ceremony happens with the node
   stopped, and no rehearsal figure exists.
 
+== The anchored emergency-rekey kill switch
+
+The wallet-level emergency rekey kill switch is now anchored. The Rust
+signer has always exported `frost_tbtc_trigger_emergency_rekey`; the Go
+bridge now reaches it through the state-anchored operation path
+(`TriggerNativeTBTCSignerEmergencyRekey` in
+`pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go`),
+so the durable write that arms the switch is compare-and-swapped onto
+the anchor stream before the call returns. That is what makes a later
+erasure detectable: an earlier out-of-band write to the durable store
+could be silently undone by restoring the pre-rekey state file, because
+nothing on the anchor stream recorded it.
+
+Three properties of the anchored call follow, and each one looks like
+an omission unless it is named:
+
+. It deliberately bypasses the admission model. The operation wrapper
+  takes no capacity reservation, and admission refuses all work once
+  headroom reaches the rotation floor while the barrier keeps admitting
+  until the certified window is genuinely exhausted. A kill switch that
+  capacity accounting can veto is not a kill switch, so the trigger
+  runs in that band unreserved.
+. The barrier stays mandatory. A poisoned anchor or an exhausted
+  certified window fails the trigger; every barrier refusal predicate
+  is operation-independent, so a state in which the trigger is refused
+  is one in which the node is already refusing every signature-producing
+  call. The kill switch is redundant there, not defeated.
+. The armed event is immutable once armed. The engine exposes no
+  export that clears it, so the wallet named in the record cannot sign
+  again until a replacement DKG completes.
+
+No operator-facing trigger for this kill switch currently exists in
+this repository. The `keep-client tbtc-signer` subcommands implement
+only the four-phase bootstrap ceremony described above; the rekey call
+is reachable today only through code paths that are not in `cmd/`.
+Wiring one is a separate piece of work.
+
 == Pre-activation checklist
 
 The FROST path is pre-production: both go-live gates in
@@ -743,12 +779,14 @@ derived above is run against real value.
 . *A supported way to read headroom* that does not require an
   auditor challenge assembled by hand: a `tbtc-signer` subcommand, or
   a `clientinfo` gauge for both headroom dimensions plus the
-  rotation-warning flag.
+  rotation-warning flag. +
+  Present as the `clientinfo` gauges `rotation_warning`,
+  `restartable_revision_headroom`, and
+  `restartable_generation_headroom`.
 . *An alert threshold set well above the danger points* - above 256
   (where all work stops), above the node's own per-input reservation for
   its seat count (175 generations at 4 seats, 815 at 20), and above what
-  one full sweep consumes (up to 588 generations at 4 seats). An alert
-  that fires at 256 fires after the node has already abandoned a batch
+  one full sweep consumes (up to 294 generations at 4 seats). An alert
   whose authorization it paid to relay.
 . *A documented, rehearsed anchor-service epoch transition:* who opens
   epoch N+1 revision 1, how the frozen checkpoint and previous event
@@ -760,8 +798,8 @@ derived above is run against real value.
 . *A decision on the 64-certificate lifetime bound,* including what a
   store does at certificate 64.
 . *A local-seat policy.* No seat count is excluded from signing any
-  more, but seat count still sets rotation cadence: 4 seats yields 6-13
-  full-size sweeps per epoch, 20 seats yields 1-2, and above roughly 30
+  more, but seat count still sets rotation cadence: 4 seats yields 13-26
+  sweeps per epoch, 20 seats yields 2-7, and above roughly 30
   a single full-size sweep can no longer be completed inside one epoch.
   Decide the supported seat count per node, and the rotation cadence
   that goes with it, before sortition produces one.
@@ -774,8 +812,9 @@ derived above is run against real value.
 . *An anchor-service rule that retires the previous binding.* After a
   rotation the service should refuse reads and compare-and-swaps for the
   previous `bindingHash`, or for an identity whose
-  `activationManifestSequence` is not the current one. Both fields ride
-  in every signed request (`frostNativeSignerAnchorIdentityToWire`), so
+* `activationManifestSequence` is not the current one. `activationManifestSequence`
+  rides in the signed identity (`frostNativeSignerAnchorIdentityToWire`) while
+  `bindingHash` rides in the request payload alongside it, so
   this is an admission rule rather than a protocol change. Without it,
   an operator who keeps an earlier rotation's artifacts *and* an earlier
   signer-store snapshot can run against the earlier certified floor; see

--- a/docs/development/frost-anchor-rotation.adoc
+++ b/docs/development/frost-anchor-rotation.adoc
@@ -300,30 +300,40 @@ full-size sweeps one at a time:
 |===
 | Local seats | Generations per 21-input sweep | Full-size sweeps per anchor epoch | Note
 
-| 1  | 105-210    | 18-36 | best case assumes one generation per anchored call
-| 2  | 168-336    | 11-22 |
-| 3  | 231-462    | 8-16  |
-| 4  | 294-588    | 6-13  |
-| 5  | 357-714    | 5-10  | the average mainnet holder; excluded entirely before this change
-| 20 | 1302-2604  | 1-2   |
-| 100| 6342-12684 | 0-0   | a single sweep consumes more than the whole window
+| 1  | 84-105    | 36-45 | best case is `k+3` per input; worst is `3k+2`
+| 2  | 105-168   | 22-36 |
+| 3  | 126-231   | 16-30 |
+| 4  | 147-294   | 13-26 |
+| 5  | 168-357   | 10-22 | the expected holder under equal weighting
+| 20 | 483-1302  | 2-7   | only reachable if the operator set shrinks to ~5
+| 100| 2163-6342 | 0-1   | not reachable under equal weighting; see below
 |===
 
 The 100-seat row is the honest edge of the model. Such a node is
-*admitted* for every input - the ceiling is gone - but a full sweep
-consumes more window than one epoch has, so it will be refused part way
-through and needs a rotation to finish. That is a throughput limit an
+*admitted* for every input - the ceiling is gone - but a full sweep can
+consume more window than one epoch has, so it may be refused part way
+through and need a rotation to finish. That is a throughput limit an
 offline ceremony fixes, not a permanent exclusion from the signing
-threshold, which is what the old ceiling was. It is also not a
-configuration any real wallet produces: one operator holding all 100
-seats of a 100-seat wallet is the protocol maximum, not a sortition
-result.
+threshold, which is what the old ceiling was.
 
-NOTE: An earlier operability assessment put these at "1-2 at 4 seats,
-about 5 at 3 seats, about 28 at 1 seat". Those figures were measured
-against the batch-wide reservation, where the *next* workflow's worst
-case, not consumption, decided when a node stopped. They no longer
-apply; use the ranges above.
+IMPORTANT: Seat count is `groupSize / operatorCount` because signers are
+equal-weighted, so the expected holder is around 5 seats and the high-seat
+rows are reachable only if the operator set shrinks a long way. Size
+against the 5-seat row, and treat 20 and 100 as sensitivity checks on
+operator-set size rather than as a stake-concentration tail.
+
+NOTE: Two earlier sets of figures in this document are wrong and should
+not be used. An operability assessment put these at "1-2 at 4 seats,
+about 5 at 3 seats, about 28 at 1 seat", measured against the batch-wide
+reservation, where the *next* workflow's worst case rather than
+consumption decided when a node stopped. A later revision of the table
+above used a single burn figure per input; real fault-free burn is a
+*range*, `k+3` to `3k+2` generations per input, because a call whose
+sweep prologue mutates state advances more than one generation. Any
+capacity or cadence number derived from a point value understates the
+window by roughly a factor of two. Use the ranges above, and confirm them
+by measurement on the live-testnet gate before relying on them for
+sizing.
 
 === Concurrency
 
@@ -662,10 +672,19 @@ under a 16 MiB bound and each certificate under a 120 KiB bound.
 
 WARNING: Because the file must always start at sequence 1 and may hold
 at most 64 entries, a signer store admits at most *63 rotations for its
-entire lifetime* - 64 anchor epochs counting the bootstrap. At 1-2
-full-size sweeps per epoch at 4 seats that is roughly 64-128 full-size
-sweeps before the chain can no longer be extended. Nothing in this tree
-implements what happens next. This is a gap, not a documented plan.
+entire lifetime* - 64 anchor epochs counting the bootstrap. At 10-22
+full-size sweeps per epoch at the expected 5 seats, that is roughly
+*630-1400 full-size sweeps* before the chain can no longer be extended.
+Nothing in this tree implements what happens next. This is a gap, not a
+documented plan.
++
+An earlier revision of this warning said "roughly 64-128 full-size
+sweeps", derived from the retracted 4-seat figures above; the real
+lifetime is about an order of magnitude larger. The cap is also a *size*
+artifact rather than a security property - each certificate must fit a
+bounded journal record, and 64 of them sit near half the request bound -
+so the ceiling is a consequence of the artifact having to be complete
+from sequence 1, not of anything the chain proves.
 
 === Restart, and the order of operations
 

--- a/docs/development/frost-anchor-rotation.adoc
+++ b/docs/development/frost-anchor-rotation.adoc
@@ -126,12 +126,56 @@ states this directly where an absent anchor stream is refused
 ....
 
 So the floor moves only under an Ed25519 signature from the offline
-authority, checked at startup against pins that the running node cannot
-influence. A finite window is the price: the node must be able to
-replay its whole history from the floor to prove it did not roll back,
-and that replay is bounded. Running out of window is therefore not a
-failure of the anchor - it is the anchor working, and asking for a
-fresh signed floor.
+authority. That signature is what the running *signer process* cannot
+forge: a compromised signer cannot mint itself a new floor, because
+every certificate is verified against the offline authority key in both
+Go and Rust. It is not a pin against the *operator* - see
+<<what-the-floor-does-not-bound>>. A finite window is the price: the
+node must be able to replay its whole history from the floor to prove
+it did not roll back, and that replay is bounded. Running out of window
+is therefore not a failure of the anchor - it is the anchor working,
+and asking for a fresh signed floor.
+
+[[what-the-floor-does-not-bound]]
+=== What the floor does not bound
+
+The floor bounds the anchor *service* and the signer *process*. It does
+not bound the *operator*, and an earlier revision of this document said
+otherwise.
+
+Every artifact that names the floor is an operator-owned local file:
+the certificate chain (`FrostNativeSignerAnchorTrustCertificatePath`),
+the init config (`TBTC_SIGNER_INIT_CONFIG_PATH`), and the activation
+manifest (`FrostPreSignActivationManifestPath` - a signed envelope read
+from disk, not fetched from chain). The only comparison the certificate
+sequence and digest ever face is against the init config, in
+`validateFrostNativeSignerAnchorTrustExpectedHead`. An operator holding
+an earlier rotation's artifacts can therefore present them to their own
+node.
+
+Three things bound how far that goes, and none of them is the floor:
+
+. *The bundle moves in lockstep.* Every rotation must change the
+  activation manifest hash, advance the manifest sequence by exactly
+  one, and advance the service epoch by exactly one
+  (`validate_rotation_endpoints`). A certificate is only presentable
+  together with its own manifest, so a downgrade means reverting the
+  whole bundle, not swapping one file.
+. *The durable trust journal is append-only.* Its head must equal the
+  configured pin, so a downgraded bundle also requires a signer-store
+  snapshot from before the transition.
+. *The anchor service can refuse.* Every signed request names the
+  current `bindingHash` and `activationManifestSequence`, so a service
+  that retires the previous binding after a rotation makes the older
+  epoch unusable. This repository can neither specify nor enforce that;
+  see the pre-activation checklist.
+
+The practical consequence: a floor downgrade is not a single edit but a
+coordinated restore of the artifact bundle *and* the signer store,
+against a service still willing to answer for a retired epoch. Treat
+the certified floor as a bound on the service and on a compromised
+signer process, and treat operator-side rollback as governed by the
+checklist items below rather than by the floor.
 
 [[when-rotation-is-required]]
 == When rotation is required
@@ -708,6 +752,26 @@ derived above is run against real value.
   fail-closed startup error.
 . *Both readiness-manifest gates flipped to `present`* with evidence,
   per that document's update discipline.
+. *An anchor-service rule that retires the previous binding.* After a
+  rotation the service should refuse reads and compare-and-swaps for the
+  previous `bindingHash`, or for an identity whose
+  `activationManifestSequence` is not the current one. Both fields ride
+  in every signed request (`frostNativeSignerAnchorIdentityToWire`), so
+  this is an admission rule rather than a protocol change. Without it,
+  an operator who keeps an earlier rotation's artifacts *and* an earlier
+  signer-store snapshot can run against the earlier certified floor; see
+  <<what-the-floor-does-not-bound>>.
+. *A decision on where a monotonic floor is published,* if operator-side
+  rollback is in scope. Nothing inside this repository can close it: every
+  candidate pin is downstream of a file the operator owns. Closing it
+  requires publishing a minimum trust-certificate sequence per signer
+  stream somewhere the operator cannot rewrite - on chain, or enforced by
+  the anchor service - which is a governance decision, not a keep-core
+  change. Note the signed activation-handshake attestation already
+  exports `trustCertificateSequence`, `anchorServiceEpoch` and the
+  certified floor revision/generation, so an external monitor retaining
+  the maximum ever seen per operator detects a downgrade today without
+  any protocol change.
 
 == References
 

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -83,6 +83,10 @@ typedef TbtcSignerResult (*tbtc_init_signer_config_fn)(
   const uint8_t* request_ptr,
   size_t request_len
 );
+typedef TbtcSignerResult (*tbtc_trigger_emergency_rekey_fn)(
+  const uint8_t* request_ptr,
+  size_t request_len
+);
 typedef TbtcSignerResult (*tbtc_durable_store_identity_fn)(void);
 typedef void (*tbtc_free_buffer_fn)(uint8_t* ptr, size_t len);
 
@@ -300,6 +304,18 @@ static TbtcSignerResult tbtc_signer_init_signer_config(const uint8_t* request_pt
   return init_signer_config(request_ptr, request_len);
 }
 
+static TbtcSignerResult tbtc_signer_trigger_emergency_rekey(const uint8_t* request_ptr, size_t request_len) {
+  tbtc_trigger_emergency_rekey_fn trigger_emergency_rekey = (tbtc_trigger_emergency_rekey_fn)dlsym(
+    RTLD_DEFAULT,
+    "frost_tbtc_trigger_emergency_rekey"
+  );
+  if (trigger_emergency_rekey == NULL) {
+    return unavailable_tbtc_signer_result();
+  }
+
+  return trigger_emergency_rekey(request_ptr, request_len);
+}
+
 static TbtcSignerResult tbtc_signer_durable_store_identity(void) {
   tbtc_durable_store_identity_fn durable_store_identity =
     (tbtc_durable_store_identity_fn)dlsym(
@@ -340,6 +356,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strings"
 	"unsafe"
 )
 
@@ -437,6 +454,19 @@ type buildTaggedTBTCSignerRetireDistributedDKGKeyPackagesResponse struct {
 	KeyGroup               string `json:"key_group"`
 	Retired                bool   `json:"retired"`
 	RetiredKeyPackageCount uint16 `json:"retired_key_package_count"`
+}
+
+type buildTaggedTBTCSignerTriggerEmergencyRekeyRequest struct {
+	SessionID string `json:"session_id"`
+	Reason    string `json:"reason"`
+}
+
+type buildTaggedTBTCSignerTriggerEmergencyRekeyResponse struct {
+	SessionID               string `json:"session_id"`
+	EmergencyRekeyRequired  bool   `json:"emergency_rekey_required"`
+	Reason                  string `json:"reason"`
+	TriggeredAtUnix         uint64 `json:"triggered_at_unix"`
+	RecommendedNewSessionID string `json:"recommended_new_session_id"`
 }
 
 type buildTaggedTBTCSignerNativeFROSTCommitment struct {
@@ -1112,6 +1142,101 @@ func decodeBuildTaggedTBTCSignerRetireDistributedDKGKeyPackagesResponse(
 		)
 	}
 	return nil
+}
+
+func buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
+	sessionID string,
+	reason string,
+) ([]byte, error) {
+	const op = "TriggerEmergencyRekey"
+	if sessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(op, "session ID is empty")
+	}
+	// The engine validates the session ID too, but rejecting here keeps a
+	// malformed operator input from costing a barrier lease and an anchor round
+	// trip before it fails.
+	if len(sessionID) > maximumTBTCSignerEmergencyRekeySessionIDLength {
+		return nil, buildTaggedTBTCSignerOperationError(
+			op,
+			"session ID is too long",
+		)
+	}
+	if strings.ContainsAny(sessionID, "\x00\n\r\t \"\\=") {
+		return nil, buildTaggedTBTCSignerOperationError(
+			op,
+			"session ID contains disallowed characters",
+		)
+	}
+	// Trim before the emptiness check so a whitespace-only reason cannot arm the
+	// switch with no recorded justification; the engine trims identically, and
+	// the response echo is compared against the trimmed value.
+	trimmedReason := strings.TrimSpace(reason)
+	if trimmedReason == "" {
+		return nil, buildTaggedTBTCSignerOperationError(op, "reason is empty")
+	}
+	return buildTaggedTBTCSignerMarshalRequest(
+		op,
+		buildTaggedTBTCSignerTriggerEmergencyRekeyRequest{
+			SessionID: sessionID,
+			Reason:    trimmedReason,
+		},
+	)
+}
+
+func decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse(
+	responsePayload []byte,
+	expectedReason string,
+) (*NativeTBTCSignerEmergencyRekey, error) {
+	const op = "TriggerEmergencyRekey"
+	var response buildTaggedTBTCSignerTriggerEmergencyRekeyResponse
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, buildTaggedTBTCSignerOperationError(
+			op,
+			fmt.Sprintf("cannot decode response payload: %v", err),
+		)
+	}
+	// The engine reports false only if it declined to arm the switch, which it
+	// signals as an error; treat a false here as a contract violation rather
+	// than as a quiet no-op, so a caller never reads "rekey done" from it.
+	if !response.EmergencyRekeyRequired {
+		return nil, buildTaggedTBTCSignerOperationError(
+			op,
+			"response does not report the emergency rekey as required",
+		)
+	}
+	if response.Reason != expectedReason {
+		return nil, buildTaggedTBTCSignerOperationError(
+			op,
+			"response reason does not match request",
+		)
+	}
+	// The engine may retarget a per-signing session to the wallet session it
+	// serves, so the echoed session ID legitimately differs from the request.
+	// It must still name some session.
+	if response.SessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			op,
+			"response session ID is empty",
+		)
+	}
+	if response.TriggeredAtUnix == 0 {
+		return nil, buildTaggedTBTCSignerOperationError(
+			op,
+			"response trigger timestamp is zero",
+		)
+	}
+	if response.RecommendedNewSessionID == "" {
+		return nil, buildTaggedTBTCSignerOperationError(
+			op,
+			"response recommended new session ID is empty",
+		)
+	}
+	return &NativeTBTCSignerEmergencyRekey{
+		SessionID:               response.SessionID,
+		Reason:                  response.Reason,
+		TriggeredAtUnix:         response.TriggeredAtUnix,
+		RecommendedNewSessionID: response.RecommendedNewSessionID,
+	}, nil
 }
 
 func decodeBuildTaggedTBTCSignerDKGPart3Response(
@@ -1841,6 +1966,18 @@ func callBuildTaggedTBTCSignerBuildTaprootTx(
 	)
 }
 
+func callBuildTaggedTBTCSignerTriggerEmergencyRekey(
+	requestPayload []byte,
+) ([]byte, error) {
+	return callBuildTaggedTBTCSignerOperation(
+		"TriggerEmergencyRekey",
+		requestPayload,
+		func(requestPtr *C.uint8_t, requestLen C.size_t) C.TbtcSignerResult {
+			return C.tbtc_signer_trigger_emergency_rekey(requestPtr, requestLen)
+		},
+	)
+}
+
 func callBuildTaggedTBTCSignerOperation(
 	operation string,
 	requestPayload []byte,
@@ -2062,6 +2199,59 @@ func ReadNativeTBTCSignerDurableStoreIdentity() (
 		)
 	}
 	return identity, nil
+}
+
+// TriggerNativeTBTCSignerEmergencyRekey arms the wallet-level emergency rekey
+// kill switch through the state-anchored operation path, so the durable write
+// is compare-and-swapped onto the anchor stream before this call returns.
+//
+// Routing matters more than the call itself. The engine export has always
+// existed, but with no Go caller the only way to arm the switch was to stop the
+// node and mutate its store out of band - an uncertified local write that a
+// restart cannot distinguish from an operator restoring the pre-rekey state
+// file. Going through callBuildTaggedTBTCSignerOperation makes the write
+// externally witnessed, so erasing it afterwards is detectable.
+//
+// Deliberately NOT admission-gated: callBuildTaggedTBTCSignerOperation performs
+// no capacity reservation, and admission refuses all work once headroom reaches
+// the rotation floor while the barrier keeps admitting until the certified
+// window is genuinely exhausted. A kill switch that capacity accounting can
+// veto is not a kill switch, so it runs in that band unreserved.
+//
+// The barrier, by contrast, stays mandatory. When it refuses - a poisoned
+// anchor, or an exhausted certified window - this call fails. That is correct
+// rather than a gap: every barrier refusal predicate is operation-independent,
+// so a state in which this trigger is refused is a state in which the node is
+// already refusing every signature-producing call. The kill switch is redundant
+// there, not defeated, and its residual is availability, never authority.
+//
+// The call is serialized behind any in-flight anchored operation and may wait
+// tens of seconds on the process-global barrier mutex; it is never refused for
+// that reason. Callers must be single-flight - the engine treats an armed event
+// as immutable, and no export clears it.
+func TriggerNativeTBTCSignerEmergencyRekey(
+	sessionID string,
+	reason string,
+) (*NativeTBTCSignerEmergencyRekey, error) {
+	requestPayload, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
+		sessionID,
+		reason,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	responsePayload, err := callBuildTaggedTBTCSignerTriggerEmergencyRekey(
+		requestPayload,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse(
+		responsePayload,
+		strings.TrimSpace(reason),
+	)
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native.go
@@ -354,6 +354,7 @@ import "C"
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -1147,40 +1148,46 @@ func decodeBuildTaggedTBTCSignerRetireDistributedDKGKeyPackagesResponse(
 func buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
 	sessionID string,
 	reason string,
-) ([]byte, error) {
+) ([]byte, string, error) {
 	const op = "TriggerEmergencyRekey"
 	if sessionID == "" {
-		return nil, buildTaggedTBTCSignerOperationError(op, "session ID is empty")
+		return nil, "", buildTaggedTBTCSignerOperationError(op, "session ID is empty")
 	}
 	// The engine validates the session ID too, but rejecting here keeps a
 	// malformed operator input from costing a barrier lease and an anchor round
 	// trip before it fails.
 	if len(sessionID) > maximumTBTCSignerEmergencyRekeySessionIDLength {
-		return nil, buildTaggedTBTCSignerOperationError(
+		return nil, "", buildTaggedTBTCSignerOperationError(
 			op,
 			"session ID is too long",
 		)
 	}
 	if strings.ContainsAny(sessionID, "\x00\n\r\t \"\\=") {
-		return nil, buildTaggedTBTCSignerOperationError(
+		return nil, "", buildTaggedTBTCSignerOperationError(
 			op,
 			"session ID contains disallowed characters",
 		)
 	}
 	// Trim before the emptiness check so a whitespace-only reason cannot arm the
 	// switch with no recorded justification; the engine trims identically, and
-	// the response echo is compared against the trimmed value.
+	// the response echo is compared against the trimmed value. Return the
+	// trimmed reason so the caller can use the same normalization for the
+	// byte-for-byte echo comparison instead of re-deriving it independently.
 	trimmedReason := strings.TrimSpace(reason)
 	if trimmedReason == "" {
-		return nil, buildTaggedTBTCSignerOperationError(op, "reason is empty")
+		return nil, "", buildTaggedTBTCSignerOperationError(op, "reason is empty")
 	}
-	return buildTaggedTBTCSignerMarshalRequest(
+	payload, err := buildTaggedTBTCSignerMarshalRequest(
 		op,
 		buildTaggedTBTCSignerTriggerEmergencyRekeyRequest{
 			SessionID: sessionID,
 			Reason:    trimmedReason,
 		},
 	)
+	if err != nil {
+		return nil, "", err
+	}
+	return payload, trimmedReason, nil
 }
 
 func decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse(
@@ -2201,9 +2208,40 @@ func ReadNativeTBTCSignerDurableStoreIdentity() (
 	return identity, nil
 }
 
+// ErrNativeTBTCSignerEmergencyRekeyArmedButUnverified is returned by
+// TriggerNativeTBTCSignerEmergencyRekey when the underlying engine call
+// returned without error but the response could not be decoded into a
+// verified rekey record. At that point the engine has already armed the
+// emergency-rekey kill switch inside invoke() - the failure (a JSON decode
+// error, a missing expected field, or any of the contract checks in
+// decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse) reflects only
+// that the Go host could not read back a fully verified acknowledgement,
+// not that the switch itself is still unprimed.
+//
+// Callers that observe this error must treat the switch as ARMED. Retrying
+// the trigger is useless: the engine treats an armed event as immutable and
+// a second commit is a no-op that only wastes barrier time. Use
+// ReadNativeTBTCSignerDurableStoreIdentity or a direct readback against the
+// engine to confirm durable state before any operator decision.
+var ErrNativeTBTCSignerEmergencyRekeyArmedButUnverified = errors.New(
+	"native tbtc signer emergency rekey: switch armed but response unverifiable",
+)
+
 // TriggerNativeTBTCSignerEmergencyRekey arms the wallet-level emergency rekey
-// kill switch through the state-anchored operation path, so the durable write
-// is compare-and-swapped onto the anchor stream before this call returns.
+// kill switch through the state-anchored operation path, so a call that
+// returns successfully has compare-and-swapped the durable write onto the
+// anchor stream before returning.
+//
+// That pairing is not atomic, and the failure path is the interesting one. The
+// engine arms the switch inside invoke(); the anchor only witnesses it in the
+// lease.commit() that follows. A commit refusal - or a crash in that window -
+// therefore returns an error from a call whose durable write already landed,
+// leaving the switch armed locally but unwitnessed by the anchor. Nothing
+// unwinds it: the discard path scrubs the Rust result buffer, not the engine's
+// durable state. Recovery is not automatic either. It depends on the local
+// store still being ahead of the anchor at the next boot, so reconciliation
+// observes the armed event and re-anchors it - which is exactly the evidence an
+// operator restoring a pre-rekey state file in that window destroys.
 //
 // Routing matters more than the call itself. The engine export has always
 // existed, but with no Go caller the only way to arm the switch was to stop the
@@ -2229,11 +2267,19 @@ func ReadNativeTBTCSignerDurableStoreIdentity() (
 // tens of seconds on the process-global barrier mutex; it is never refused for
 // that reason. Callers must be single-flight - the engine treats an armed event
 // as immutable, and no export clears it.
+
+// When decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse fails on a
+// payload the engine has already produced, this wraps the underlying error
+// in ErrNativeTBTCSignerEmergencyRekeyArmedButUnverified so callers can
+// distinguish "the switch was never armed" from "the switch was armed but
+// the response was not verifiable". The wrapped error is terminal: do not
+// retry the trigger, since the engine treats an armed event as immutable
+// (see the single-flight paragraph above).
 func TriggerNativeTBTCSignerEmergencyRekey(
 	sessionID string,
 	reason string,
 ) (*NativeTBTCSignerEmergencyRekey, error) {
-	requestPayload, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
+	requestPayload, normalizedReason, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
 		sessionID,
 		reason,
 	)
@@ -2248,10 +2294,18 @@ func TriggerNativeTBTCSignerEmergencyRekey(
 		return nil, err
 	}
 
-	return decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse(
+	result, err := decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse(
 		responsePayload,
-		strings.TrimSpace(reason),
+		normalizedReason,
 	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: [%w]",
+			ErrNativeTBTCSignerEmergencyRekeyArmedButUnverified,
+			err,
+		)
+	}
+	return result, nil
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_cgo_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_cgo_test.go
@@ -1,0 +1,313 @@
+//go:build frost_native && frost_tbtc_signer && cgo
+
+package signing
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Worker env vars for the subprocess that runs the success scenario in
+// isolation. The other scenarios run inline against a barrier installed over
+// test-double state, so they do not need their own subprocess role.
+const (
+	rekeyWorkerRoleEnv     = "KEEP_CORE_FROST_TBTC_REKEY_WORKER_ROLE"
+	rekeyWorkerStateDirEnv = "TBTC_SIGNER_STATE_PATH"
+	rekeyWorkerProfileEnv  = "TBTC_SIGNER_PROFILE"
+	rekeyWorkerEnforceEnv  = "TBTC_SIGNER_ENFORCE_PROVENANCE_GATE"
+	rekeyWorkerStateKeyEnv = "TBTC_SIGNER_STATE_ENCRYPTION_KEY_HEX"
+
+	rekeySkipPrefix = "FROST_REKEY_SKIP="
+	rekeyErrPrefix  = "FROST_REKEY_ERROR="
+
+	rekeyRoleSuccess = "success"
+)
+
+// TestTriggerNativeTBTCSignerEmergencyRekey_CgoWiringAndBarrierGating proves
+// the cgo-backed TriggerNativeTBTCSignerEmergencyRekey path is wired through
+// the state anchor barrier: a successful call advances the durable anchor tip
+// exactly once, while calls with a poisoned barrier or an exhausted certified
+// anchor window are refused.
+//
+// The success scenario mutates durable signer state (arming the wallet-level
+// kill switch is wallet-lifetime and single-flight - the engine has no export
+// that clears it), so it runs in a dedicated subprocess with its own
+// ephemeral state directory. The poisoned and exhausted scenarios are refused
+// before any state-touching cgo call reaches the engine: they run inline
+// against an installed barrier over test-double state, and the inline call to
+// TriggerNativeTBTCSignerEmergencyRekey only reaches the ABI preflight,
+// which is the part that fails closed if the linked libfrost_tbtc is missing
+// the FFI contract version symbol - in which case the scenario SKIPs rather
+// than failing the suite.
+func TestTriggerNativeTBTCSignerEmergencyRekey_CgoWiringAndBarrierGating(t *testing.T) {
+	role := os.Getenv(rekeyWorkerRoleEnv)
+	if role != "" {
+		runRekeyWorker(t, role)
+		return
+	}
+
+	t.Run("SuccessAdvancesAnchorTipOnce", func(t *testing.T) {
+		runRekeySuccessSubprocess(t)
+	})
+	t.Run("PoisonedBarrierRefusesCall", func(t *testing.T) {
+		runRekeyPoisonedScenario(t)
+	})
+	t.Run("ExhaustedAnchorWindowRefusesCall", func(t *testing.T) {
+		runRekeyExhaustedScenario(t)
+	})
+}
+
+func runRekeySuccessSubprocess(t *testing.T) {
+	stateDir := filepath.Join(
+		os.TempDir(),
+		fmt.Sprintf(
+			"keep-frost-tbtc-rekey-%s-%d-%d",
+			rekeyRoleSuccess,
+			os.Getpid(),
+			time.Now().UnixNano(),
+		),
+	)
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("create subprocess state dir: %v", err)
+	}
+
+	stateKey := make([]byte, 32)
+	for i := range stateKey {
+		stateKey[i] = byte(i + 1)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0],
+		"-test.run", "^TestTriggerNativeTBTCSignerEmergencyRekey_CgoWiringAndBarrierGating$",
+		"-test.v",
+	)
+	cmd.Env = withEnvOverrides(os.Environ(), map[string]string{
+		rekeyWorkerRoleEnv:           rekeyRoleSuccess,
+		rekeyWorkerStateDirEnv:       filepath.Join(stateDir, "signer-state"),
+		rekeyWorkerProfileEnv:        "development",
+		rekeyWorkerEnforceEnv:        "false",
+		rekeyWorkerStateKeyEnv:       hex.EncodeToString(stateKey),
+		frostSubprocessSkipPrefixEnv: rekeySkipPrefix,
+	})
+	out, err := cmd.CombinedOutput()
+	output := string(out)
+	if skipMsg := extractPrefixed(output, rekeySkipPrefix); skipMsg != "" {
+		t.Skipf("subprocess skipped: %s", skipMsg)
+	}
+	if errMsg := extractPrefixed(output, rekeyErrPrefix); errMsg != "" {
+		t.Fatalf("subprocess reported error: %s\n%s", errMsg, indentTail(output, 40))
+	}
+	if err != nil {
+		t.Fatalf("subprocess failed (err=%v):\n%s", err, indentTail(output, 40))
+	}
+}
+
+func runRekeyWorker(t *testing.T, role string) {
+	switch role {
+	case rekeyRoleSuccess:
+		runRekeySuccessScenario(t)
+	default:
+		fmt.Printf("%sunknown rekey worker role: %s\n", rekeyErrPrefix, role)
+		t.Fatalf("unknown rekey worker role: %s", role)
+	}
+}
+
+func runRekeySuccessScenario(t *testing.T) {
+	setupRealCgoSignerStateAnchor(t)
+
+	initialTip, err := ReadNativeTBTCSignerStateWitnessTip()
+	skipFrostUnavailable(t, "state-witness tip", err)
+	if err != nil {
+		t.Fatalf("cannot read pre-trigger state tip: %v", err)
+	}
+
+	const (
+		sessionID = "wallet-session"
+		reason    = "compromise"
+	)
+	rekey, err := TriggerNativeTBTCSignerEmergencyRekey(sessionID, reason)
+	skipFrostUnavailable(t, "trigger emergency rekey", err)
+	if err != nil {
+		t.Fatalf("unexpected trigger error: %v", err)
+	}
+	if rekey == nil {
+		t.Fatal("trigger returned a nil rekey record on success")
+	}
+	if rekey.SessionID == "" {
+		t.Fatalf("trigger returned an empty session id: %+v", rekey)
+	}
+	if rekey.Reason != reason {
+		t.Fatalf(
+			"trigger returned a different reason than requested: got %q want %q",
+			rekey.Reason, reason,
+		)
+	}
+	if rekey.TriggeredAtUnix == 0 {
+		t.Fatalf("trigger returned a zero trigger timestamp: %+v", rekey)
+	}
+	if rekey.RecommendedNewSessionID == "" {
+		t.Fatalf("trigger returned an empty recommended new session id: %+v", rekey)
+	}
+
+	finalTip, err := ReadNativeTBTCSignerStateWitnessTip()
+	skipFrostUnavailable(t, "state-witness tip after", err)
+	if err != nil {
+		t.Fatalf("cannot read post-trigger state tip: %v", err)
+	}
+
+	if finalTip.Generation != initialTip.Generation+1 {
+		t.Fatalf(
+			"expected anchor generation to advance by exactly one, got %d -> %d",
+			initialTip.Generation, finalTip.Generation,
+		)
+	}
+	if finalTip.AnchorRevision != initialTip.AnchorRevision+1 {
+		t.Fatalf(
+			"expected anchor revision to advance by exactly one, got %d -> %d",
+			initialTip.AnchorRevision, finalTip.AnchorRevision,
+		)
+	}
+	if finalTip.StateCommitment == initialTip.StateCommitment {
+		t.Fatal(
+			"anchor state commitment did not advance after a successful emergency rekey",
+		)
+	}
+	if finalTip.AnchorAcknowledgementDigest == initialTip.AnchorAcknowledgementDigest {
+		t.Fatal(
+			"anchor acknowledgement digest did not advance after a successful emergency rekey",
+		)
+	}
+}
+
+// skipRekeyCgoUnavailable turns an ErrNativeCryptographyUnavailable-classed
+// failure on TriggerNativeTBTCSignerEmergencyRekey into a SKIP for the
+// inline barrier-only scenarios. The barrier refuses pre-call, so any
+// ErrNativeCryptographyUnavailable here is purely the ABI preflight failing
+// because the linked libfrost_tbtc predates FFI contract versioning - the
+// wiring we are pinning is unreachable in that build.
+func skipRekeyCgoUnavailable(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	if errors.Is(err, ErrNativeCryptographyUnavailable) {
+		if prefix := os.Getenv(frostSubprocessSkipPrefixEnv); prefix != "" {
+			fmt.Printf("%s%s\n", prefix, frostUnavailableSkipMessage(
+				"trigger emergency rekey", err,
+			))
+		}
+		t.Skip(frostUnavailableSkipMessage("trigger emergency rekey", err))
+	}
+}
+
+func runRekeyPoisonedScenario(t *testing.T) {
+	resetNativeTBTCSignerStateAnchorBarrierForTest()
+	t.Cleanup(resetNativeTBTCSignerStateAnchorBarrierForTest)
+
+	initial := testNativeTBTCSignerStateWitnessTip(1, [32]byte{2})
+	current := initial
+	// Install the barrier with a healthy committer first: the installer
+	// calls VerifyNativeTBTCSignerStateTip itself, so a pre-set verifyErr
+	// would refuse installation rather than poisoning on a request-taking
+	// call.
+	committer := &testNativeTBTCSignerStateAnchorCommitter{current: &current}
+	installTestNativeTBTCSignerStateAnchorBarrier(
+		t, &initial, &current, committer,
+	)
+
+	// Force the committer to disagree with the anchor: the next
+	// request-taking call now classifies the disagreement as a fact about
+	// the anchor and poisons the barrier, while returning
+	// ErrNativeTBTCSignerStateAnchorTerminal to the caller. The state-touching
+	// arming FFI never fires, so the immutable kill switch is untouched.
+	committer.verifyErr = errors.New(
+		"test: forced anchor disagreement to poison the barrier",
+	)
+
+	rekey, err := TriggerNativeTBTCSignerEmergencyRekey(
+		"wallet-session",
+		"compromise",
+	)
+	skipRekeyCgoUnavailable(t, err)
+	if !errors.Is(err, ErrNativeTBTCSignerStateAnchorTerminal) {
+		t.Fatalf(
+			"a verify-failing committer did not poison the barrier: rekey=%+v err=%v",
+			rekey, err,
+		)
+	}
+	if rekey != nil {
+		t.Fatalf("a verify-failing committer returned a rekey record: %+v", rekey)
+	}
+
+	// With the committer now honest, a second call MUST still be refused:
+	// the barrier is latched terminal, and any request-taking call routed
+	// through it must surface ErrNativeTBTCSignerStateAnchorTerminal.
+	committer.verifyErr = nil
+	rekey, err = TriggerNativeTBTCSignerEmergencyRekey(
+		"wallet-session",
+		"compromise",
+	)
+	skipRekeyCgoUnavailable(t, err)
+	if !errors.Is(err, ErrNativeTBTCSignerStateAnchorTerminal) {
+		t.Fatalf(
+			"a poisoned barrier accepted the rekey trigger: rekey=%+v err=%v",
+			rekey, err,
+		)
+	}
+	if rekey != nil {
+		t.Fatalf("a poisoned barrier returned a rekey record: %+v", rekey)
+	}
+	if poisoned := NativeTBTCSignerStateAnchorPoisoned(); !errors.Is(
+		poisoned, ErrNativeTBTCSignerStateAnchorTerminal,
+	) {
+		t.Fatalf("poisoned barrier was not reported by its accessor: %v", poisoned)
+	}
+}
+
+func runRekeyExhaustedScenario(t *testing.T) {
+	resetNativeTBTCSignerStateAnchorBarrierForTest()
+	t.Cleanup(resetNativeTBTCSignerStateAnchorBarrierForTest)
+
+	initial := testNativeTBTCSignerStateWitnessTip(1, [32]byte{2})
+	// Push the initial tip to the certified revision window's edge: the
+	// barrier's revision-distance check fires when
+	// readback.AnchorRevision - trustHead.CertifiedFloor.Revision >=
+	// MaximumAnchorRevisionDistance. Setting the tip at exactly that
+	// distance exhausts the window before any request-taking call runs.
+	initial.AnchorRevision =
+		testNativeTBTCSignerStateAnchorTrustHead().CertifiedFloor.Revision +
+			NativeTBTCSignerStateAnchorMaximumRevisionDistance
+	current := initial
+	committer := &testNativeTBTCSignerStateAnchorCommitter{current: &current}
+	installTestNativeTBTCSignerStateAnchorBarrier(
+		t, &initial, &current, committer,
+	)
+
+	rekey, err := TriggerNativeTBTCSignerEmergencyRekey(
+		"wallet-session",
+		"compromise",
+	)
+	skipRekeyCgoUnavailable(t, err)
+	if !errors.Is(err, ErrNativeTBTCSignerStateAnchorUnavailable) {
+		t.Fatalf(
+			"an exhausted certified window accepted the rekey trigger: rekey=%+v err=%v",
+			rekey, err,
+		)
+	}
+	if rekey != nil {
+		t.Fatalf("an exhausted window returned a rekey record: %+v", rekey)
+	}
+	if !strings.Contains(err.Error(), "certified anchor revision window is exhausted") {
+		t.Fatalf("exhaustion reason was not surfaced: %v", err)
+	}
+}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -1443,3 +1443,75 @@ func TestDecodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(t *t
 		t.Fatal("expected mismatched participant correspondence to be rejected")
 	}
 }
+
+func TestBuildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(t *testing.T) {
+	payload, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
+		"tbtc-frost-dkg-abcd-attempt-1",
+		"  suspected key compromise  ",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+	var request buildTaggedTBTCSignerTriggerEmergencyRekeyRequest
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("cannot decode built payload: [%v]", err)
+	}
+	if request.SessionID != "tbtc-frost-dkg-abcd-attempt-1" {
+		t.Fatalf("unexpected session ID: [%v]", request.SessionID)
+	}
+	// The reason is trimmed before it is sent, so the response echo (which the
+	// engine also trims) compares equal.
+	if request.Reason != "suspected key compromise" {
+		t.Fatalf("unexpected reason: [%v]", request.Reason)
+	}
+
+	if _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("", "reason"); err == nil {
+		t.Fatal("expected an empty session ID to be rejected")
+	}
+	// A whitespace-only reason must not arm the switch with no justification.
+	if _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("session", "   "); err == nil {
+		t.Fatal("expected a whitespace-only reason to be rejected")
+	}
+	if _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
+		strings.Repeat("s", maximumTBTCSignerEmergencyRekeySessionIDLength+1),
+		"reason",
+	); err == nil {
+		t.Fatal("expected an over-long session ID to be rejected")
+	}
+	if _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("bad session", "reason"); err == nil {
+		t.Fatal("expected a session ID with disallowed characters to be rejected")
+	}
+}
+
+func TestDecodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse(t *testing.T) {
+	// The engine retargets a per-signing session to the wallet session it
+	// serves, so a session ID that differs from the request is expected.
+	rekey, err := decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse(
+		[]byte(`{"session_id":"wallet-session","emergency_rekey_required":true,"reason":"compromise","triggered_at_unix":1700000000,"recommended_new_session_id":"wallet-session-rekey-1700000000"}`),
+		"compromise",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+	if rekey.SessionID != "wallet-session" ||
+		rekey.RecommendedNewSessionID != "wallet-session-rekey-1700000000" ||
+		rekey.TriggeredAtUnix != 1700000000 {
+		t.Fatalf("unexpected rekey record: [%+v]", rekey)
+	}
+
+	for name, payload := range map[string]string{
+		"malformed payload":           `{`,
+		"rekey not reported required": `{"session_id":"s","emergency_rekey_required":false,"reason":"compromise","triggered_at_unix":1,"recommended_new_session_id":"r"}`,
+		"reason mismatch":             `{"session_id":"s","emergency_rekey_required":true,"reason":"other","triggered_at_unix":1,"recommended_new_session_id":"r"}`,
+		"empty session ID":            `{"session_id":"","emergency_rekey_required":true,"reason":"compromise","triggered_at_unix":1,"recommended_new_session_id":"r"}`,
+		"zero trigger timestamp":      `{"session_id":"s","emergency_rekey_required":true,"reason":"compromise","triggered_at_unix":0,"recommended_new_session_id":"r"}`,
+		"empty recommended session":   `{"session_id":"s","emergency_rekey_required":true,"reason":"compromise","triggered_at_unix":1,"recommended_new_session_id":""}`,
+	} {
+		if _, err := decodeBuildTaggedTBTCSignerTriggerEmergencyRekeyResponse(
+			[]byte(payload),
+			"compromise",
+		); err == nil {
+			t.Fatalf("expected [%v] to be rejected", name)
+		}
+	}
+}

--- a/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
+++ b/pkg/frost/signing/native_frost_engine_tbtc_signer_registration_frost_native_test.go
@@ -1445,7 +1445,7 @@ func TestDecodeBuildTaggedTBTCSignerDeriveInteractiveAttemptContextResponse(t *t
 }
 
 func TestBuildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(t *testing.T) {
-	payload, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
+	payload, normalizedReason, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
 		"tbtc-frost-dkg-abcd-attempt-1",
 		"  suspected key compromise  ",
 	)
@@ -1464,21 +1464,27 @@ func TestBuildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(t *testing.T) 
 	if request.Reason != "suspected key compromise" {
 		t.Fatalf("unexpected reason: [%v]", request.Reason)
 	}
+	// The builder returns the same trimmed reason so the caller feeds an
+	// identical string into the response-echo comparison instead of trimming
+	// the original argument again.
+	if normalizedReason != "suspected key compromise" {
+		t.Fatalf("unexpected normalized reason: [%v]", normalizedReason)
+	}
 
-	if _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("", "reason"); err == nil {
+	if _, _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("", "reason"); err == nil {
 		t.Fatal("expected an empty session ID to be rejected")
 	}
 	// A whitespace-only reason must not arm the switch with no justification.
-	if _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("session", "   "); err == nil {
+	if _, _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("session", "   "); err == nil {
 		t.Fatal("expected a whitespace-only reason to be rejected")
 	}
-	if _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
+	if _, _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload(
 		strings.Repeat("s", maximumTBTCSignerEmergencyRekeySessionIDLength+1),
 		"reason",
 	); err == nil {
 		t.Fatal("expected an over-long session ID to be rejected")
 	}
-	if _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("bad session", "reason"); err == nil {
+	if _, _, err := buildTaggedTBTCSignerTriggerEmergencyRekeyRequestPayload("bad session", "reason"); err == nil {
 		t.Fatal("expected a session ID with disallowed characters to be rejected")
 	}
 }

--- a/pkg/frost/signing/native_tbtc_signer_emergency_rekey.go
+++ b/pkg/frost/signing/native_tbtc_signer_emergency_rekey.go
@@ -1,0 +1,24 @@
+package signing
+
+// maximumTBTCSignerEmergencyRekeySessionIDLength bounds the operator-supplied
+// session ID before it reaches the engine. The engine validates the ID too;
+// this only stops an obviously malformed input from consuming a barrier lease
+// and an anchor round trip on its way to a guaranteed rejection.
+const maximumTBTCSignerEmergencyRekeySessionIDLength = 128
+
+// NativeTBTCSignerEmergencyRekey is the engine's record of an armed wallet-level
+// emergency rekey.
+//
+// SessionID is the session the engine actually armed, which is not always the
+// one requested: arming a per-signing session retargets to the wallet session
+// it serves, so the write lands where the interactive gates read it.
+//
+// The event is immutable once armed - no engine export clears it - so the
+// wallet named here cannot sign again, and RecommendedNewSessionID is the
+// engine's suggested identity for the replacement DKG.
+type NativeTBTCSignerEmergencyRekey struct {
+	SessionID               string
+	Reason                  string
+	TriggeredAtUnix         uint64
+	RecommendedNewSessionID string
+}

--- a/pkg/frost/signing/native_tbtc_signer_emergency_rekey_default_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_emergency_rekey_default_test.go
@@ -1,0 +1,17 @@
+//go:build !(frost_native && frost_tbtc_signer && cgo)
+
+package signing
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTriggerNativeTBTCSignerEmergencyRekeyFailsClosedWithoutBridge(
+	t *testing.T,
+) {
+	rekey, err := TriggerNativeTBTCSignerEmergencyRekey("session", "compromise")
+	if rekey != nil || !errors.Is(err, ErrNativeCryptographyUnavailable) {
+		t.Fatalf("expected unavailable emergency rekey, got [%+v] [%v]", rekey, err)
+	}
+}

--- a/pkg/frost/signing/native_tbtc_signer_inventory_default.go
+++ b/pkg/frost/signing/native_tbtc_signer_inventory_default.go
@@ -4,6 +4,16 @@ package signing
 
 import "fmt"
 
+func TriggerNativeTBTCSignerEmergencyRekey(
+	sessionID string,
+	reason string,
+) (*NativeTBTCSignerEmergencyRekey, error) {
+	return nil, fmt.Errorf(
+		"%w: tbtc-signer bridge operation [TriggerEmergencyRekey] is unavailable in this build",
+		ErrNativeCryptographyUnavailable,
+	)
+}
+
 func ReadNativeTBTCSignerRetainedKeyPackageInventory() (
 	*NativeTBTCSignerRetainedKeyPackageInventory,
 	error,

--- a/pkg/frost/signing/native_tbtc_signer_state_anchor_barrier.go
+++ b/pkg/frost/signing/native_tbtc_signer_state_anchor_barrier.go
@@ -504,6 +504,10 @@ func (lease *nativeTBTCSignerStateAnchorLease) commit() error {
 	}
 
 	if *candidate == lease.expected {
+		// Nothing advanced, so nothing was consumed: no generation, and no
+		// revision either, because this path skips the CAS entirely. Counting
+		// it would inflate the burn-rate denominator's numerator with
+		// operations the anchor never had to witness.
 		barrier.tip = *candidate
 		lease.completed = true
 		return nil
@@ -585,6 +589,14 @@ func (lease *nativeTBTCSignerStateAnchorLease) commit() error {
 			"native signer did not durably install the exact anchor acknowledgement",
 		))
 	}
+
+	// Count only after the acknowledgement is validated and durably read back,
+	// so the totals describe work the anchor witnessed rather than work
+	// attempted. Reaching here means exactly one compare-and-swap succeeded.
+	recordNativeTBTCSignerStateAnchorConsumption(
+		acknowledged.Generation-lease.expected.Generation,
+		1,
+	)
 
 	barrier.tip = *acknowledged
 	lease.completed = true

--- a/pkg/frost/signing/native_tbtc_signer_state_anchor_barrier.go
+++ b/pkg/frost/signing/native_tbtc_signer_state_anchor_barrier.go
@@ -506,8 +506,9 @@ func (lease *nativeTBTCSignerStateAnchorLease) commit() error {
 	if *candidate == lease.expected {
 		// Nothing advanced, so nothing was consumed: no generation, and no
 		// revision either, because this path skips the CAS entirely. Counting
-		// it would inflate the burn-rate denominator's numerator with
-		// operations the anchor never had to witness.
+		// it would inflate the burn-rate numerator with operations the
+		// anchor never had to witness.
+
 		barrier.tip = *candidate
 		lease.completed = true
 		return nil

--- a/pkg/frost/signing/native_tbtc_signer_state_anchor_barrier_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_state_anchor_barrier_test.go
@@ -343,7 +343,11 @@ func TestNativeTBTCSignerOutputBarrierDiscardsAndPoisonsOnInvokePanic(
 
 func TestNativeTBTCSignerStateAnchorBarrierCommitsBeforeCompletion(t *testing.T) {
 	resetNativeTBTCSignerStateAnchorBarrierForTest()
+	resetNativeTBTCSignerStateAnchorMetricsForTest()
 	t.Cleanup(resetNativeTBTCSignerStateAnchorBarrierForTest)
+	t.Cleanup(resetNativeTBTCSignerStateAnchorMetricsForTest)
+
+	baseGenerations, baseRevisions := NativeTBTCSignerStateAnchorConsumption()
 
 	initial := testNativeTBTCSignerStateWitnessTip(1, [32]byte{2})
 	current := initial
@@ -401,11 +405,38 @@ func TestNativeTBTCSignerStateAnchorBarrierCommitsBeforeCompletion(t *testing.T)
 	if committer.verifyCalls != 2 {
 		t.Fatal("startup and pre-operation authenticated remote reads were not required")
 	}
+
+	// The burn-rate numerator records work the anchor witnessed. A commit
+	// that advances one generation and spends one CAS revision must move
+	// both totals by exactly that amount, and only AFTER the acknowledgement
+	// has been validated and durably read back - so the totals describe
+	// work the anchor witnessed rather than work attempted.
+	gotGenerations, gotRevisions := NativeTBTCSignerStateAnchorConsumption()
+	if gotGenerations != baseGenerations+1 {
+		t.Fatalf(
+			"consumption generations after a single-step commit: got [%d], "+
+				"want [%d]",
+			gotGenerations,
+			baseGenerations+1,
+		)
+	}
+	if gotRevisions != baseRevisions+1 {
+		t.Fatalf(
+			"consumption revisions after a single-step commit: got [%d], "+
+				"want [%d]",
+			gotRevisions,
+			baseRevisions+1,
+		)
+	}
 }
 
 func TestNativeTBTCSignerStateAnchorBarrierChecksTipWithoutMutation(t *testing.T) {
 	resetNativeTBTCSignerStateAnchorBarrierForTest()
+	resetNativeTBTCSignerStateAnchorMetricsForTest()
 	t.Cleanup(resetNativeTBTCSignerStateAnchorBarrierForTest)
+	t.Cleanup(resetNativeTBTCSignerStateAnchorMetricsForTest)
+
+	baseGenerations, baseRevisions := NativeTBTCSignerStateAnchorConsumption()
 
 	initial := testNativeTBTCSignerStateWitnessTip(1, [32]byte{2})
 	current := initial
@@ -445,6 +476,27 @@ func TestNativeTBTCSignerStateAnchorBarrierChecksTipWithoutMutation(t *testing.T
 	lease.release()
 	if committer.calls != 0 {
 		t.Fatal("unchanged Rust tip unexpectedly issued a remote CAS")
+	}
+
+	// The skip-CAS branch spends nothing: an operation that advanced no
+	// generation spends no revision either, because the barrier skips the
+	// compare-and-swap when the tip is unchanged. Counting it would inflate
+	// the burn-rate numerator with operations the anchor never had to
+	// witness.
+	gotGenerations, gotRevisions := NativeTBTCSignerStateAnchorConsumption()
+	if gotGenerations != baseGenerations {
+		t.Fatalf(
+			"skip-CAS path consumed generations: got [%d], want [%d]",
+			gotGenerations,
+			baseGenerations,
+		)
+	}
+	if gotRevisions != baseRevisions {
+		t.Fatalf(
+			"skip-CAS path consumed revisions: got [%d], want [%d]",
+			gotRevisions,
+			baseRevisions,
+		)
 	}
 }
 

--- a/pkg/frost/signing/native_tbtc_signer_state_anchor_metrics.go
+++ b/pkg/frost/signing/native_tbtc_signer_state_anchor_metrics.go
@@ -65,6 +65,22 @@ var (
 	// headroom_observations_total > 0, and its rate is also the staleness
 	// signal for the two gauges.
 	nativeTBTCSignerStateAnchorHeadroomObservations atomic.Uint64
+
+	// The two consumption counters below are the burn-rate numerator. They are
+	// deliberately monotonic totals rather than levels: the headroom gauges
+	// already report a level, but that level resets at every rotation, so a
+	// rate cannot be taken across one. These do not reset, so
+	// rate(generations_consumed_total) divided by the rate of an admitted-work
+	// counter yields real burn per unit of work, across rotations.
+	//
+	// That ratio is the measurement the anchor's capacity planning currently
+	// lacks. Fault-free burn is only bounded - between k+3 and 3k+2 durable
+	// generations per signed input, because a call whose sweep prologue mutates
+	// state advances more than one generation - and every window-sizing and
+	// rotation-cadence figure derived so far is a code reading against that
+	// range rather than an observation of it.
+	nativeTBTCSignerStateAnchorGenerationsConsumed atomic.Uint64
+	nativeTBTCSignerStateAnchorRevisionsConsumed   atomic.Uint64
 )
 
 // nativeTBTCSignerStateAnchorHeadroomRecord is the immutable snapshot stored
@@ -97,6 +113,8 @@ const (
 	nativeTBTCSignerStateAnchorGenerationHeadroomMetricName   = "restartable_generation_headroom"
 	nativeTBTCSignerStateAnchorHeadroomObservationsMetricName = "headroom_observations_total"
 	nativeTBTCSignerStateAnchorRotationWarningMetricName      = "rotation_warning"
+	nativeTBTCSignerStateAnchorGenerationsConsumedMetricName  = "generations_consumed_total"
+	nativeTBTCSignerStateAnchorRevisionsConsumedMetricName    = "revisions_consumed_total"
 )
 
 // RegisterNativeTBTCSignerStateAnchorMetrics registers the state-anchor health
@@ -163,7 +181,49 @@ func nativeTBTCSignerStateAnchorMetricSources() map[string]clientinfo.Source {
 			}
 			return 1
 		},
+		nativeTBTCSignerStateAnchorGenerationsConsumedMetricName: func() float64 {
+			return float64(
+				nativeTBTCSignerStateAnchorGenerationsConsumed.Load(),
+			)
+		},
+		nativeTBTCSignerStateAnchorRevisionsConsumedMetricName: func() float64 {
+			return float64(
+				nativeTBTCSignerStateAnchorRevisionsConsumed.Load(),
+			)
+		},
 	}
+}
+
+// recordNativeTBTCSignerStateAnchorConsumption adds one anchored operation's
+// durable cost to the burn-rate totals: the generations its native call
+// advanced, and the revision its compare-and-swap spent.
+//
+// Called only after the acknowledgement has been validated and durably read
+// back, so it counts work the anchor actually witnessed rather than work
+// attempted. An operation that advanced no generation spends no revision
+// either - the barrier skips the CAS when the tip is unchanged - and is
+// counted as neither.
+func recordNativeTBTCSignerStateAnchorConsumption(
+	generations uint64,
+	revisions uint64,
+) {
+	if generations > 0 {
+		nativeTBTCSignerStateAnchorGenerationsConsumed.Add(generations)
+	}
+	if revisions > 0 {
+		nativeTBTCSignerStateAnchorRevisionsConsumed.Add(revisions)
+	}
+}
+
+// NativeTBTCSignerStateAnchorConsumption returns the burn-rate totals. Exposed
+// so a caller can assert on what the counters will report without reaching
+// into package state.
+func NativeTBTCSignerStateAnchorConsumption() (
+	generations uint64,
+	revisions uint64,
+) {
+	return nativeTBTCSignerStateAnchorGenerationsConsumed.Load(),
+		nativeTBTCSignerStateAnchorRevisionsConsumed.Load()
 }
 
 // RecordNativeTBTCSignerStateAnchorRestartableHeadroom publishes the

--- a/pkg/frost/signing/native_tbtc_signer_state_anchor_metrics.go
+++ b/pkg/frost/signing/native_tbtc_signer_state_anchor_metrics.go
@@ -72,6 +72,18 @@ var (
 type nativeTBTCSignerStateAnchorHeadroomRecord struct {
 	revisions   uint64
 	generations uint64
+	// rotationWarning travels with the headroom pair rather than being derived
+	// at scrape time because it is not a function of the pair alone: the
+	// workload term needs the node's largest local seat count, which only the
+	// readiness inventory knows. Publishing it here is what makes the warning
+	// alertable without an auditor challenge.
+	rotationWarning bool
+	// largestLocalSeatCount is retained so a publisher that has fresh headroom
+	// but no fresh inventory - the anchor commit path - can recompute the
+	// warning against the last seat count observed. Seat count only changes on
+	// DKG and retirement, both of which force a full readiness reconciliation
+	// that republishes it.
+	largestLocalSeatCount uint64
 }
 
 // nativeTBTCSignerStateAnchorMetricsApplication is the clientinfo
@@ -84,6 +96,7 @@ const (
 	nativeTBTCSignerStateAnchorRevisionHeadroomMetricName     = "restartable_revision_headroom"
 	nativeTBTCSignerStateAnchorGenerationHeadroomMetricName   = "restartable_generation_headroom"
 	nativeTBTCSignerStateAnchorHeadroomObservationsMetricName = "headroom_observations_total"
+	nativeTBTCSignerStateAnchorRotationWarningMetricName      = "rotation_warning"
 )
 
 // RegisterNativeTBTCSignerStateAnchorMetrics registers the state-anchor health
@@ -138,6 +151,18 @@ func nativeTBTCSignerStateAnchorMetricSources() map[string]clientinfo.Source {
 				nativeTBTCSignerStateAnchorHeadroomObservations.Load(),
 			)
 		},
+		// Reports 0 both when no rotation is due and when nothing has ever
+		// published, exactly as the headroom gauges do. Alerts on this gauge
+		// carry the same obligation: require headroom_observations_total > 0,
+		// or a node that has never run an anchored workflow reads the same as
+		// a healthy one.
+		nativeTBTCSignerStateAnchorRotationWarningMetricName: func() float64 {
+			record := nativeTBTCSignerStateAnchorHeadroomSignal.Load()
+			if record == nil || !record.rotationWarning {
+				return 0
+			}
+			return 1
+		},
 	}
 }
 
@@ -155,14 +180,48 @@ func nativeTBTCSignerStateAnchorMetricSources() map[string]clientinfo.Source {
 func RecordNativeTBTCSignerStateAnchorRestartableHeadroom(
 	revisions uint64,
 	generations uint64,
+	rotationWarning bool,
+	largestLocalSeatCount uint64,
 ) {
 	nativeTBTCSignerStateAnchorHeadroomSignal.Store(
 		&nativeTBTCSignerStateAnchorHeadroomRecord{
-			revisions:   revisions,
-			generations: generations,
+			revisions:             revisions,
+			generations:           generations,
+			rotationWarning:       rotationWarning,
+			largestLocalSeatCount: largestLocalSeatCount,
 		},
 	)
 	nativeTBTCSignerStateAnchorHeadroomObservations.Add(1)
+}
+
+// NativeTBTCSignerStateAnchorLargestLocalSeatCount returns the seat count that
+// travelled with the last published headroom, and whether anything has
+// published one.
+//
+// It exists for the anchor commit path, which has authenticated headroom on
+// every successful compare-and-swap but no inventory of its own. Without this
+// the commit path could publish headroom but not the warning derived from it,
+// which is how the gauge ends up refreshing only on readiness reconciliation -
+// the exact staleness this mirror is meant to remove.
+func NativeTBTCSignerStateAnchorLargestLocalSeatCount() (
+	seats uint64,
+	observed bool,
+) {
+	record := nativeTBTCSignerStateAnchorHeadroomSignal.Load()
+	if record == nil {
+		return 0, false
+	}
+	return record.largestLocalSeatCount, true
+}
+
+// NativeTBTCSignerStateAnchorRotationWarning returns the mirrored rotation
+// warning and whether anything has ever published one.
+func NativeTBTCSignerStateAnchorRotationWarning() (warning bool, observed bool) {
+	record := nativeTBTCSignerStateAnchorHeadroomSignal.Load()
+	if record == nil {
+		return false, false
+	}
+	return record.rotationWarning, true
 }
 
 // NativeTBTCSignerStateAnchorRestartableHeadroom returns the mirrored headroom

--- a/pkg/frost/signing/native_tbtc_signer_state_anchor_metrics_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_state_anchor_metrics_test.go
@@ -79,8 +79,8 @@ func TestNativeTBTCSignerStateAnchorMetrics_HeadroomGaugesMirrorTheLastReading(
 		t.Fatal("headroom reported as observed before any reading")
 	}
 
-	RecordNativeTBTCSignerStateAnchorRestartableHeadroom(4000, 3900)
-	RecordNativeTBTCSignerStateAnchorRestartableHeadroom(1234, 567)
+	RecordNativeTBTCSignerStateAnchorRestartableHeadroom(4000, 3900, false, 5)
+	RecordNativeTBTCSignerStateAnchorRestartableHeadroom(1234, 567, false, 5)
 
 	if got := nativeTBTCSignerStateAnchorMetricSourceForTest(
 		t,
@@ -121,7 +121,7 @@ func TestNativeTBTCSignerStateAnchorMetrics_ExhaustedHeadroomIsObserved(
 	resetNativeTBTCSignerStateAnchorMetricsForTest()
 	t.Cleanup(resetNativeTBTCSignerStateAnchorMetricsForTest)
 
-	RecordNativeTBTCSignerStateAnchorRestartableHeadroom(0, 0)
+	RecordNativeTBTCSignerStateAnchorRestartableHeadroom(0, 0, true, 5)
 
 	if got := nativeTBTCSignerStateAnchorMetricSourceForTest(
 		t,
@@ -142,13 +142,14 @@ func TestNativeTBTCSignerStateAnchorMetrics_RegisteredSourceNames(t *testing.T) 
 		nativeTBTCSignerStateAnchorRevisionHeadroomMetricName,
 		nativeTBTCSignerStateAnchorGenerationHeadroomMetricName,
 		nativeTBTCSignerStateAnchorHeadroomObservationsMetricName,
+		nativeTBTCSignerStateAnchorRotationWarningMetricName,
 	} {
 		if _, ok := sources[name]; !ok {
 			t.Errorf("metric source [%s] is not registered", name)
 		}
 	}
-	if len(sources) != 4 {
-		t.Errorf("registered source count: got %d want 4", len(sources))
+	if len(sources) != 5 {
+		t.Errorf("registered source count: got %d want 5", len(sources))
 	}
 	if nativeTBTCSignerStateAnchorMetricsApplication !=
 		"frost_native_signer_anchor" {
@@ -164,4 +165,53 @@ func TestRegisterNativeTBTCSignerStateAnchorMetrics_NilRegistryIsNoOp(
 	t *testing.T,
 ) {
 	RegisterNativeTBTCSignerStateAnchorMetrics(nil) // must not panic
+}
+
+// The rotation warning must be alertable from a scrape. It cannot be derived
+// from the two headroom gauges alone, because the workload term needs the
+// node's seat count - so it travels with the pair and gets its own gauge.
+func TestNativeTBTCSignerStateAnchorMetrics_RotationWarningGauge(t *testing.T) {
+	resetNativeTBTCSignerStateAnchorMetricsForTest()
+	t.Cleanup(resetNativeTBTCSignerStateAnchorMetricsForTest)
+
+	// Never published reads 0, exactly as the headroom gauges do; an alert
+	// must qualify on the observations counter to tell the two apart.
+	if got := nativeTBTCSignerStateAnchorMetricSourceForTest(
+		t,
+		nativeTBTCSignerStateAnchorRotationWarningMetricName,
+	); got != 0 {
+		t.Fatalf("rotation warning before any reading: got %v want 0", got)
+	}
+	if warning, observed :=
+		NativeTBTCSignerStateAnchorRotationWarning(); warning || observed {
+		t.Fatal("rotation warning reported as observed before any reading")
+	}
+
+	RecordNativeTBTCSignerStateAnchorRestartableHeadroom(4000, 3900, false, 7)
+	if got := nativeTBTCSignerStateAnchorMetricSourceForTest(
+		t,
+		nativeTBTCSignerStateAnchorRotationWarningMetricName,
+	); got != 0 {
+		t.Fatalf("rotation warning while healthy: got %v want 0", got)
+	}
+
+	RecordNativeTBTCSignerStateAnchorRestartableHeadroom(200, 180, true, 7)
+	if got := nativeTBTCSignerStateAnchorMetricSourceForTest(
+		t,
+		nativeTBTCSignerStateAnchorRotationWarningMetricName,
+	); got != 1 {
+		t.Fatalf("rotation warning when due: got %v want 1", got)
+	}
+	if warning, observed :=
+		NativeTBTCSignerStateAnchorRotationWarning(); !warning || !observed {
+		t.Fatalf("accessor: got (%v, %v) want (true, true)", warning, observed)
+	}
+
+	// The seat count rides along so a publisher holding fresh headroom but no
+	// inventory - the anchor commit path - can still recompute the warning.
+	if seats, observed :=
+		NativeTBTCSignerStateAnchorLargestLocalSeatCount(); !observed ||
+		seats != 7 {
+		t.Fatalf("seat count: got (%d, %v) want (7, true)", seats, observed)
+	}
 }

--- a/pkg/frost/signing/native_tbtc_signer_state_anchor_metrics_test.go
+++ b/pkg/frost/signing/native_tbtc_signer_state_anchor_metrics_test.go
@@ -143,13 +143,15 @@ func TestNativeTBTCSignerStateAnchorMetrics_RegisteredSourceNames(t *testing.T) 
 		nativeTBTCSignerStateAnchorGenerationHeadroomMetricName,
 		nativeTBTCSignerStateAnchorHeadroomObservationsMetricName,
 		nativeTBTCSignerStateAnchorRotationWarningMetricName,
+		nativeTBTCSignerStateAnchorGenerationsConsumedMetricName,
+		nativeTBTCSignerStateAnchorRevisionsConsumedMetricName,
 	} {
 		if _, ok := sources[name]; !ok {
 			t.Errorf("metric source [%s] is not registered", name)
 		}
 	}
-	if len(sources) != 5 {
-		t.Errorf("registered source count: got %d want 5", len(sources))
+	if len(sources) != 7 {
+		t.Errorf("registered source count: got %d want 7", len(sources))
 	}
 	if nativeTBTCSignerStateAnchorMetricsApplication !=
 		"frost_native_signer_anchor" {
@@ -213,5 +215,64 @@ func TestNativeTBTCSignerStateAnchorMetrics_RotationWarningGauge(t *testing.T) {
 		NativeTBTCSignerStateAnchorLargestLocalSeatCount(); !observed ||
 		seats != 7 {
 		t.Fatalf("seat count: got (%d, %v) want (7, true)", seats, observed)
+	}
+}
+
+// The burn-rate numerator. These are monotonic totals rather than levels
+// precisely because the headroom gauges reset at every rotation, so no rate can
+// be taken across one; dividing these by the admission counter yields real
+// generations and revisions per unit of work, which is the measurement the
+// anchor capacity model currently lacks.
+func TestNativeTBTCSignerStateAnchorMetrics_ConsumptionTotals(t *testing.T) {
+	baseGenerations, baseRevisions := NativeTBTCSignerStateAnchorConsumption()
+
+	// An operation that advanced nothing spends no revision either, because
+	// the barrier skips the compare-and-swap when the tip is unchanged.
+	recordNativeTBTCSignerStateAnchorConsumption(0, 0)
+	if generations, revisions :=
+		NativeTBTCSignerStateAnchorConsumption(); generations != baseGenerations ||
+		revisions != baseRevisions {
+		t.Fatalf(
+			"a non-advancing operation was counted: (%d, %d) want (%d, %d)",
+			generations,
+			revisions,
+			baseGenerations,
+			baseRevisions,
+		)
+	}
+
+	recordNativeTBTCSignerStateAnchorConsumption(2, 1)
+	recordNativeTBTCSignerStateAnchorConsumption(3, 1)
+
+	generations, revisions := NativeTBTCSignerStateAnchorConsumption()
+	if generations != baseGenerations+5 || revisions != baseRevisions+2 {
+		t.Fatalf(
+			"consumption totals: got (%d, %d) want (%d, %d)",
+			generations,
+			revisions,
+			baseGenerations+5,
+			baseRevisions+2,
+		)
+	}
+
+	if got := nativeTBTCSignerStateAnchorMetricSourceForTest(
+		t,
+		nativeTBTCSignerStateAnchorGenerationsConsumedMetricName,
+	); got != float64(baseGenerations+5) {
+		t.Fatalf(
+			"generations gauge: got %v want %v",
+			got,
+			float64(baseGenerations+5),
+		)
+	}
+	if got := nativeTBTCSignerStateAnchorMetricSourceForTest(
+		t,
+		nativeTBTCSignerStateAnchorRevisionsConsumedMetricName,
+	); got != float64(baseRevisions+2) {
+		t.Fatalf(
+			"revisions gauge: got %v want %v",
+			got,
+			float64(baseRevisions+2),
+		)
 	}
 }

--- a/pkg/tbtc/frost_native_signer_anchor_admission.go
+++ b/pkg/tbtc/frost_native_signer_anchor_admission.go
@@ -279,13 +279,18 @@ func (controller *frostNativeSignerAnchorAdmissionController) reserveDKG(
 		Generations: maximumPersistenceCalls,
 	}
 
-	return controller.reserve(
+	reservation, err := controller.reserve(
 		"FROST native DKG",
 		cost,
 		func() (frostNativeSignerAnchorCapacity, error) {
 			return controller.currentRestartableHeadroom(ctx)
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+	recordFrostNativeSignerAnchorAdmittedDKG()
+	return reservation, nil
 }
 
 func (controller *frostNativeSignerAnchorAdmissionController) reserveDKGRetirement(
@@ -459,18 +464,8 @@ func (controller *frostNativeSignerAnchorAdmissionController) reserve(
 			unreservedGenerations,
 		)
 	}
-
 	controller.reserved.Revisions += cost.Revisions
 	controller.reserved.Generations += cost.Generations
-	// The burn-rate denominator. Counted once per admitted workflow, which for
-	// pre-sign is once per input, so the anchor consumption counters divided by
-	// this yield real generations and revisions per unit of work.
-	//
-	// This is the measurement the capacity model is missing: fault-free burn is
-	// only bounded, between k+3 and 3k+2 generations per input, and every
-	// window-sizing and rotation-cadence figure so far is a code reading
-	// against that range rather than an observation of it.
-	frostNativeSignerAnchorAdmissions.Add(1)
 	return &frostNativeSignerAnchorRevisionReservation{
 		controller: controller,
 		cost:       cost,
@@ -585,11 +580,12 @@ func (reservation *frostNativeSignerAnchorRevisionReservation) Release() {
 // own lifetime, so a batch never needs more than one input's worth of
 // unconsumed window at any instant. Charging the whole batch up front was the
 // arithmetic error this replaces: at production parameters (21 inputs, 5
-// signing attempts) it admitted at most four local seats. Signers are
-// equal-weighted, so a hundred-seat wallet shared by around twenty operators
-// gives every operator about five - meaning that ceiling excluded every
-// operator, not merely the larger ones, and left formed wallets unable to
-// sweep the deposits they had already received.
+// signing attempts) it admitted at most four local seats. The sortition is
+// stake-weighted with replacement and has no per-operator cap, so a
+// hundred-seat wallet shared by roughly twenty operators gives the average
+// holder about five seats and a large staker holds many more - meaning that
+// ceiling excluded every operator, not merely the larger ones, and left
+// formed wallets unable to sweep the deposits they had already received.
 //
 // A ceiling still exists in principle, because both windows are finite. One
 // input costs 20*seats+6 revisions and 40*seats+15 generations, so the
@@ -871,14 +867,14 @@ func frostNativeSignerAnchorLargestAdmissibleWorkflowCost(
 	return cost, true
 }
 
-// FROST native signer anchor admission rejection counters.
+// FROST native signer anchor admission counters.
 //
 // A node that stops admitting FROST work does so silently: the refusals reach
 // the log wrapped inside a generic wallet-action failure, and nothing anchored
 // is registered with clientinfo at all, so a monitoring system cannot tell a
 // node that is refusing every signing request from one that simply has not been
-// asked. These process-wide cumulative counters make each refusal cause
-// countable on its own, because the six causes need six different responses:
+// asked. The six refusal counters make each cause countable on its own,
+// because the six causes need six different responses:
 //
 //   - seatCeiling is a CONFIGURATION signal. It never clears on its own and no
 //     rotation fixes it: this node holds more local seats than the certified
@@ -913,9 +909,28 @@ func frostNativeSignerAnchorLargestAdmissibleWorkflowCost(
 //     including the first input's, because at that point the relay has already
 //     happened either way.
 //
-// They follow the roast_interactive_signing_metrics.go pattern, are emitted in
-// every build, and stay at zero until an admission is actually refused - so
-// they are inert by default and registering them activates no behavior.
+// The three admission counters are the burn-rate denominators that make the
+// refusal counters usable. A single "admitted workflows" total would not line
+// up with what the consumption counters are reporting per unit, because each
+// workflow class has its own admission unit - one input, one batch's relay
+// gate, one DKG - so the counters are split along the same axes as their
+// consumption:
+//
+//   - frostNativeSignerAnchorAdmittedPresignInputs is the per-input
+//     denominator; the anchor consumption totals divided by this yield real
+//     generations and revisions per signed input.
+//   - frostNativeSignerAnchorAdmittedPresignRelayGates is the per-batch
+//     denominator for the up-front authorization relay gate; authorize()
+//     takes a one-input reservation and releases it before the per-input
+//     loop takes over, so a batch refused at input 7 has already incremented
+//     this counter.
+//   - frostNativeSignerAnchorAdmittedDKGs is the per-DKG denominator; each
+//     admitted native DKG workflow increments it once.
+//
+// All nine counters follow the roast_interactive_signing_metrics.go pattern,
+// are emitted in every build, and stay at zero until something is actually
+// recorded - so they are inert by default and registering them activates no
+// behavior.
 var (
 	frostNativeSignerAnchorSeatCeilingRejections           atomic.Uint64
 	frostNativeSignerAnchorReservationContentionRejections atomic.Uint64
@@ -924,14 +939,22 @@ var (
 	frostNativeSignerAnchorPoisonedRejections              atomic.Uint64
 	frostNativeSignerAnchorPreSignInputRejections          atomic.Uint64
 
-	// frostNativeSignerAnchorAdmissions counts admitted workflows - the
-	// denominator for the anchor consumption totals published by
-	// pkg/frost/signing. Every other counter here records a refusal; this one
-	// records work that was allowed to proceed, without which the consumption
-	// totals have no unit.
-	frostNativeSignerAnchorAdmissions atomic.Uint64
+	// frostNativeSignerAnchorAdmittedPresignInputs counts admitted pre-sign
+	// transaction inputs. This is the burn-rate denominator for pre-sign: the
+	// anchor consumption totals divided by this yield real generations and
+	// revisions per signed input. Admitted in admitInput, after the per-input
+	// reservation succeeds.
+	frostNativeSignerAnchorAdmittedPresignInputs     atomic.Uint64
+	// frostNativeSignerAnchorAdmittedPresignRelayGates counts admitted
+	// pre-sign authorization relay gates. authorize() takes a one-input
+	// reservation up front to gate the on-chain relay of an authorization, so
+	// this counts batches the relay gate admitted, not inputs the loop
+	// admitted.
+	frostNativeSignerAnchorAdmittedPresignRelayGates atomic.Uint64
+	// frostNativeSignerAnchorAdmittedDKGs counts admitted native DKG
+	// workflows. Admitted in reserveDKG, after the DKG reservation succeeds.
+	frostNativeSignerAnchorAdmittedDKGs              atomic.Uint64
 )
-
 // frostNativeSignerAnchorAdmissionMetricsApplication is the clientinfo
 // application-label prefix; the registry concatenates it with each per-source
 // name, so the final labels look like
@@ -945,7 +968,9 @@ const (
 	frostNativeSignerAnchorRotationFloorMetricName         = "rotation_floor_rejected_total"
 	frostNativeSignerAnchorPoisonedMetricName              = "poisoned_rejected_total"
 	frostNativeSignerAnchorPreSignInputMetricName          = "pre_sign_input_rejected_total"
-	frostNativeSignerAnchorAdmittedMetricName              = "admitted_total"
+	frostNativeSignerAnchorAdmittedPresignInputsMetricName     = "admitted_presign_input_total"
+	frostNativeSignerAnchorAdmittedPresignRelayGatesMetricName = "admitted_presign_relay_gate_total"
+	frostNativeSignerAnchorAdmittedDKGsMetricName              = "admitted_dkg_total"
 )
 
 // RegisterFrostNativeSignerAnchorAdmissionMetrics registers the cumulative
@@ -993,8 +1018,20 @@ func RegisterFrostNativeSignerAnchorAdmissionMetrics(
 					frostNativeSignerAnchorPreSignInputRejections.Load(),
 				)
 			},
-			frostNativeSignerAnchorAdmittedMetricName: func() float64 {
-				return float64(frostNativeSignerAnchorAdmissions.Load())
+			frostNativeSignerAnchorAdmittedPresignInputsMetricName: func() float64 {
+				return float64(
+					frostNativeSignerAnchorAdmittedPresignInputs.Load(),
+				)
+			},
+			frostNativeSignerAnchorAdmittedPresignRelayGatesMetricName: func() float64 {
+				return float64(
+					frostNativeSignerAnchorAdmittedPresignRelayGates.Load(),
+				)
+			},
+			frostNativeSignerAnchorAdmittedDKGsMetricName: func() float64 {
+				return float64(
+					frostNativeSignerAnchorAdmittedDKGs.Load(),
+				)
 			},
 		},
 	)
@@ -1040,6 +1077,29 @@ func recordFrostNativeSignerAnchorPreSignInputRejection() {
 	frostNativeSignerAnchorPreSignInputRejections.Add(1)
 }
 
+// recordFrostNativeSignerAnchorAdmittedPresignInput marks one pre-sign
+// transaction input admitted by the per-input reservation. Paired with
+// frostNativeSignerAnchorPreSignInputRejections, the two together let a
+// monitoring system distinguish "admitted N inputs" from "admitted N and
+// refused M of them".
+func recordFrostNativeSignerAnchorAdmittedPresignInput() {
+	frostNativeSignerAnchorAdmittedPresignInputs.Add(1)
+}
+
+// recordFrostNativeSignerAnchorAdmittedPresignRelayGate marks one pre-sign
+// authorization relay gate admitted by the up-front reservation. authorize()
+// takes the gate while it relays and finalizes the authorization on chain,
+// and releases it before the per-input reservations take over.
+func recordFrostNativeSignerAnchorAdmittedPresignRelayGate() {
+	frostNativeSignerAnchorAdmittedPresignRelayGates.Add(1)
+}
+
+// recordFrostNativeSignerAnchorAdmittedDKG marks one native DKG workflow
+// admitted by the DKG reservation.
+func recordFrostNativeSignerAnchorAdmittedDKG() {
+	frostNativeSignerAnchorAdmittedDKGs.Add(1)
+}
+
 // resetFrostNativeSignerAnchorAdmissionMetricsForTest clears the cumulative
 // counters. Exposed only for the package's own tests; not a production helper.
 func resetFrostNativeSignerAnchorAdmissionMetricsForTest() {
@@ -1049,4 +1109,7 @@ func resetFrostNativeSignerAnchorAdmissionMetricsForTest() {
 	frostNativeSignerAnchorRotationFloorRejections.Store(0)
 	frostNativeSignerAnchorPoisonedRejections.Store(0)
 	frostNativeSignerAnchorPreSignInputRejections.Store(0)
+	frostNativeSignerAnchorAdmittedPresignInputs.Store(0)
+	frostNativeSignerAnchorAdmittedPresignRelayGates.Store(0)
+	frostNativeSignerAnchorAdmittedDKGs.Store(0)
 }

--- a/pkg/tbtc/frost_native_signer_anchor_admission.go
+++ b/pkg/tbtc/frost_native_signer_anchor_admission.go
@@ -462,6 +462,15 @@ func (controller *frostNativeSignerAnchorAdmissionController) reserve(
 
 	controller.reserved.Revisions += cost.Revisions
 	controller.reserved.Generations += cost.Generations
+	// The burn-rate denominator. Counted once per admitted workflow, which for
+	// pre-sign is once per input, so the anchor consumption counters divided by
+	// this yield real generations and revisions per unit of work.
+	//
+	// This is the measurement the capacity model is missing: fault-free burn is
+	// only bounded, between k+3 and 3k+2 generations per input, and every
+	// window-sizing and rotation-cadence figure so far is a code reading
+	// against that range rather than an observation of it.
+	frostNativeSignerAnchorAdmissions.Add(1)
 	return &frostNativeSignerAnchorRevisionReservation{
 		controller: controller,
 		cost:       cost,
@@ -914,6 +923,13 @@ var (
 	frostNativeSignerAnchorRotationFloorRejections         atomic.Uint64
 	frostNativeSignerAnchorPoisonedRejections              atomic.Uint64
 	frostNativeSignerAnchorPreSignInputRejections          atomic.Uint64
+
+	// frostNativeSignerAnchorAdmissions counts admitted workflows - the
+	// denominator for the anchor consumption totals published by
+	// pkg/frost/signing. Every other counter here records a refusal; this one
+	// records work that was allowed to proceed, without which the consumption
+	// totals have no unit.
+	frostNativeSignerAnchorAdmissions atomic.Uint64
 )
 
 // frostNativeSignerAnchorAdmissionMetricsApplication is the clientinfo
@@ -929,6 +945,7 @@ const (
 	frostNativeSignerAnchorRotationFloorMetricName         = "rotation_floor_rejected_total"
 	frostNativeSignerAnchorPoisonedMetricName              = "poisoned_rejected_total"
 	frostNativeSignerAnchorPreSignInputMetricName          = "pre_sign_input_rejected_total"
+	frostNativeSignerAnchorAdmittedMetricName              = "admitted_total"
 )
 
 // RegisterFrostNativeSignerAnchorAdmissionMetrics registers the cumulative
@@ -975,6 +992,9 @@ func RegisterFrostNativeSignerAnchorAdmissionMetrics(
 				return float64(
 					frostNativeSignerAnchorPreSignInputRejections.Load(),
 				)
+			},
+			frostNativeSignerAnchorAdmittedMetricName: func() float64 {
+				return float64(frostNativeSignerAnchorAdmissions.Load())
 			},
 		},
 	)

--- a/pkg/tbtc/frost_native_signer_anchor_admission.go
+++ b/pkg/tbtc/frost_native_signer_anchor_admission.go
@@ -576,10 +576,11 @@ func (reservation *frostNativeSignerAnchorRevisionReservation) Release() {
 // own lifetime, so a batch never needs more than one input's worth of
 // unconsumed window at any instant. Charging the whole batch up front was the
 // arithmetic error this replaces: at production parameters (21 inputs, 5
-// signing attempts) it admitted at most four local seats, which on a
-// hundred-seat wallet shared by around twenty operators excluded most of the
-// stake-weighted seats and left formed wallets unable to sweep the deposits
-// they had already received.
+// signing attempts) it admitted at most four local seats. Signers are
+// equal-weighted, so a hundred-seat wallet shared by around twenty operators
+// gives every operator about five - meaning that ceiling excluded every
+// operator, not merely the larger ones, and left formed wallets unable to
+// sweep the deposits they had already received.
 //
 // A ceiling still exists in principle, because both windows are finite. One
 // input costs 20*seats+6 revisions and 40*seats+15 generations, so the

--- a/pkg/tbtc/frost_native_signer_anchor_admission_test.go
+++ b/pkg/tbtc/frost_native_signer_anchor_admission_test.go
@@ -505,6 +505,45 @@ func TestFrostNativeSignerAnchorAdmissionController_AtomicallyReservesNearWarnin
 	); err != nil {
 		t.Fatalf("released reservation remained charged: [%v]", err)
 	}
+
+	// The DKG admit counter is incremented only by reserveDKG, not by the
+	// controller-level reservePreSign calls above, so a successful native
+	// DKG reservation must be the exact amount it moves.
+	baseDKGs := frostNativeSignerAnchorAdmittedDKGs.Load()
+	dkgReservation, err := controller.reserveDKG(
+		context.Background(),
+		1,
+	)
+	if err != nil {
+		t.Fatalf("native DKG reservation was refused: [%v]", err)
+	}
+	defer dkgReservation.Release()
+	if got := frostNativeSignerAnchorAdmittedDKGs.Load(); got != baseDKGs+1 {
+		t.Fatalf(
+			"native DKG admission counter moved by [%d], want [1]",
+			got-baseDKGs,
+		)
+	}
+
+	// The pre-sign admit counters are incremented by the gate (admitInput and
+	// authorize), not by the controller-level reservePreSign calls in this
+	// test, so they must stay at zero. A counter that bumps on the wrong call
+	// site would burn a per-input or per-batch denominator the operator has
+	// no way to reconstruct from the calls actually made.
+	if got := frostNativeSignerAnchorAdmittedPresignInputs.Load(); got != 0 {
+		t.Fatalf(
+			"controller-level reservePreSign bumped the gate-level pre-sign "+
+				"input counter to [%d]; only gate.admitInput must",
+			got,
+		)
+	}
+	if got := frostNativeSignerAnchorAdmittedPresignRelayGates.Load(); got != 0 {
+		t.Fatalf(
+			"controller-level reservePreSign bumped the gate-level pre-sign "+
+				"relay-gate counter to [%d]; only gate.authorize must",
+			got,
+		)
+	}
 }
 
 func TestFrostNativeSignerAnchorAdmissionController_ContentionSaturatesAvailableHeadroom(
@@ -599,6 +638,34 @@ func TestFrostNativeSignerAnchorAdmissionController_ContentionSaturatesAvailable
 		t.Fatalf("released temporary reservation still blocked retry: [%v]", err)
 	}
 	retry.Release()
+
+	// Two controller-level reservePreSign reservations succeeded, two were
+	// refused. None of them went through gate.admitInput or gate.authorize,
+	// and none went through reserveDKG, so every admission counter must
+	// stay at zero. A counter that bumps on the wrong call site would burn
+	// a per-input or per-batch denominator the operator has no way to
+	// reconstruct from the calls actually made.
+	if got := frostNativeSignerAnchorAdmittedPresignInputs.Load(); got != 0 {
+		t.Fatalf(
+			"controller-level reservePreSign bumped the gate-level pre-sign "+
+				"input counter to [%d]; only gate.admitInput must",
+			got,
+		)
+	}
+	if got := frostNativeSignerAnchorAdmittedPresignRelayGates.Load(); got != 0 {
+		t.Fatalf(
+			"controller-level reservePreSign bumped the gate-level pre-sign "+
+				"relay-gate counter to [%d]; only gate.authorize must",
+			got,
+		)
+	}
+	if got := frostNativeSignerAnchorAdmittedDKGs.Load(); got != 0 {
+		t.Fatalf(
+			"controller-level reservePreSign bumped the native DKG "+
+				"admission counter to [%d]; only reserveDKG must",
+			got,
+		)
+	}
 }
 
 func TestFrostNativeSignerAnchorAdmissionController_RejectsStaleReadinessHeadroom(
@@ -761,6 +828,18 @@ func TestFrostNativeSignerAnchorAdmissionController_RefusesWhilePoisoned(
 	if preSignInput := frostNativeSignerAnchorPreSignInputRejections.Load(); preSignInput != 0 {
 		t.Fatalf("pre-sign input rejections counted [%d]", preSignInput)
 	}
+	// Every reservation in this test was refused, so no admission counter
+	// may have moved. The DKG admission counter in particular only fires on
+	// a successful reserveDKG, so a poisoned DKG reservation that bumped
+	// it would make the burn-rate denominator count work that never
+	// actually proceeded.
+	if got := frostNativeSignerAnchorAdmittedDKGs.Load(); got != 0 {
+		t.Fatalf(
+			"poisoned reservations bumped the native DKG admission "+
+				"counter to [%d]; only successful reserveDKG must",
+			got,
+		)
+	}
 
 	// The poison was the only thing refusing: with it cleared the identical
 	// reservation is admitted, so the refusals above cannot be explained by
@@ -777,6 +856,27 @@ func TestFrostNativeSignerAnchorAdmissionController_RefusesWhilePoisoned(
 		t.Fatalf("healthy anchor refused an admissible workflow: [%v]", err)
 	}
 	reservation.Release()
+
+	// The recovery reservation also went through controller-level
+	// reservePreSign, not through gate.admitInput, gate.authorize, or
+	// reserveDKG, so the per-workflow admission counters must still be at
+	// zero. A successful reservation that bumped the gate-level counters
+	// would tell operators a per-input or per-batch admission happened
+	// when only a controller-level reservation did.
+	if got := frostNativeSignerAnchorAdmittedPresignInputs.Load(); got != 0 {
+		t.Fatalf(
+			"controller-level reservePreSign bumped the gate-level "+
+				"pre-sign input counter to [%d]; only gate.admitInput must",
+			got,
+		)
+	}
+	if got := frostNativeSignerAnchorAdmittedPresignRelayGates.Load(); got != 0 {
+		t.Fatalf(
+			"controller-level reservePreSign bumped the gate-level "+
+				"pre-sign relay-gate counter to [%d]; only gate.authorize must",
+			got,
+		)
+	}
 
 	resetFrostNativeSignerAnchorAdmissionMetricsForTest()
 }
@@ -1057,6 +1157,31 @@ func TestFrostNativeSignerAnchorAdmissionRefusalsNameARemedy(t *testing.T) {
 		{
 			name:     "pre-sign input",
 			counted:  frostNativeSignerAnchorPreSignInputRejections.Load(),
+			expected: 0,
+		},
+		// Every reserveDKG call in this test was refused on a refusal path,
+		// so the native DKG admission counter must stay at zero. A counter
+		// that bumps on a refused reservation would tell operators that a
+		// DKG workflow was admitted when the seat count or window said it
+		// could not be.
+		{
+			name:     "admitted DKG",
+			counted:  frostNativeSignerAnchorAdmittedDKGs.Load(),
+			expected: 0,
+		},
+		// Nothing here went through gate.admitInput or gate.authorize, so the
+		// gate-level pre-sign admission counters must stay at zero. A counter
+		// that bumps on a controller-level reservation would tell operators
+		// a per-input or per-batch admission happened when only a raw
+		// reservation did.
+		{
+			name:     "admitted pre-sign input",
+			counted:  frostNativeSignerAnchorAdmittedPresignInputs.Load(),
+			expected: 0,
+		},
+		{
+			name:     "admitted pre-sign relay gate",
+			counted:  frostNativeSignerAnchorAdmittedPresignRelayGates.Load(),
 			expected: 0,
 		},
 	} {

--- a/pkg/tbtc/frost_native_signer_anchor_binding.go
+++ b/pkg/tbtc/frost_native_signer_anchor_binding.go
@@ -475,6 +475,7 @@ func (binding *frostNativeSignerAnchorBinding) installAcknowledgementLocked(
 			"native signer did not durably install the exact signed acknowledgement",
 		)
 	}
+	binding.publishRestartableHeadroomLocked(readback)
 	return readback, nil
 }
 
@@ -682,6 +683,58 @@ func (binding *frostNativeSignerAnchorBinding) restartableGenerationHeadroom(
 		)
 	}
 	return FrostNativeSignerAnchorMaximumHistoryProofEntries - distance, nil
+}
+
+// publishRestartableHeadroomLocked mirrors the headroom carried by a tip the
+// anchor has just acknowledged.
+//
+// Without this the mirror refreshes only when a full readiness reconciliation
+// succeeds, so a node that is signing steadily and a node that has stalled
+// look identical at the scrape until the next reconciliation - and pre-sign
+// authorization caches readiness per finality window, so an entire authorized
+// batch can burn window invisibly inside one window. Every successful
+// compare-and-swap already holds an authenticated tip, which is precisely when
+// these numbers are both fresh and free.
+//
+// The rotation warning is recomputed from the seat count that travelled with
+// the previous publication, because this path has authenticated headroom but
+// no inventory. Seat count only changes on DKG and retirement, both of which
+// force a full reconciliation that republishes it.
+//
+// Failure to compute either half leaves the previous mirror value standing
+// rather than publishing a partial pair: the two are only meaningful together,
+// and a stale pair is more honest than a half-fresh one. The caller must hold
+// the binding mutex.
+func (binding *frostNativeSignerAnchorBinding) publishRestartableHeadroomLocked(
+	tip *frostsigning.NativeTBTCSignerStateWitnessTip,
+) {
+	if binding == nil || tip == nil {
+		return
+	}
+	revisionHeadroom, err := binding.restartableRevisionHeadroom(
+		tip.AnchorServiceEpoch,
+		tip.AnchorRevision,
+	)
+	if err != nil {
+		return
+	}
+	generationHeadroom, err := binding.restartableGenerationHeadroom(
+		tip.Generation,
+	)
+	if err != nil {
+		return
+	}
+	seats, _ := frostsigning.NativeTBTCSignerStateAnchorLargestLocalSeatCount()
+	frostsigning.RecordNativeTBTCSignerStateAnchorRestartableHeadroom(
+		revisionHeadroom,
+		generationHeadroom,
+		frostNativeSignerAnchorWorkloadRotationWarning(
+			revisionHeadroom,
+			generationHeadroom,
+			seats,
+		),
+		seats,
+	)
 }
 
 func (binding *frostNativeSignerAnchorBinding) localTipMatchesRemoteRecord(

--- a/pkg/tbtc/frost_native_signer_anchor_binding.go
+++ b/pkg/tbtc/frost_native_signer_anchor_binding.go
@@ -563,6 +563,7 @@ func (binding *frostNativeSignerAnchorBinding) recoverAcknowledgementLocked(
 			"native signer did not durably recover the exact signed acknowledgement",
 		)
 	}
+	binding.publishRestartableHeadroomLocked(readback)
 	return readback, nil
 }
 

--- a/pkg/tbtc/frost_native_signer_anchor_binding_test.go
+++ b/pkg/tbtc/frost_native_signer_anchor_binding_test.go
@@ -779,3 +779,65 @@ func setTestAnchorBindingTipAnchor(
 	tip.AnchorEventRoot = reference.EventRoot
 	tip.AnchorAcknowledgementDigest = reference.AcknowledgementDigest
 }
+
+// Headroom must refresh when the anchor acknowledges a tip, not only when a
+// full readiness reconciliation succeeds. Without this a node signing steadily
+// and a node that has stalled are indistinguishable at the scrape, and pre-sign
+// authorization caches readiness per finality window, so an entire authorized
+// batch can burn window invisibly inside one window.
+func TestFrostNativeSignerAnchorBindingPublishesHeadroomOnAcknowledgement(
+	t *testing.T,
+) {
+	fixture := newTestAnchorBindingFixture(t, false)
+
+	// The mirror is process-global and its reset helper is unexported, so this
+	// test establishes its own baseline rather than clearing it. Every
+	// assertion below is relative to this publication.
+	//
+	// It also supplies the seat count the commit path reuses: that path has
+	// authenticated headroom but no inventory of its own.
+	frostsigning.RecordNativeTBTCSignerStateAnchorRestartableHeadroom(
+		4096,
+		4096,
+		false,
+		4,
+	)
+
+	tip := fixture.tip
+	tip.AnchorServiceEpoch = fixture.floor.ServiceEpoch
+	tip.AnchorRevision = fixture.floor.Revision + 96
+	tip.Generation = fixture.floor.Checkpoint.Generation + 96
+	fixture.binding.publishRestartableHeadroomLocked(&tip)
+
+	revisions, generations, observed :=
+		frostsigning.NativeTBTCSignerStateAnchorRestartableHeadroom()
+	if !observed ||
+		revisions != FrostNativeSignerAnchorMaximumHistoryEvents-96 ||
+		generations != FrostNativeSignerAnchorMaximumHistoryProofEntries-96 {
+		t.Fatalf(
+			"acknowledged tip did not refresh the headroom mirror: (%d, %d, %v)",
+			revisions,
+			generations,
+			observed,
+		)
+	}
+	if seats, _ :=
+		frostsigning.NativeTBTCSignerStateAnchorLargestLocalSeatCount(); seats != 4 {
+		t.Fatalf("seat count was not carried forward: got %d want 4", seats)
+	}
+
+	// A tip outside the certified floor leaves the previous reading standing
+	// rather than publishing a partial or misleading pair.
+	before, _, _ := frostsigning.NativeTBTCSignerStateAnchorRestartableHeadroom()
+	outside := tip
+	outside.AnchorServiceEpoch = fixture.floor.ServiceEpoch + 1
+	fixture.binding.publishRestartableHeadroomLocked(&outside)
+	if after, _, _ :=
+		frostsigning.NativeTBTCSignerStateAnchorRestartableHeadroom(); after != before {
+		t.Fatalf(
+			"unauthenticated tip overwrote the mirror: got %d want %d",
+			after,
+			before,
+		)
+	}
+}

--- a/pkg/tbtc/frost_native_signer_anchor_binding_test.go
+++ b/pkg/tbtc/frost_native_signer_anchor_binding_test.go
@@ -825,9 +825,19 @@ func TestFrostNativeSignerAnchorBindingPublishesHeadroomOnAcknowledgement(
 		frostsigning.NativeTBTCSignerStateAnchorLargestLocalSeatCount(); seats != 4 {
 		t.Fatalf("seat count was not carried forward: got %d want 4", seats)
 	}
+	if warning, observed :=
+		frostsigning.NativeTBTCSignerStateAnchorRotationWarning(); !observed ||
+		warning {
+		t.Fatalf(
+			"healthy acknowledgement did not clear the rotation warning mirror: (%v, %v)",
+			warning,
+			observed,
+		)
+	}
 
 	// A tip outside the certified floor leaves the previous reading standing
 	// rather than publishing a partial or misleading pair.
+
 	before, _, _ := frostsigning.NativeTBTCSignerStateAnchorRestartableHeadroom()
 	outside := tip
 	outside.AnchorServiceEpoch = fixture.floor.ServiceEpoch + 1
@@ -838,6 +848,41 @@ func TestFrostNativeSignerAnchorBindingPublishesHeadroomOnAcknowledgement(
 			"unauthenticated tip overwrote the mirror: got %d want %d",
 			after,
 			before,
+		)
+	}
+
+	// A tip at the rotation floor (256 generations of restartable history
+	// remaining) flips the warning gauge back on: the mirror has to track
+	// that as faithfully as it tracks the healthy reading, or an operator
+	// staring at the scrape will not see a node that is about to stop
+	// admitting its own input.
+	near := tip
+	near.AnchorRevision = fixture.floor.Revision +
+		(FrostNativeSignerAnchorMaximumHistoryEvents -
+			FrostNativeSignerAnchorRotationWarningHeadroom)
+	near.Generation = fixture.floor.Checkpoint.Generation +
+		(FrostNativeSignerAnchorMaximumHistoryProofEntries -
+			FrostNativeSignerAnchorRotationWarningHeadroom)
+	fixture.binding.publishRestartableHeadroomLocked(&near)
+
+	revisions, generations, observed =
+		frostsigning.NativeTBTCSignerStateAnchorRestartableHeadroom()
+	if !observed ||
+		revisions != FrostNativeSignerAnchorRotationWarningHeadroom ||
+		generations != FrostNativeSignerAnchorRotationWarningHeadroom {
+		t.Fatalf(
+			"near-floor tip did not refresh the headroom mirror: (%d, %d, %v)",
+			revisions,
+			generations,
+			observed,
+		)
+	}
+	if warning, observed := frostsigning.NativeTBTCSignerStateAnchorRotationWarning(); !observed ||
+		!warning {
+		t.Fatalf(
+			"near-floor acknowledgement did not raise the rotation warning mirror: (%v, %v)",
+			warning,
+			observed,
 		)
 	}
 }

--- a/pkg/tbtc/frost_native_signer_anchor_observability_test.go
+++ b/pkg/tbtc/frost_native_signer_anchor_observability_test.go
@@ -227,11 +227,15 @@ func (stub *stubFrostProductionSignerReadinessVerifier) verifyFrostProductionSig
 func readinessSnapshotWithHeadroom(
 	revisions uint64,
 	generations uint64,
+	rotationWarning bool,
+	largestLocalSeatCount uint64,
 ) *frostProductionSignerReadinessSnapshot {
 	return &frostProductionSignerReadinessSnapshot{
 		Inventory: &frostNativeSignerInventorySnapshot{
 			RestartableRevisionHeadroom:   revisions,
 			RestartableGenerationHeadroom: generations,
+			AnchorRotationWarning:         rotationWarning,
+			LargestLocalSeatCount:         largestLocalSeatCount,
 		},
 	}
 }
@@ -249,7 +253,7 @@ func publishFrostNativeSignerAnchorHeadroomForTest(
 	t.Helper()
 	if _, err := newFrostNativeSignerAnchorHeadroomObserver(
 		&stubFrostProductionSignerReadinessVerifier{
-			snapshot: readinessSnapshotWithHeadroom(revisions, generations),
+			snapshot: readinessSnapshotWithHeadroom(revisions, generations, false, 0),
 		},
 	).verifyFrostProductionSignerReadiness(
 		context.Background(),
@@ -290,7 +294,7 @@ func TestFrostNativeSignerAnchorHeadroomObserver_PublishesOnSuccess(
 	t *testing.T,
 ) {
 	stub := &stubFrostProductionSignerReadinessVerifier{
-		snapshot: readinessSnapshotWithHeadroom(3971, 3820),
+		snapshot: readinessSnapshotWithHeadroom(3971, 3820, true, 42),
 	}
 	observer := newFrostNativeSignerAnchorHeadroomObserver(stub)
 
@@ -315,6 +319,22 @@ func TestFrostNativeSignerAnchorHeadroomObserver_PublishesOnSuccess(
 		3971,
 		3820,
 	)
+	warning, warningObserved := frostsigning.NativeTBTCSignerStateAnchorRotationWarning()
+	if !warningObserved || !warning {
+		t.Errorf(
+			"rotation warning mirror is (%v, %v), want (true, true)",
+			warning,
+			warningObserved,
+		)
+	}
+	seats, seatsObserved := frostsigning.NativeTBTCSignerStateAnchorLargestLocalSeatCount()
+	if !seatsObserved || seats != 42 {
+		t.Errorf(
+			"largest local seat count mirror is (%d, %v), want (42, true)",
+			seats,
+			seatsObserved,
+		)
+	}
 }
 
 // Zero is the value that means "the certified windows are exhausted". A failed
@@ -332,7 +352,7 @@ func TestFrostNativeSignerAnchorHeadroomObserver_FailurePublishesNothing(
 		{
 			name: "reconciliation error",
 			stub: &stubFrostProductionSignerReadinessVerifier{
-				snapshot: readinessSnapshotWithHeadroom(0, 0),
+				snapshot: readinessSnapshotWithHeadroom(0, 0, false, 0),
 				err:      errors.New("anchor service unreachable"),
 			},
 		},
@@ -375,7 +395,7 @@ func TestFrostNativeSignerAnchorHeadroomObserver_UnchangedDelegatesOnly(
 	}
 	observer := newFrostNativeSignerAnchorHeadroomObserver(stub)
 
-	snapshot := readinessSnapshotWithHeadroom(4096, 4096)
+	snapshot := readinessSnapshotWithHeadroom(4096, 4096, false, 0)
 	err := observer.verifyFrostProductionSignerReadinessUnchanged(
 		context.Background(),
 		snapshot,

--- a/pkg/tbtc/frost_native_signer_anchor_per_input_admission_test.go
+++ b/pkg/tbtc/frost_native_signer_anchor_per_input_admission_test.go
@@ -686,4 +686,43 @@ func TestFrostPreSignAuthorizationGate_AdmitInputChargesOneInput(t *testing.T) {
 	}(); reserved != (frostNativeSignerAnchorCapacity{}) {
 		t.Fatalf("[%+v] stayed reserved after the sweep", reserved)
 	}
+
+	// The pre-sign input admission counter is incremented by exactly one for
+	// every successful gate.admitInput. The loop above admitted a full sweep
+	// (frostPreSignAuthorizationMaximumInputs inputs), so the counter must
+	// match. A counter that fires on the wrong call site would burn a
+	// per-input denominator the operator has no way to reconstruct from the
+	// inputs the gate actually admitted.
+	if got := frostNativeSignerAnchorAdmittedPresignInputs.Load(); got !=
+		uint64(frostPreSignAuthorizationMaximumInputs) {
+		t.Fatalf(
+			"pre-sign input admissions counted [%d], expected [%d] (one per "+
+				"admitted input of a full sweep)",
+			got,
+			frostPreSignAuthorizationMaximumInputs,
+		)
+	}
+
+	// The pre-sign relay-gate admission counter is incremented only by
+	// gate.authorize, not by the controller-level reservePreSign this test
+	// uses to set up the relay reservation. A counter that bumps on a
+	// controller-level reservation would tell operators a per-batch relay
+	// gate was admitted when the authorize path was never reached.
+	if got := frostNativeSignerAnchorAdmittedPresignRelayGates.Load(); got != 0 {
+		t.Fatalf(
+			"controller-level reservePreSign bumped the pre-sign relay-gate "+
+				"admission counter to [%d]; only gate.authorize must",
+			got,
+		)
+	}
+
+	// The native DKG admission counter is incremented only by reserveDKG,
+	// which the gate never calls, so it must stay at zero.
+	if got := frostNativeSignerAnchorAdmittedDKGs.Load(); got != 0 {
+		t.Fatalf(
+			"gate.admitInput bumped the native DKG admission counter to "+
+				"[%d]; only reserveDKG must",
+			got,
+		)
+	}
 }

--- a/pkg/tbtc/frost_native_signer_anchor_trust.go
+++ b/pkg/tbtc/frost_native_signer_anchor_trust.go
@@ -946,10 +946,18 @@ func frostNativeSignerAnchorTrustValidateReferenceDescendant(
 		}
 		return nil
 	}
+	// The store fingerprint is checked here to match the Rust engine's
+	// descendant validator, which rejects a fingerprint change across
+	// generations. Both trees must agree on which references are admissible:
+	// where they disagree, one accepts a chain the other refuses on every
+	// store open, which is a fail-closed brick with no truncation path back.
 	if candidate.PreviousEventRoot == [32]byte{} ||
-		candidate.Checkpoint.Generation < floor.Checkpoint.Generation {
+		candidate.Checkpoint.Generation < floor.Checkpoint.Generation ||
+		candidate.Checkpoint.StoreFingerprint !=
+			floor.Checkpoint.StoreFingerprint {
 		return fmt.Errorf(
-			"later reference is unlinked or rolls back its checkpoint generation",
+			"later reference is unlinked, rolls back its checkpoint " +
+				"generation, or changes its store fingerprint",
 		)
 	}
 	if candidate.Checkpoint.Generation == floor.Checkpoint.Generation &&

--- a/pkg/tbtc/frost_native_signer_anchor_trust_startup.go
+++ b/pkg/tbtc/frost_native_signer_anchor_trust_startup.go
@@ -374,6 +374,28 @@ func reconstructFrostNativeSignerAnchorTrustPriorHead(
 		)
 	}
 
+	// A durable trust head ahead of the configured pin means the artifacts on
+	// disk are older than this signer store - the configuration was rolled back
+	// while the store was not. That already fails closed a few lines below,
+	// because every rotation changes the activation manifest hash and so the
+	// endpoint identities cannot match; naming the condition here only turns an
+	// oblique identity mismatch into a diagnosable one.
+	//
+	// This is diagnosability, not a new guarantee, and in particular it is NOT a
+	// bound on operator-side rollback: reverting the artifact bundle *and* the
+	// signer store together leaves readback equal to installed and fires nothing
+	// here or anywhere else. See "What the floor does not bound" in
+	// docs/development/frost-anchor-rotation.adoc.
+	if readback.CertificateSequence > installed.TrustCertificateSequence {
+		return nil, fmt.Errorf(
+			"durable native signer anchor trust head sequence [%v] is ahead of "+
+				"the installed certificate pin [%v]; the configured anchor "+
+				"artifacts are older than this signer store",
+			readback.CertificateSequence,
+			installed.TrustCertificateSequence,
+		)
+	}
+
 	identity := runtimeManifest.NativeSignerAnchor.Identity
 	anchorManifest := runtimeManifest.NativeSignerAnchor
 	if readback.OfflineAuthoritySPKISHA256 !=

--- a/pkg/tbtc/frost_native_signer_anchor_trust_startup_test.go
+++ b/pkg/tbtc/frost_native_signer_anchor_trust_startup_test.go
@@ -187,6 +187,55 @@ func TestReconstructFrostNativeSignerAnchorTrustPriorHead(t *testing.T) {
 	}
 }
 
+// The honest pending-rotation path must keep working: the durable head sits at
+// or below the configured pin, which is exactly what a node about to install a
+// new certificate looks like.
+func TestReconstructFrostNativeSignerAnchorTrustPriorHeadAcceptsConfiguredPin(
+	t *testing.T,
+) {
+	fixture, _, readback := newFrostNativeSignerAnchorTrustPriorStartupFixture()
+
+	if readback.CertificateSequence > fixture.installed.TrustCertificateSequence {
+		t.Fatalf(
+			"fixture is not representative: readback sequence [%v] already "+
+				"exceeds the installed pin [%v]",
+			readback.CertificateSequence,
+			fixture.installed.TrustCertificateSequence,
+		)
+	}
+	if _, err := reconstructFrostNativeSignerAnchorTrustPriorHead(
+		&readback,
+		fixture.runtime,
+		&fixture.installed,
+		&fixture.certificate,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Configuration rolled back while the signer store was not. This is a
+// diagnosability assertion over a state that already failed closed; it is not a
+// bound on operator rollback, which reverts both and leaves the two equal.
+func TestReconstructFrostNativeSignerAnchorTrustPriorHeadRejectsAheadDurableHead(
+	t *testing.T,
+) {
+	fixture, _, readback := newFrostNativeSignerAnchorTrustPriorStartupFixture()
+	readback.CertificateSequence = fixture.installed.TrustCertificateSequence + 1
+
+	_, err := reconstructFrostNativeSignerAnchorTrustPriorHead(
+		&readback,
+		fixture.runtime,
+		&fixture.installed,
+		&fixture.certificate,
+	)
+	if err == nil {
+		t.Fatal("expected a durable trust head ahead of the pin to be rejected")
+	}
+	if !strings.Contains(err.Error(), "ahead of the installed certificate pin") {
+		t.Fatalf("unexpected error: [%v]", err)
+	}
+}
+
 func TestReconstructFrostNativeSignerAnchorTrustPriorHeadUsesCertifiedFloor(
 	t *testing.T,
 ) {

--- a/pkg/tbtc/frost_native_signer_anchor_trust_test.go
+++ b/pkg/tbtc/frost_native_signer_anchor_trust_test.go
@@ -803,6 +803,20 @@ func TestFrostNativeSignerAnchorTrustReferenceDescendantRules(t *testing.T) {
 				trustTestBytes32(0xa6),
 			)
 		},
+		// Mirrors the Rust descendant validator, which refuses a store
+		// fingerprint change across generations. The two trees must admit the
+		// same references or one accepts a chain the other refuses on every
+		// store open.
+		"store fingerprint change": func(candidate *FrostNativeSignerAnchorTrustReference) {
+			rehomed := floor.Checkpoint.StoreFingerprint
+			rehomed[0] ^= 1
+			candidate.Checkpoint = trustTestCheckpoint(
+				rehomed,
+				floor.Checkpoint.Generation+1,
+				trustTestBytes32(0xa7),
+				trustTestBytes32(0xa8),
+			)
+		},
 	}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/tbtc/frost_pre_sign_authorization.go
+++ b/pkg/tbtc/frost_pre_sign_authorization.go
@@ -1756,6 +1756,7 @@ func (tfpsag *thresholdFrostPreSignAuthorizationGate) authorize(
 			err,
 		)
 	}
+	recordFrostNativeSignerAnchorAdmittedPresignRelayGate()
 	reservationTransferred := false
 	defer func() {
 		if !reservationTransferred {
@@ -1920,6 +1921,7 @@ func (tfpsag *thresholdFrostPreSignAuthorizationGate) admitInput(
 		recordFrostNativeSignerAnchorPreSignInputRejection()
 		return nil, err
 	}
+	recordFrostNativeSignerAnchorAdmittedPresignInput()
 	return reservation.Release, nil
 }
 

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -910,6 +910,8 @@ func (fnsaho *frostNativeSignerAnchorHeadroomObserver) verifyFrostProductionSign
 		signing.RecordNativeTBTCSignerStateAnchorRestartableHeadroom(
 			snapshot.Inventory.RestartableRevisionHeadroom,
 			snapshot.Inventory.RestartableGenerationHeadroom,
+			snapshot.Inventory.AnchorRotationWarning,
+			snapshot.Inventory.LargestLocalSeatCount,
 		)
 	}
 	return snapshot, err

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -665,9 +665,10 @@ func (wte *walletTransactionExecutor) signTransaction(
 		// job is done: it gated the on-chain relay on a node that had the
 		// capacity to act on it. From here the sequential loop reserves an
 		// input's worth for each input it signs, and holding both at once would
-		// charge two inputs for one input's work - at the hundred-seat maximum
-		// that is 8030 of a 4096-entry proof window, which would reinstate a
-		// seat ceiling at fifty rather than remove it.
+		// charge two inputs for one input's work. At the expected five seats
+		// under equal weighting that wastes 215 of a 4096-entry proof window on
+		// every input, and the waste scales with seat count, so a smaller
+		// operator set makes it worse rather than better.
 		//
 		// Releasing here rather than leaving it to the deferred release is safe
 		// and is not a hole: the release is idempotent, the deferred call still

--- a/pkg/tbtc/wallet.go
+++ b/pkg/tbtc/wallet.go
@@ -665,10 +665,11 @@ func (wte *walletTransactionExecutor) signTransaction(
 		// job is done: it gated the on-chain relay on a node that had the
 		// capacity to act on it. From here the sequential loop reserves an
 		// input's worth for each input it signs, and holding both at once would
-		// charge two inputs for one input's work. At the expected five seats
-		// under equal weighting that wastes 215 of a 4096-entry proof window on
-		// every input, and the waste scales with seat count, so a smaller
-		// operator set makes it worse rather than better.
+		// charge two inputs for one input's work. At the average five seats
+		// the mainnet stake-weighted sortition produces that wastes 215 of
+		// a 4096-entry proof window on every input, and the waste scales
+		// with seat count, so a smaller operator set makes it worse
+		// rather than better.
 		//
 		// Releasing here rather than leaving it to the deferred release is safe
 		// and is not a hole: the release is idempotent, the deferred call still


### PR DESCRIPTION
Six fixes for the FROST native signer anchor path. Stacked on #4199 rather than folded into it, so that PR stays mergeable as-is.

None of these change the Rust signer: `frost_tbtc_trigger_emergency_rekey` already exists at the pinned ref, so the ABI and `ci/frost-signer-pin.env` are untouched.

## 1. Route the emergency rekey through the state anchor (fdbfdd28a)

The engine has always exported the kill-switch trigger, but **nothing in Go called it** — a repo-wide grep for the symbol returns nothing. With no Go caller, the only way to arm the switch is to stop the node and mutate its durable store directly. That write never passes through the anchored operation path, so it is never compare-and-swapped onto the anchor stream. On restart the anchor sees local and remote agreeing, and an operator who restores the pre-rekey state file first has erased a kill switch aimed at them with no evidence anywhere in the stream.

The fix routes the call through `callBuildTaggedTBTCSignerOperation`, so the durable write is CAS-ed onto the anchor stream before the call returns. That is what makes a later erasure detectable.

Two properties that look like omissions but are deliberate, and are documented at the entrypoint:

- **Not admission-gated.** The operation wrapper takes no capacity reservation, and admission refuses all work once headroom reaches the rotation floor (256) while the barrier keeps admitting until the certified window is genuinely exhausted. A kill switch that capacity accounting can veto is not a kill switch, so it runs unreserved in that band.
- **The barrier stays mandatory.** A poisoned anchor or an exhausted window fails the trigger. Every barrier refusal predicate is operation-independent, so a state in which this trigger is refused is one in which the node already refuses every signature-producing call — the switch is redundant there, not defeated, and its residual is availability rather than authority.

The exported call is single-flight by contract: the engine treats an armed event as immutable and no export clears it.

**No runtime behaviour changes from this PR.** The kill switch remains unreachable from any operator-facing CLI; the anchored path is landed so any trigger built on it will be certified. The remaining options for that trigger surface each need a decision the code cannot supply: what names the target session, whether the switch is per-wallet or node-wide, and what the recovery path is for an accidental trigger given the event is immutable. The #4222 exposure stays open until those answers exist. Note that an out-of-process CLI is specifically not a viable path here: with the running node holding the store's exclusive `flock` it cannot write, and with the node stopped the write is unanchored — the same bug restated — but that constraint is one input to the design, not the whole reason the surface is deferred.

Quarantine, fault scores, and `finalize_request_fingerprint` have the same missing-wiring shape but **no runtime writers in the Rust crate at all** — only test-support writers. A Go call into a nonexistent writer is not a fix, so those need a Rust-side writer first and are filed separately.

## 2. Correct what the anchor certified floor bounds (eb6692c71)

`docs/development/frost-anchor-rotation.adoc` said the floor is "checked at startup against pins that the running node cannot influence." That holds against a **compromised signer process**, which cannot forge the offline authority's signature. It does not hold against the **operator**: every artifact naming the floor — certificate chain, init config, activation manifest — is a local file the operator owns, and the certificate sequence and digest are only ever compared against the init config. The activation manifest is a signed envelope read from disk, not fetched from chain.

The doc now says that, and adds what genuinely bounds an operator-side downgrade:

1. The bundle moves in lockstep — every rotation must change the manifest hash and advance the manifest sequence and service epoch by exactly one, so a downgrade means reverting the whole bundle, not swapping one file.
2. The durable trust journal is append-only and its head must equal the configured pin, so a downgrade also needs a pre-rotation signer-store snapshot.
3. The anchor service can retire the previous binding — every signed request already carries the current `bindingHash` and `activationManifestSequence`.

Only (3) is a real control, and it lives outside this repository, so it becomes a pre-activation checklist item alongside a decision on where a monotonic floor is published if operator-side rollback is in scope.

**No code change closes this gap**, and the PR does not pretend otherwise: every candidate in-repo pin is downstream of an operator-owned file. Putting the floor *reference* into the activation manifest is not merely awkward but unsatisfiable — `manifestHash` feeds `bindingHash` feeds the event root, which *is* the floor, so the manifest would have to commit to a hash of itself. A plain minimum-sequence integer would dodge that circularity but is security-null here, because an old certificate is only presentable together with its own old manifest, which would carry the old minimum.

Worth noting for whoever picks up the checklist item: the signed activation-handshake attestation already exports `trustCertificateSequence`, `anchorServiceEpoch` and the certified floor revision/generation, so an external monitor retaining the maximum ever seen per operator detects a downgrade today with no protocol change.

## 3. Diagnose a durable trust head ahead of the configured pin (eaae1fcd8)

A durable trust head ahead of the configured pin now says the artifacts are older than the store, rather than surfacing later as an opaque endpoint-identity mismatch. The comment states explicitly that this is **not** a bound on operator rollback — reverting the bundle and the store together leaves the two equal and fires nothing — so a later reader does not mistake it for a fix.

## 4. Publish restartable headroom on every acknowledged commit (cd83062ad)

The restartable headroom mirror and the rotation warning were previously published only on a full readiness reconciliation, so a steadily signing node and a stalled node looked identical at the scrape until the next reconciliation. Since pre-sign authorization caches readiness per finality window, an entire authorized batch could burn window invisibly inside one window. Every successful compare-and-swap already holds an authenticated tip, so the publication moves onto the commit path and the rotation warning follows the seat count that travelled with the previous publication (seat count only changes on DKG and retirement, both of which force a full reconciliation).

## 5. Correct the runbook cadence and seat-scaling framing (c07b47578)

`docs/development/frost-anchor-rotation.adoc` carried stale workload numbers in several places. The corrected table derives each cell from the fault-free range `k+3..3k+2` generations per input: at 4 seats the worst case is 294 generations (was 588 — the retracted figure), the range at the 5-seat expected holder is 13–26 sweeps per epoch (was 6–13), and at 20 seats 2–7 sweeps (was 1–2). The seat-sizing directive was also rewritten: the original framing assumed equal-weighted signers and recommended sizing against the 5-seat average; this PR removes that assumption, names the sortition as stake-weighted with replacement, and reframes the high-seat rows as the upper tail of the distribution reachable by operators with concentrated stake.

## 6. Measure real anchor burn rate (69a24d045)

Every workflow that reaches the shared `reserve()` path now increments its own counter, so the published burn-rate ratio has a single well-defined unit. The single `admitted_total` counter is replaced by three: `admitted_presign_input_total`, `admitted_presign_relay_gate_total`, and `admitted_dkg_total`. The pre-sign reservation counts the per-input work; the relay-gate reservation counts the up-front authorization; DKG counts the per-local-seat reservation. The reset helper, var-block comment, and registration function doc were updated to match.

## Verification

```
go build ./...
go vet ./pkg/tbtc/... ./pkg/frost/signing/...
go test -run 'FrostNativeSignerAnchor' ./pkg/tbtc/
go test -run 'EmergencyRekey' ./pkg/frost/signing/                                    # default build: stub fails closed
CGO_ENABLED=1 go test -tags "frost_native frost_tbtc_signer" -run 'EmergencyRekey' ./pkg/frost/signing/
```

New tests cover the payload builder (empty/whitespace reason, over-long and malformed session IDs), the response decoder (six rejection cases, including the engine retargeting a per-signing session to its wallet session), the default-build stub failing closed, the rotation warning gauge value in both healthy and near-floor scenarios, the observer threading warning and seat count through to the accessors, the consumption and admission counters advancing on commit and staying flat on the skip-CAS path, the new cgo-tagged wiring and barrier-gating for the trigger, and both the honest and rejected paths of the new trust-head assertion.
