### PR TITLE
feat(covenantsigner): HTTP issuer for SignerApprovalCertificate

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -332,6 +332,12 @@ func initCovenantSignerFlags(cmd *cobra.Command, cfg *config.Config) {
 		covenantsigner.Config{}.AuthToken,
 		"Covenant signer provider static Bearer auth token. Required for non-loopback binds; prefer config file or env var over CLI in production.",
 	)
+	cmd.Flags().StringVar(
+		&cfg.CovenantSigner.AdminAuthToken,
+		"covenantSigner.adminAuthToken",
+		covenantsigner.Config{}.AdminAuthToken,
+		"Covenant signer certificate-issuer admin route static Bearer auth token. Distinct from covenantSigner.authToken -- never falls back to it. Required for non-loopback binds; prefer config file or env var over CLI in production.",
+	)
 	cmd.Flags().BoolVar(
 		&cfg.CovenantSigner.EnableSelfV1,
 		"covenantSigner.enableSelfV1",

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -212,6 +212,13 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: "secret-token",
 		defaultValue:          "",
 	},
+	"covenantSigner.adminAuthToken": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.CovenantSigner.AdminAuthToken },
+		flagName:              "--covenantSigner.adminAuthToken",
+		flagValue:             "secret-admin-token",
+		expectedValueFromFlag: "secret-admin-token",
+		defaultValue:          "",
+	},
 	"covenantSigner.enableSelfV1": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.CovenantSigner.EnableSelfV1 },
 		flagName:              "--covenantSigner.enableSelfV1",

--- a/pkg/covenantsigner/config.go
+++ b/pkg/covenantsigner/config.go
@@ -14,6 +14,12 @@ type Config struct {
 	// config files over CLI flags to avoid exposing the token in
 	// /proc/PID/cmdline.
 	AuthToken string
+	// AdminAuthToken enables static Bearer authentication for the
+	// certificate-issuer admin route (POST /v1/admin/signer-approval-certificates).
+	// It is a distinct credential from AuthToken and never falls back to it:
+	// an ordinary submit/poll client token must never be sufficient to mint a
+	// signer approval certificate. Non-loopback binds must set this.
+	AdminAuthToken string
 	// EnableSelfV1 exposes the self_v1 signer HTTP routes. Keep this disabled
 	// for a qc_v1-first launch unless self_v1 has cleared its own go-live gate.
 	EnableSelfV1 bool

--- a/pkg/covenantsigner/engine.go
+++ b/pkg/covenantsigner/engine.go
@@ -95,6 +95,15 @@ var ErrSignerApprovalCertificateIssuerUnsupported = errors.New(
 	"covenant signer engine does not support signer approval certificate issuance",
 )
 
+// ErrSignerApprovalCertificateIssuerBusy is returned when the engine's signing
+// executor for the requested wallet is already running another signing
+// operation (e.g. a concurrent Submit or a concurrent issuance). Callers
+// should retry after a short delay; the request was rejected before any
+// threshold signing began, so retrying is always safe.
+var ErrSignerApprovalCertificateIssuerBusy = errors.New(
+	"covenant signer engine is busy signing for this wallet",
+)
+
 type passiveEngine struct{}
 
 func NewPassiveEngine() Engine {

--- a/pkg/covenantsigner/engine.go
+++ b/pkg/covenantsigner/engine.go
@@ -33,9 +33,9 @@ type Transition struct {
 // underlying signing job. The service treats this as a terminal failure and
 // transitions the job to JobStateFailed.
 //
-// An Engine may also implement SignerApprovalVerifier and
-// CurrentBlockHeightProvider; see their doc comments for the constraints
-// between them.
+// An Engine may also implement SignerApprovalVerifier,
+// CurrentBlockHeightProvider, and SignerApprovalCertificateIssuer; see their
+// doc comments for the constraints between them.
 type Engine interface {
 	OnSubmit(ctx context.Context, job *Job) (*Transition, error)
 	OnPoll(ctx context.Context, job *Job) (*Transition, error)
@@ -69,6 +69,31 @@ func (savf SignerApprovalVerifierFunc) VerifySignerApproval(
 ) error {
 	return savf(request)
 }
+
+// SignerApprovalCertificateIssuer is implemented by Engines that can produce a
+// v2 SignerApprovalCertificate for a wallet they control by running a threshold
+// signing round over the certificate digest. The admin HTTP issuer endpoint
+// type-asserts the engine to this interface; engines that omit it return 501.
+//
+// approvalDigest must be the 32-byte artifact-approval payload digest that the
+// eventual Submit request will carry — VerifySignerApproval rejects certificates
+// whose ApprovalDigest does not match request.artifactApprovals.payload.
+// endBlock is a host-chain (e.g. Ethereum) height after which the certificate
+// must be rejected as expired.
+type SignerApprovalCertificateIssuer interface {
+	IssueSignerApprovalCertificate(
+		ctx context.Context,
+		walletPublicKeyHash [20]byte,
+		approvalDigest []byte,
+		endBlock uint64,
+	) (*SignerApprovalCertificate, error)
+}
+
+// ErrSignerApprovalCertificateIssuerUnsupported is returned when the configured
+// engine does not implement SignerApprovalCertificateIssuer.
+var ErrSignerApprovalCertificateIssuerUnsupported = errors.New(
+	"covenant signer engine does not support signer approval certificate issuance",
+)
 
 type passiveEngine struct{}
 

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -55,6 +55,12 @@ func Initialize(
 			listenAddress,
 		)
 	}
+	if !isLoopback && strings.TrimSpace(config.AdminAuthToken) == "" {
+		return nil, false, fmt.Errorf(
+			"covenant signer adminAuthToken is required for non-loopback listenAddress [%s]",
+			listenAddress,
+		)
+	}
 
 	eip712DomainOption, err := WithEIP712Domain(config.EIP712ChainID, config.EIP712Salt)
 	if err != nil {
@@ -167,7 +173,7 @@ func Initialize(
 		cancelService: cancelService,
 		httpServer: &http.Server{
 			Addr:              net.JoinHostPort(listenAddress, strconv.Itoa(config.Port)),
-			Handler:           newHandler(service, serviceCtx, config.AuthToken, config.EnableSelfV1),
+			Handler:           newHandler(service, serviceCtx, config.AuthToken, config.AdminAuthToken, config.EnableSelfV1),
 			ReadHeaderTimeout: 5 * time.Second,
 			ReadTimeout:       30 * time.Second,
 			WriteTimeout:      30 * time.Second,
@@ -209,9 +215,10 @@ func Initialize(
 	}()
 
 	logger.Infof(
-		"enabled covenant signer provider endpoint on [%v] auth=[%v] self_v1=[%v]",
+		"enabled covenant signer provider endpoint on [%v] auth=[%v] admin_auth=[%v] self_v1=[%v]",
 		server.httpServer.Addr,
 		strings.TrimSpace(config.AuthToken) != "",
+		strings.TrimSpace(config.AdminAuthToken) != "",
 		config.EnableSelfV1,
 	)
 
@@ -311,9 +318,24 @@ func hasCustodianTrustRootForRoute(
 	return false
 }
 
-func newHandler(service *Service, serviceCtx context.Context, authToken string, enableSelfV1 bool) http.Handler {
+func newHandler(
+	service *Service,
+	serviceCtx context.Context,
+	authToken string,
+	adminAuthToken string,
+	enableSelfV1 bool,
+) http.Handler {
 	mux := http.NewServeMux()
 	protectedHandler := withBearerAuth(mux, authToken)
+
+	// The admin certificate-issuer route is authenticated separately from
+	// submit/poll: it mints a threshold-signed authorization artifact rather
+	// than consuming one, so it must never be reachable with the ordinary
+	// client token. adminAuthToken never falls back to authToken -- an empty
+	// adminAuthToken makes withBearerAuth a no-op here exactly as it does for
+	// authToken, which Initialize forbids on a non-loopback listen address.
+	adminMux := http.NewServeMux()
+	protectedAdminHandler := withBearerAuth(adminMux, adminAuthToken)
 
 	// Single rate limiter shared across all submit routes. The server uses one
 	// static auth token, so this is equivalent to per-token limiting.
@@ -337,7 +359,7 @@ func newHandler(service *Service, serviceCtx context.Context, authToken string, 
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	mux.HandleFunc(
+	adminMux.HandleFunc(
 		"POST /v1/admin/signer-approval-certificates",
 		issueSignerApprovalCertificateHandler(service, serviceCtx, submitLimiter),
 	)
@@ -353,6 +375,10 @@ func newHandler(service *Service, serviceCtx context.Context, authToken string, 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/healthz" {
 			mux.ServeHTTP(w, r)
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/v1/admin/") {
+			protectedAdminHandler.ServeHTTP(w, r)
 			return
 		}
 
@@ -439,6 +465,11 @@ func handleError(w http.ResponseWriter, err error) {
 		http.Error(w, err.Error(), http.StatusNotImplemented)
 		return
 	}
+	if errors.Is(err, ErrSignerApprovalCertificateIssuerBusy) {
+		w.Header().Set("Retry-After", "5")
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
 
 	logger.Errorf("covenant signer request failed: [%v]", err)
 	http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -504,7 +535,15 @@ func issueSignerApprovalCertificateHandler(
 		}
 
 		// Certificate issuance runs a full threshold signing round, so use the
-		// same service-level timeout and detached context as submit.
+		// same service-level timeout and detached context as submit. Unlike
+		// submit there is no poll route to recover the result: a slow round
+		// finishes and is discarded if the connection is gone by then, and
+		// the server's WriteTimeout (30s) is shorter than submitTimeout, so
+		// any round exceeding it cannot deliver its result at all. Callers
+		// MUST use a client timeout >= submitTimeout and treat a lost
+		// connection as "outcome unknown, safe to retry" rather than
+		// "failed" -- retrying issues a fresh signature over the same
+		// (payload, endBlock), never a duplicate side effect.
 		issueCtx, cancelIssue := context.WithTimeout(serviceCtx, submitTimeout)
 		defer cancelIssue()
 

--- a/pkg/covenantsigner/server.go
+++ b/pkg/covenantsigner/server.go
@@ -337,6 +337,10 @@ func newHandler(service *Service, serviceCtx context.Context, authToken string, 
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
+	mux.HandleFunc(
+		"POST /v1/admin/signer-approval-certificates",
+		issueSignerApprovalCertificateHandler(service, serviceCtx, submitLimiter),
+	)
 	mux.HandleFunc("POST /v1/qc_v1/signer/requests", submitHandler(service, serviceCtx, TemplateQcV1, submitLimiter))
 	mux.HandleFunc("POST /v1/qc_v1/signer/requests:poll", pollBodyHandler(service, TemplateQcV1, pollLimiter))
 	mux.HandleFunc("/v1/qc_v1/signer/requests/", pollPathHandler(service, TemplateQcV1, pollLimiter))
@@ -431,6 +435,10 @@ func handleError(w http.ResponseWriter, err error) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
+	if errors.Is(err, ErrSignerApprovalCertificateIssuerUnsupported) {
+		http.Error(w, err.Error(), http.StatusNotImplemented)
+		return
+	}
 
 	logger.Errorf("covenant signer request failed: [%v]", err)
 	http.Error(w, "internal server error", http.StatusInternalServerError)
@@ -476,6 +484,37 @@ func submitHandler(service *Service, serviceCtx context.Context, route TemplateI
 		}
 
 		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+func issueSignerApprovalCertificateHandler(
+	service *Service,
+	serviceCtx context.Context,
+	limiter *rate.Limiter,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !limiter.Allow() {
+			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+			return
+		}
+
+		input := IssueSignerApprovalCertificateInput{}
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+
+		// Certificate issuance runs a full threshold signing round, so use the
+		// same service-level timeout and detached context as submit.
+		issueCtx, cancelIssue := context.WithTimeout(serviceCtx, submitTimeout)
+		defer cancelIssue()
+
+		certificate, err := service.IssueSignerApprovalCertificate(issueCtx, input)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, certificate)
 	}
 }
 

--- a/pkg/covenantsigner/server_test.go
+++ b/pkg/covenantsigner/server_test.go
@@ -35,7 +35,7 @@ func TestServerHandlesSubmitAndPathPoll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", true))
 	defer server.Close()
 
 	submitPayload := mustJSON(t, SignerSubmitInput{
@@ -89,7 +89,7 @@ func TestServerRejectsUnknownFieldsOnSubmit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", true))
 	defer server.Close()
 
 	base := baseRequest(TemplateSelfV1)
@@ -194,7 +194,7 @@ func TestServerRejectsTrailingJSONOnSubmit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", true))
 	defer server.Close()
 
 	validPayload := mustJSON(t, SignerSubmitInput{
@@ -517,9 +517,10 @@ func TestInitializeRequiresTrustRootsForNonLoopbackListenAddress(t *testing.T) {
 	_, enabled, err := Initialize(
 		ctx,
 		Config{
-			Port:          availableLoopbackPort(t),
-			ListenAddress: "0.0.0.0",
-			AuthToken:     "test-token",
+			Port:           availableLoopbackPort(t),
+			ListenAddress:  "0.0.0.0",
+			AuthToken:      "test-token",
+			AdminAuthToken: "test-admin-token",
 		},
 		handle,
 		&scriptedVerifierEngine{},
@@ -542,9 +543,10 @@ func TestInitializeRequiresSignerApprovalVerifierForNonLoopbackListenAddress(t *
 	_, enabled, err := Initialize(
 		ctx,
 		Config{
-			Port:          availableLoopbackPort(t),
-			ListenAddress: "0.0.0.0",
-			AuthToken:     "test-token",
+			Port:           availableLoopbackPort(t),
+			ListenAddress:  "0.0.0.0",
+			AuthToken:      "test-token",
+			AdminAuthToken: "test-admin-token",
 			DepositorTrustRoots: []DepositorTrustRoot{
 				testDepositorTrustRoot(TemplateQcV1),
 			},
@@ -583,7 +585,7 @@ func TestServerRequiresBearerTokenWhenConfigured(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "test-token", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "test-token", "", true))
 	defer server.Close()
 
 	submitPayload := mustJSON(t, SignerSubmitInput{
@@ -656,7 +658,7 @@ func TestServerCanKeepSelfV1RoutesDark(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "", false))
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", false))
 	defer server.Close()
 
 	response, err := http.Post(
@@ -712,7 +714,7 @@ func TestServerBoundaryErrorMatrix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "test-token", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "test-token", "", true))
 	defer server.Close()
 
 	submitPayload := mustJSON(t, SignerSubmitInput{
@@ -879,7 +881,7 @@ func TestSubmitHandlerDetachesContextFromHTTPLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	handler := newHandler(service, context.Background(), "", true)
+	handler := newHandler(service, context.Background(), "", "", true)
 
 	submitPayload := mustJSON(t, SignerSubmitInput{
 		RouteRequestID: "ors_detach_cancel",
@@ -969,7 +971,7 @@ func TestSubmitHandlerPreCancelledContextStillSucceeds(t *testing.T) {
 	// Test through the handler directly using httptest.ResponseRecorder
 	// because an HTTP client would fail to send a request with a
 	// pre-cancelled context.
-	handler := newHandler(service, context.Background(), "", true)
+	handler := newHandler(service, context.Background(), "", "", true)
 
 	submitPayload := mustJSON(t, SignerSubmitInput{
 		RouteRequestID: "ors_detach_precancel",
@@ -1044,7 +1046,7 @@ func TestSubmitHandlerPreservesServiceContextValues(t *testing.T) {
 	// its timeout context from serviceCtx (not from the HTTP request), so
 	// values on the service context must be visible to the engine.
 	serviceCtx := context.WithValue(context.Background(), testKey, testValue)
-	handler := newHandler(service, serviceCtx, "", true)
+	handler := newHandler(service, serviceCtx, "", "", true)
 
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -1105,11 +1107,38 @@ func (sie *scriptedIssuerEngine) IssueSignerApprovalCertificate(
 }
 
 func TestServerIssuesSignerApprovalCertificate(t *testing.T) {
+	route := TemplateQcV1
+	payload := ArtifactApprovalPayload{
+		ApprovalVersion:           artifactApprovalVersion,
+		Route:                     route,
+		ScriptTemplateID:          route,
+		DestinationCommitmentHash: "0x" + strings.Repeat("aa", 32),
+		PlanCommitmentHash:        "0x" + strings.Repeat("bb", 32),
+	}
+	artifactApprovals := ArtifactApprovalEnvelope{
+		Payload: payload,
+		Approvals: []ArtifactRoleApproval{
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: mustArtifactApprovalSignature(testDepositorPrivateKey, payload),
+			},
+			{
+				Role:      ArtifactApprovalRoleCustodian,
+				Signature: mustArtifactApprovalSignature(testCustodianPrivateKey, payload),
+			},
+		},
+	}
+	expectedApprovalDigest, err := ComputeArtifactApprovalDigest(payload, testEIP712ChainID, testEIP712Salt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	depositorTrustRoot := testDepositorTrustRoot(route)
 	endBlock := uint64(12345678)
 	expected := &SignerApprovalCertificate{
 		CertificateVersion: 2,
 		SignatureAlgorithm: "tecdsa-secp256k1",
-		ApprovalDigest:     "0x" + strings.Repeat("11", 32),
+		ApprovalDigest:     "0x" + hex.EncodeToString(expectedApprovalDigest),
 		WalletPublicKey:    "0x04" + strings.Repeat("22", 64),
 		SignerSetHash:      "0x" + strings.Repeat("33", 32),
 		Signature:          "0x30" + strings.Repeat("44", 32),
@@ -1117,42 +1146,50 @@ func TestServerIssuesSignerApprovalCertificate(t *testing.T) {
 	}
 
 	handle := newMemoryHandle()
-	service, err := NewService(handle, &scriptedIssuerEngine{
-		issue: func(
-			_ context.Context,
-			walletPublicKeyHash [20]byte,
-			approvalDigest []byte,
-			gotEndBlock uint64,
-		) (*SignerApprovalCertificate, error) {
-			if gotEndBlock != endBlock {
-				t.Fatalf("unexpected endBlock: %d", gotEndBlock)
-			}
-			if hex.EncodeToString(walletPublicKeyHash[:]) != strings.Repeat("12", 20) {
-				t.Fatalf("unexpected wallet pkh: %x", walletPublicKeyHash)
-			}
-			if hex.EncodeToString(approvalDigest) != strings.Repeat("11", 32) {
-				t.Fatalf("unexpected approval digest: %x", approvalDigest)
-			}
-			return expected, nil
+	service, err := NewService(
+		handle,
+		&scriptedIssuerEngine{
+			issue: func(
+				_ context.Context,
+				walletPublicKeyHash [20]byte,
+				approvalDigest []byte,
+				gotEndBlock uint64,
+			) (*SignerApprovalCertificate, error) {
+				if gotEndBlock != endBlock {
+					t.Fatalf("unexpected endBlock: %d", gotEndBlock)
+				}
+				if hex.EncodeToString(walletPublicKeyHash[:]) != strings.Repeat("12", 20) {
+					t.Fatalf("unexpected wallet pkh: %x", walletPublicKeyHash)
+				}
+				if !bytes.Equal(approvalDigest, expectedApprovalDigest) {
+					t.Fatalf("unexpected approval digest: %x", approvalDigest)
+				}
+				return expected, nil
+			},
 		},
-	})
+		WithDepositorTrustRoots([]DepositorTrustRoot{depositorTrustRoot}),
+		WithCustodianTrustRoots([]CustodianTrustRoot{testCustodianTrustRoot(route)}),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", true))
 	defer server.Close()
 
-	payload := mustJSON(t, IssueSignerApprovalCertificateInput{
+	payloadBytes := mustJSON(t, IssueSignerApprovalCertificateInput{
 		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
-		ApprovalDigest:      "0x" + strings.Repeat("11", 32),
+		Route:               route,
+		Reserve:             depositorTrustRoot.Reserve,
+		Network:             depositorTrustRoot.Network,
+		ArtifactApprovals:   artifactApprovals,
 		EndBlock:            endBlock,
 	})
 
 	response, err := http.Post(
 		server.URL+"/v1/admin/signer-approval-certificates",
 		"application/json",
-		bytes.NewReader(payload),
+		bytes.NewReader(payloadBytes),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1168,8 +1205,15 @@ func TestServerIssuesSignerApprovalCertificate(t *testing.T) {
 	if err := json.NewDecoder(response.Body).Decode(&got); err != nil {
 		t.Fatal(err)
 	}
-	if got.ApprovalDigest != expected.ApprovalDigest {
-		t.Fatalf("unexpected certificate: %+v", got)
+	if got.CertificateVersion != expected.CertificateVersion ||
+		got.SignatureAlgorithm != expected.SignatureAlgorithm ||
+		got.ApprovalDigest != expected.ApprovalDigest ||
+		got.WalletPublicKey != expected.WalletPublicKey ||
+		got.SignerSetHash != expected.SignerSetHash ||
+		got.Signature != expected.Signature ||
+		got.EndBlock == nil ||
+		*got.EndBlock != *expected.EndBlock {
+		t.Fatalf("unexpected certificate: got %+v, want %+v", got, expected)
 	}
 }
 
@@ -1180,12 +1224,13 @@ func TestServerReturns501WhenEngineLacksCertificateIssuer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", true))
 	defer server.Close()
 
+	// The unsupported-issuer check runs before any input is validated, so a
+	// minimal body is enough to exercise this path.
 	payload := mustJSON(t, IssueSignerApprovalCertificateInput{
 		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
-		ApprovalDigest:      "0x" + strings.Repeat("11", 32),
 		EndBlock:            12345678,
 	})
 
@@ -1205,71 +1250,179 @@ func TestServerReturns501WhenEngineLacksCertificateIssuer(t *testing.T) {
 	}
 }
 
-func TestServerRequiresBearerTokenForCertificateIssuer(t *testing.T) {
-	handle := newMemoryHandle()
-	service, err := NewService(handle, &scriptedIssuerEngine{
-		issue: func(
-			context.Context,
-			[20]byte,
-			[]byte,
-			uint64,
-		) (*SignerApprovalCertificate, error) {
-			endBlock := uint64(1)
-			return &SignerApprovalCertificate{EndBlock: &endBlock}, nil
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+// TestServerRequiresAdminBearerTokenForCertificateIssuer proves the admin
+// certificate-issuer route is gated by its own credential, distinct from the
+// ordinary submit/poll authToken: the submit token must be rejected here even
+// though it is accepted on every other route.
+func TestServerRequiresAdminBearerTokenForCertificateIssuer(t *testing.T) {
+	route := TemplateSelfV1
+	payload := ArtifactApprovalPayload{
+		ApprovalVersion:           artifactApprovalVersion,
+		Route:                     route,
+		ScriptTemplateID:          route,
+		DestinationCommitmentHash: "0x" + strings.Repeat("aa", 32),
+		PlanCommitmentHash:        "0x" + strings.Repeat("bb", 32),
 	}
+	artifactApprovals := ArtifactApprovalEnvelope{
+		Payload: payload,
+		Approvals: []ArtifactRoleApproval{
+			{
+				Role:      ArtifactApprovalRoleDepositor,
+				Signature: mustArtifactApprovalSignature(testDepositorPrivateKey, payload),
+			},
+		},
+	}
+	depositorTrustRoot := testDepositorTrustRoot(route)
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "test-token", true))
-	defer server.Close()
-
-	payload := mustJSON(t, IssueSignerApprovalCertificateInput{
-		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
-		ApprovalDigest:      "0x" + strings.Repeat("11", 32),
-		EndBlock:            12345678,
-	})
-
-	unauthorized, err := http.NewRequest(
-		http.MethodPost,
-		server.URL+"/v1/admin/signer-approval-certificates",
-		bytes.NewReader(payload),
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedIssuerEngine{
+			issue: func(
+				context.Context,
+				[20]byte,
+				[]byte,
+				uint64,
+			) (*SignerApprovalCertificate, error) {
+				endBlock := uint64(1)
+				return &SignerApprovalCertificate{EndBlock: &endBlock}, nil
+			},
+		},
+		WithDepositorTrustRoots([]DepositorTrustRoot{depositorTrustRoot}),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	unauthorized.Header.Set("Content-Type", "application/json")
 
-	response, err := http.DefaultClient.Do(unauthorized)
+	server := httptest.NewServer(newHandler(service, context.Background(), "submit-token", "admin-token", true))
+	defer server.Close()
+
+	payloadBytes := mustJSON(t, IssueSignerApprovalCertificateInput{
+		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
+		Route:               route,
+		Reserve:             depositorTrustRoot.Reserve,
+		Network:             depositorTrustRoot.Network,
+		ArtifactApprovals:   artifactApprovals,
+		EndBlock:            12345678,
+	})
+
+	doRequest := func(bearerToken string) *http.Response {
+		request, err := http.NewRequest(
+			http.MethodPost,
+			server.URL+"/v1/admin/signer-approval-certificates",
+			bytes.NewReader(payloadBytes),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.Header.Set("Content-Type", "application/json")
+		if bearerToken != "" {
+			request.Header.Set("Authorization", "Bearer "+bearerToken)
+		}
+
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return response
+	}
+
+	noTokenResponse := doRequest("")
+	defer noTokenResponse.Body.Close()
+	if noTokenResponse.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(noTokenResponse.Body)
+		t.Fatalf("expected 401 with no token, got %d %s", noTokenResponse.StatusCode, string(body))
+	}
+
+	// The ordinary submit/poll token must never authorize the admin route --
+	// this is the exact regression this test exists to catch.
+	submitTokenResponse := doRequest("submit-token")
+	defer submitTokenResponse.Body.Close()
+	if submitTokenResponse.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(submitTokenResponse.Body)
+		t.Fatalf("expected 401 with the submit token, got %d %s", submitTokenResponse.StatusCode, string(body))
+	}
+
+	adminTokenResponse := doRequest("admin-token")
+	defer adminTokenResponse.Body.Close()
+	if adminTokenResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(adminTokenResponse.Body)
+		t.Fatalf("expected 200 with the admin token, got %d %s", adminTokenResponse.StatusCode, string(body))
+	}
+}
+
+// TestServerRejectsCertificateIssuanceWithForgedApproval proves the server
+// derives and signs only a digest it authenticated itself: a well-formed
+// ArtifactApprovals envelope whose depositor signature was not produced by
+// the trust-rooted depositor key must be rejected before the engine is ever
+// invoked, even though every other field is valid.
+func TestServerRejectsCertificateIssuanceWithForgedApproval(t *testing.T) {
+	route := TemplateSelfV1
+	payload := ArtifactApprovalPayload{
+		ApprovalVersion:           artifactApprovalVersion,
+		Route:                     route,
+		ScriptTemplateID:          route,
+		DestinationCommitmentHash: "0x" + strings.Repeat("aa", 32),
+		PlanCommitmentHash:        "0x" + strings.Repeat("bb", 32),
+	}
+	artifactApprovals := ArtifactApprovalEnvelope{
+		Payload: payload,
+		Approvals: []ArtifactRoleApproval{
+			{
+				Role: ArtifactApprovalRoleDepositor,
+				// Signed by a key other than the pinned depositorTrustRoots
+				// key -- not the depositor's signature.
+				Signature: mustArtifactApprovalSignature(testSignerPrivateKey, payload),
+			},
+		},
+	}
+	depositorTrustRoot := testDepositorTrustRoot(route)
+
+	handle := newMemoryHandle()
+	service, err := NewService(
+		handle,
+		&scriptedIssuerEngine{
+			issue: func(
+				context.Context,
+				[20]byte,
+				[]byte,
+				uint64,
+			) (*SignerApprovalCertificate, error) {
+				t.Fatal("issuer should not be called for a forged approval")
+				return nil, nil
+			},
+		},
+		WithDepositorTrustRoots([]DepositorTrustRoot{depositorTrustRoot}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", true))
+	defer server.Close()
+
+	payloadBytes := mustJSON(t, IssueSignerApprovalCertificateInput{
+		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
+		Route:               route,
+		Reserve:             depositorTrustRoot.Reserve,
+		Network:             depositorTrustRoot.Network,
+		ArtifactApprovals:   artifactApprovals,
+		EndBlock:            12345678,
+	})
+
+	response, err := http.Post(
+		server.URL+"/v1/admin/signer-approval-certificates",
+		"application/json",
+		bytes.NewReader(payloadBytes),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer response.Body.Close()
-	if response.StatusCode != http.StatusUnauthorized {
+
+	if response.StatusCode != http.StatusBadRequest {
 		body, _ := io.ReadAll(response.Body)
-		t.Fatalf("expected 401, got %d %s", response.StatusCode, string(body))
-	}
-
-	authorized, err := http.NewRequest(
-		http.MethodPost,
-		server.URL+"/v1/admin/signer-approval-certificates",
-		bytes.NewReader(payload),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	authorized.Header.Set("Content-Type", "application/json")
-	authorized.Header.Set("Authorization", "Bearer test-token")
-
-	authorizedResponse, err := http.DefaultClient.Do(authorized)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer authorizedResponse.Body.Close()
-	if authorizedResponse.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(authorizedResponse.Body)
-		t.Fatalf("expected 200, got %d %s", authorizedResponse.StatusCode, string(body))
+		t.Fatalf("expected 400, got %d %s", response.StatusCode, string(body))
 	}
 }
 
@@ -1290,12 +1443,12 @@ func TestServerRejectsUnknownFieldsOnCertificateIssuer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", true))
 	defer server.Close()
 
 	payload := []byte(`{
 		"walletPublicKeyHash":"0x` + strings.Repeat("12", 20) + `",
-		"approvalDigest":"0x` + strings.Repeat("11", 32) + `",
+		"route":"self_v1",
 		"endBlock":12345678,
 		"unexpected":true
 	}`)
@@ -1333,12 +1486,11 @@ func TestServerRejectsInvalidCertificateIssuerInput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	server := httptest.NewServer(newHandler(service, context.Background(), "", "", true))
 	defer server.Close()
 
 	payload := mustJSON(t, IssueSignerApprovalCertificateInput{
 		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
-		ApprovalDigest:      "0x" + strings.Repeat("11", 32),
 		EndBlock:            0,
 	})
 

--- a/pkg/covenantsigner/server_test.go
+++ b/pkg/covenantsigner/server_test.go
@@ -3,6 +3,7 @@ package covenantsigner
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1078,5 +1079,281 @@ func TestSubmitHandlerPreservesServiceContextValues(t *testing.T) {
 			testValue,
 			capturedValue,
 		)
+	}
+}
+
+type scriptedIssuerEngine struct {
+	scriptedEngine
+	issue func(
+		ctx context.Context,
+		walletPublicKeyHash [20]byte,
+		approvalDigest []byte,
+		endBlock uint64,
+	) (*SignerApprovalCertificate, error)
+}
+
+func (sie *scriptedIssuerEngine) IssueSignerApprovalCertificate(
+	ctx context.Context,
+	walletPublicKeyHash [20]byte,
+	approvalDigest []byte,
+	endBlock uint64,
+) (*SignerApprovalCertificate, error) {
+	if sie.issue == nil {
+		return nil, fmt.Errorf("issue function not configured")
+	}
+	return sie.issue(ctx, walletPublicKeyHash, approvalDigest, endBlock)
+}
+
+func TestServerIssuesSignerApprovalCertificate(t *testing.T) {
+	endBlock := uint64(12345678)
+	expected := &SignerApprovalCertificate{
+		CertificateVersion: 2,
+		SignatureAlgorithm: "tecdsa-secp256k1",
+		ApprovalDigest:     "0x" + strings.Repeat("11", 32),
+		WalletPublicKey:    "0x04" + strings.Repeat("22", 64),
+		SignerSetHash:      "0x" + strings.Repeat("33", 32),
+		Signature:          "0x30" + strings.Repeat("44", 32),
+		EndBlock:           &endBlock,
+	}
+
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedIssuerEngine{
+		issue: func(
+			_ context.Context,
+			walletPublicKeyHash [20]byte,
+			approvalDigest []byte,
+			gotEndBlock uint64,
+		) (*SignerApprovalCertificate, error) {
+			if gotEndBlock != endBlock {
+				t.Fatalf("unexpected endBlock: %d", gotEndBlock)
+			}
+			if hex.EncodeToString(walletPublicKeyHash[:]) != strings.Repeat("12", 20) {
+				t.Fatalf("unexpected wallet pkh: %x", walletPublicKeyHash)
+			}
+			if hex.EncodeToString(approvalDigest) != strings.Repeat("11", 32) {
+				t.Fatalf("unexpected approval digest: %x", approvalDigest)
+			}
+			return expected, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	defer server.Close()
+
+	payload := mustJSON(t, IssueSignerApprovalCertificateInput{
+		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
+		ApprovalDigest:      "0x" + strings.Repeat("11", 32),
+		EndBlock:            endBlock,
+	})
+
+	response, err := http.Post(
+		server.URL+"/v1/admin/signer-approval-certificates",
+		"application/json",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("unexpected status: %d %s", response.StatusCode, string(body))
+	}
+
+	var got SignerApprovalCertificate
+	if err := json.NewDecoder(response.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ApprovalDigest != expected.ApprovalDigest {
+		t.Fatalf("unexpected certificate: %+v", got)
+	}
+}
+
+func TestServerReturns501WhenEngineLacksCertificateIssuer(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedEngine{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	defer server.Close()
+
+	payload := mustJSON(t, IssueSignerApprovalCertificateInput{
+		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
+		ApprovalDigest:      "0x" + strings.Repeat("11", 32),
+		EndBlock:            12345678,
+	})
+
+	response, err := http.Post(
+		server.URL+"/v1/admin/signer-approval-certificates",
+		"application/json",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNotImplemented {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected 501, got %d %s", response.StatusCode, string(body))
+	}
+}
+
+func TestServerRequiresBearerTokenForCertificateIssuer(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedIssuerEngine{
+		issue: func(
+			context.Context,
+			[20]byte,
+			[]byte,
+			uint64,
+		) (*SignerApprovalCertificate, error) {
+			endBlock := uint64(1)
+			return &SignerApprovalCertificate{EndBlock: &endBlock}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service, context.Background(), "test-token", true))
+	defer server.Close()
+
+	payload := mustJSON(t, IssueSignerApprovalCertificateInput{
+		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
+		ApprovalDigest:      "0x" + strings.Repeat("11", 32),
+		EndBlock:            12345678,
+	})
+
+	unauthorized, err := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/v1/admin/signer-approval-certificates",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unauthorized.Header.Set("Content-Type", "application/json")
+
+	response, err := http.DefaultClient.Do(unauthorized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected 401, got %d %s", response.StatusCode, string(body))
+	}
+
+	authorized, err := http.NewRequest(
+		http.MethodPost,
+		server.URL+"/v1/admin/signer-approval-certificates",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorized.Header.Set("Content-Type", "application/json")
+	authorized.Header.Set("Authorization", "Bearer test-token")
+
+	authorizedResponse, err := http.DefaultClient.Do(authorized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer authorizedResponse.Body.Close()
+	if authorizedResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(authorizedResponse.Body)
+		t.Fatalf("expected 200, got %d %s", authorizedResponse.StatusCode, string(body))
+	}
+}
+
+func TestServerRejectsUnknownFieldsOnCertificateIssuer(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedIssuerEngine{
+		issue: func(
+			context.Context,
+			[20]byte,
+			[]byte,
+			uint64,
+		) (*SignerApprovalCertificate, error) {
+			t.Fatal("issuer should not be called for malformed bodies")
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	defer server.Close()
+
+	payload := []byte(`{
+		"walletPublicKeyHash":"0x` + strings.Repeat("12", 20) + `",
+		"approvalDigest":"0x` + strings.Repeat("11", 32) + `",
+		"endBlock":12345678,
+		"unexpected":true
+	}`)
+
+	response, err := http.Post(
+		server.URL+"/v1/admin/signer-approval-certificates",
+		"application/json",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected 400, got %d %s", response.StatusCode, string(body))
+	}
+}
+
+func TestServerRejectsInvalidCertificateIssuerInput(t *testing.T) {
+	handle := newMemoryHandle()
+	service, err := NewService(handle, &scriptedIssuerEngine{
+		issue: func(
+			context.Context,
+			[20]byte,
+			[]byte,
+			uint64,
+		) (*SignerApprovalCertificate, error) {
+			t.Fatal("issuer should not be called for invalid input")
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(newHandler(service, context.Background(), "", true))
+	defer server.Close()
+
+	payload := mustJSON(t, IssueSignerApprovalCertificateInput{
+		WalletPublicKeyHash: "0x" + strings.Repeat("12", 20),
+		ApprovalDigest:      "0x" + strings.Repeat("11", 32),
+		EndBlock:            0,
+	})
+
+	response, err := http.Post(
+		server.URL+"/v1/admin/signer-approval-certificates",
+		"application/json",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected 400, got %d %s", response.StatusCode, string(body))
 	}
 }

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -219,9 +219,10 @@ func newRequestID(prefix string) (string, error) {
 }
 
 // IssueSignerApprovalCertificate asks the engine to threshold-sign a v2
-// SignerApprovalCertificate for the given wallet and approval digest. Engines
-// that do not implement SignerApprovalCertificateIssuer return
-// ErrSignerApprovalCertificateIssuerUnsupported.
+// SignerApprovalCertificate for the given wallet over a digest this node
+// derives itself from an authenticated artifact approval -- never a
+// caller-asserted digest. Engines that do not implement
+// SignerApprovalCertificateIssuer return ErrSignerApprovalCertificateIssuerUnsupported.
 func (s *Service) IssueSignerApprovalCertificate(
 	ctx context.Context,
 	input IssueSignerApprovalCertificateInput,
@@ -239,22 +240,42 @@ func (s *Service) IssueSignerApprovalCertificate(
 		return nil, err
 	}
 
-	approvalDigest, err := decodeBytes32HexString(
-		"approvalDigest",
-		input.ApprovalDigest,
+	if input.EndBlock == 0 {
+		return nil, NewInputError("endBlock is required")
+	}
+
+	approvalDigest, err := deriveIssuanceApprovalDigest(
+		input.Route,
+		input.Reserve,
+		input.Network,
+		input.ArtifactApprovals,
+		s.depositorTrustRoots,
+		s.custodianTrustRoots,
+		s.eip712ChainID,
+		s.eip712Salt,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	if input.EndBlock == 0 {
-		return nil, NewInputError("endBlock is required")
+	// Certificate issuance runs the same class of expensive threshold-signing
+	// round as Submit and Poll, so it is bounded by the same maxInFlight
+	// semaphore -- an unbounded number of concurrent issuance rounds must
+	// never be able to saturate the engine when Submit/Poll already respect
+	// this cap.
+	if s.inFlightSlots != nil {
+		select {
+		case s.inFlightSlots <- struct{}{}:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		defer func() { <-s.inFlightSlots }()
 	}
 
 	return issuer.IssueSignerApprovalCertificate(
 		ctx,
 		walletPublicKeyHash,
-		approvalDigest[:],
+		approvalDigest,
 		input.EndBlock,
 	)
 }

--- a/pkg/covenantsigner/service.go
+++ b/pkg/covenantsigner/service.go
@@ -218,6 +218,47 @@ func newRequestID(prefix string) (string, error) {
 	return fmt.Sprintf("%s_%s", prefix, hex.EncodeToString(randomBytes)), nil
 }
 
+// IssueSignerApprovalCertificate asks the engine to threshold-sign a v2
+// SignerApprovalCertificate for the given wallet and approval digest. Engines
+// that do not implement SignerApprovalCertificateIssuer return
+// ErrSignerApprovalCertificateIssuerUnsupported.
+func (s *Service) IssueSignerApprovalCertificate(
+	ctx context.Context,
+	input IssueSignerApprovalCertificateInput,
+) (*SignerApprovalCertificate, error) {
+	issuer, ok := s.engine.(SignerApprovalCertificateIssuer)
+	if !ok {
+		return nil, ErrSignerApprovalCertificateIssuerUnsupported
+	}
+
+	walletPublicKeyHash, err := decodeBytes20HexString(
+		"walletPublicKeyHash",
+		input.WalletPublicKeyHash,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	approvalDigest, err := decodeBytes32HexString(
+		"approvalDigest",
+		input.ApprovalDigest,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if input.EndBlock == 0 {
+		return nil, NewInputError("endBlock is required")
+	}
+
+	return issuer.IssueSignerApprovalCertificate(
+		ctx,
+		walletPublicKeyHash,
+		approvalDigest[:],
+		input.EndBlock,
+	)
+}
+
 func applyTransition(job *Job, transition *Transition, now time.Time) {
 	if transition == nil {
 		return

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -232,6 +232,14 @@ type SignerApprovalCertificate struct {
 	EndBlock           *uint64  `json:"endBlock"`
 }
 
+// IssueSignerApprovalCertificateInput is the request body for
+// POST /v1/admin/signer-approval-certificates.
+type IssueSignerApprovalCertificateInput struct {
+	WalletPublicKeyHash string `json:"walletPublicKeyHash"`
+	ApprovalDigest      string `json:"approvalDigest"`
+	EndBlock            uint64 `json:"endBlock"`
+}
+
 type SigningRequirements struct {
 	SignerRequired    bool `json:"signerRequired"`
 	CustodianRequired bool `json:"custodianRequired"`

--- a/pkg/covenantsigner/types.go
+++ b/pkg/covenantsigner/types.go
@@ -233,11 +233,20 @@ type SignerApprovalCertificate struct {
 }
 
 // IssueSignerApprovalCertificateInput is the request body for
-// POST /v1/admin/signer-approval-certificates.
+// POST /v1/admin/signer-approval-certificates. The caller supplies an
+// authenticated artifact approval, not a bare digest: Route/Reserve/Network
+// select the trust-root scope this node uses to resolve the depositor (and,
+// for qc_v1, custodian) identity that must have signed ArtifactApprovals.
+// The server verifies that signature itself -- the same authenticity check
+// the Submit path runs -- and derives the signed digest from the
+// authenticated payload; it never signs a caller-asserted digest.
 type IssueSignerApprovalCertificateInput struct {
-	WalletPublicKeyHash string `json:"walletPublicKeyHash"`
-	ApprovalDigest      string `json:"approvalDigest"`
-	EndBlock            uint64 `json:"endBlock"`
+	WalletPublicKeyHash string                   `json:"walletPublicKeyHash"`
+	Route               TemplateID               `json:"route"`
+	Reserve             string                   `json:"reserve"`
+	Network             string                   `json:"network"`
+	ArtifactApprovals   ArtifactApprovalEnvelope `json:"artifactApprovals"`
+	EndBlock            uint64                   `json:"endBlock"`
 }
 
 type SigningRequirements struct {

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -229,6 +229,22 @@ func decodeBytes32HexString(name string, value string) ([32]byte, error) {
 	return decoded, nil
 }
 
+func decodeBytes20HexString(name string, value string) ([20]byte, error) {
+	var decoded [20]byte
+
+	if err := validateAddressString(name, value); err != nil {
+		return decoded, err
+	}
+
+	rawValue, err := hex.DecodeString(strings.TrimPrefix(value, "0x"))
+	if err != nil {
+		return decoded, &inputError{fmt.Sprintf("%s must be valid hex", name)}
+	}
+
+	copy(decoded[:], rawValue)
+	return decoded, nil
+}
+
 func normalizeLowerHex(value string) string {
 	return strings.ToLower(value)
 }

--- a/pkg/covenantsigner/validation.go
+++ b/pkg/covenantsigner/validation.go
@@ -204,6 +204,17 @@ func validateBytes32HexString(name string, value string) error {
 
 	return nil
 }
+func validateBytes20HexString(name string, value string) error {
+	if err := validateHexString(name, value); err != nil {
+		return err
+	}
+
+	if len(value) != 42 {
+		return &inputError{fmt.Sprintf("%s must be a 20-byte 0x-prefixed hex string", name)}
+	}
+
+	return nil
+}
 
 func validateUint32Range(name string, value uint64) error {
 	if value > math.MaxUint32 {
@@ -232,7 +243,7 @@ func decodeBytes32HexString(name string, value string) ([32]byte, error) {
 func decodeBytes20HexString(name string, value string) ([20]byte, error) {
 	var decoded [20]byte
 
-	if err := validateAddressString(name, value); err != nil {
+	if err := validateBytes20HexString(name, value); err != nil {
 		return decoded, err
 	}
 

--- a/pkg/covenantsigner/validation_approval.go
+++ b/pkg/covenantsigner/validation_approval.go
@@ -832,3 +832,148 @@ func resolveExpectedCustodianPublicKey(
 
 	return "", false
 }
+
+// deriveIssuanceApprovalDigest verifies that artifactApprovals carries
+// exactly the roles required for route, each authentically signed by the
+// depositor (and, for qc_v1, custodian) identity pinned in this node's own
+// depositorTrustRoots/custodianTrustRoots for the (route, reserve, network)
+// scope -- the same authenticity check validateArtifactApprovalAuthenticity
+// runs on the Submit path -- then returns the EIP-712 digest this node
+// derived from the authenticated payload. It never trusts a caller-asserted
+// digest: the issuer only ever signs a digest it computed itself.
+func deriveIssuanceApprovalDigest(
+	route TemplateID,
+	reserve string,
+	network string,
+	artifactApprovals ArtifactApprovalEnvelope,
+	depositorTrustRoots []DepositorTrustRoot,
+	custodianTrustRoots []CustodianTrustRoot,
+	chainID uint64,
+	salt [32]byte,
+) ([]byte, error) {
+	requiredRoles, err := requiredStructuredArtifactApprovalRoles(route)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := artifactApprovals.Payload
+	if payload.ApprovalVersion != artifactApprovalVersion {
+		return nil, &inputError{"artifactApprovals.payload.approvalVersion must equal 2"}
+	}
+	if payload.Route != route {
+		return nil, &inputError{"artifactApprovals.payload.route must match route"}
+	}
+	if payload.ScriptTemplateID != route {
+		return nil, &inputError{"artifactApprovals.payload.scriptTemplateId must match route"}
+	}
+	if err := validateBytes32HexString(
+		"artifactApprovals.payload.destinationCommitmentHash",
+		payload.DestinationCommitmentHash,
+	); err != nil {
+		return nil, err
+	}
+	if err := validateBytes32HexString(
+		"artifactApprovals.payload.planCommitmentHash",
+		payload.PlanCommitmentHash,
+	); err != nil {
+		return nil, err
+	}
+	if err := validateIssuanceApprovalRoles(artifactApprovals.Approvals, requiredRoles); err != nil {
+		return nil, err
+	}
+
+	// trustRootLookupScope only reads Route, Reserve, and the network of
+	// whichever destination reservation is set. RedeemDestination is used
+	// purely as a carrier for the (reserve, network) trust-root scope here --
+	// certificate issuance has no real destination reservation of its own.
+	scopeRequest := RouteSubmitRequest{
+		Route:   route,
+		Reserve: reserve,
+		RedeemDestination: &RedeemDestinationReservation{
+			Network: strings.ToLower(strings.TrimSpace(network)),
+		},
+	}
+
+	depositorPublicKey, hasDepositorTrustRoot := resolveExpectedDepositorPublicKey(
+		scopeRequest,
+		depositorTrustRoots,
+	)
+	if !hasDepositorTrustRoot {
+		return nil, &inputError{
+			"no depositorTrustRoots entry is configured for the requested route/reserve/network; certificate issuance requires a pinned depositor identity",
+		}
+	}
+	depositorEthAddress := resolveExpectedDepositorEthAddress(scopeRequest, depositorTrustRoots)
+
+	var custodianPublicKey string
+	if containsArtifactApprovalRole(requiredRoles, ArtifactApprovalRoleCustodian) {
+		expectedCustodianPublicKey, hasCustodianTrustRoot := resolveExpectedCustodianPublicKey(
+			scopeRequest,
+			custodianTrustRoots,
+		)
+		if !hasCustodianTrustRoot {
+			return nil, &inputError{
+				"no custodianTrustRoots entry is configured for the requested route/reserve/network; certificate issuance requires a pinned custodian identity",
+			}
+		}
+		custodianPublicKey = expectedCustodianPublicKey
+	}
+
+	authenticityRequest := RouteSubmitRequest{ArtifactApprovals: &artifactApprovals}
+	if err := validateArtifactApprovalAuthenticity(
+		authenticityRequest,
+		depositorPublicKey,
+		depositorEthAddress,
+		custodianPublicKey,
+		chainID,
+		salt,
+	); err != nil {
+		return nil, err
+	}
+
+	return ComputeArtifactApprovalDigest(payload, chainID, salt)
+}
+
+func validateIssuanceApprovalRoles(
+	approvals []ArtifactRoleApproval,
+	requiredRoles []ArtifactApprovalRole,
+) error {
+	if len(approvals) != len(requiredRoles) {
+		return &inputError{"artifactApprovals.approvals must include exactly the roles required for route"}
+	}
+
+	seenRoles := make(map[ArtifactApprovalRole]struct{}, len(requiredRoles))
+	for i, approval := range approvals {
+		if !containsArtifactApprovalRole(requiredRoles, approval.Role) {
+			return &inputError{fmt.Sprintf(
+				"artifactApprovals.approvals[%d].role is not allowed for route",
+				i,
+			)}
+		}
+		if _, ok := seenRoles[approval.Role]; ok {
+			return &inputError{fmt.Sprintf(
+				"artifactApprovals.approvals[%d].role duplicates role %s",
+				i,
+				approval.Role,
+			)}
+		}
+		if err := validateHexString(
+			fmt.Sprintf("artifactApprovals.approvals[%d].signature", i),
+			approval.Signature,
+		); err != nil {
+			return err
+		}
+		seenRoles[approval.Role] = struct{}{}
+	}
+
+	return nil
+}
+
+func containsArtifactApprovalRole(roles []ArtifactApprovalRole, role ArtifactApprovalRole) bool {
+	for _, candidate := range roles {
+		if candidate == role {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -416,12 +416,20 @@ func (cse *covenantSignerEngine) IssueSignerApprovalCertificate(
 		)
 	}
 
-	return signingExecutor.issueSignerApprovalCertificate(
+	certificate, err := signingExecutor.issueSignerApprovalCertificate(
 		ctx,
 		approvalDigest,
 		startBlock,
 		endBlock,
 	)
+	if err != nil {
+		if errors.Is(err, errSigningExecutorBusy) {
+			return nil, covenantsigner.ErrSignerApprovalCertificateIssuerBusy
+		}
+		return nil, err
+	}
+
+	return certificate, nil
 }
 
 func (cse *covenantSignerEngine) submitSelfV1(

--- a/pkg/tbtc/covenant_signer.go
+++ b/pkg/tbtc/covenant_signer.go
@@ -43,9 +43,10 @@ type covenantSignerEngine struct {
 // engine also providing a current block height; losing this interface
 // silently would make certificates never expire.
 var (
-	_ covenantsigner.Engine                     = (*covenantSignerEngine)(nil)
-	_ covenantsigner.SignerApprovalVerifier     = (*covenantSignerEngine)(nil)
-	_ covenantsigner.CurrentBlockHeightProvider = (*covenantSignerEngine)(nil)
+	_ covenantsigner.Engine                          = (*covenantSignerEngine)(nil)
+	_ covenantsigner.SignerApprovalVerifier          = (*covenantSignerEngine)(nil)
+	_ covenantsigner.CurrentBlockHeightProvider      = (*covenantSignerEngine)(nil)
+	_ covenantsigner.SignerApprovalCertificateIssuer = (*covenantSignerEngine)(nil)
 )
 
 // defaultMinActiveOutpointConfirmations is the confirmation threshold applied
@@ -330,6 +331,97 @@ func (cse *covenantSignerEngine) CurrentBlockHeight(context.Context) (uint64, er
 	}
 
 	return blockCounter.CurrentBlock()
+}
+
+// IssueSignerApprovalCertificate threshold-signs a v2 signer approval
+// certificate for a wallet this node controls. approvalDigest must match the
+// artifact-approval payload digest of the Submit request that will carry the
+// certificate. endBlock is the host-chain expiry height.
+func (cse *covenantSignerEngine) IssueSignerApprovalCertificate(
+	ctx context.Context,
+	walletPublicKeyHash [20]byte,
+	approvalDigest []byte,
+	endBlock uint64,
+) (*covenantsigner.SignerApprovalCertificate, error) {
+	if len(approvalDigest) != sha256.Size {
+		return nil, covenantsigner.NewInputError(
+			fmt.Sprintf(
+				"approvalDigest must be exactly %d bytes",
+				sha256.Size,
+			),
+		)
+	}
+
+	wallet, ok := cse.node.walletRegistry.getWalletByPublicKeyHash(
+		walletPublicKeyHash,
+	)
+	if !ok {
+		return nil, covenantsigner.NewInputError(
+			"walletPublicKeyHash does not resolve to a wallet controlled by this node",
+		)
+	}
+
+	walletChainData, err := cse.node.chain.GetWallet(walletPublicKeyHash)
+	if err != nil {
+		if errors.Is(err, ErrWalletNotFound) {
+			return nil, covenantsigner.NewInputError(
+				"walletPublicKeyHash must resolve to a registered on-chain wallet",
+			)
+		}
+		return nil, fmt.Errorf(
+			"cannot resolve on-chain wallet for signer approval certificate: %w",
+			err,
+		)
+	}
+	if err := ensureWalletRegistryDataAvailable(
+		walletChainData,
+		"issue signer approval certificate",
+	); err != nil {
+		return nil, err
+	}
+	if !isCovenantSigningEligibleState(walletChainData.State) {
+		return nil, covenantsigner.NewInputError(
+			fmt.Sprintf(
+				"walletPublicKeyHash resolves to a wallet in state [%v] that is "+
+					"not eligible for covenant signing",
+				walletChainData.State,
+			),
+		)
+	}
+
+	signingExecutor, ok, err := cse.node.getSigningExecutor(wallet.publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve signing executor: %w", err)
+	}
+	if !ok {
+		return nil, covenantsigner.NewInputError(
+			"wallet is not controlled by this node",
+		)
+	}
+
+	startBlock, err := signingExecutor.getCurrentBlockFn()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot get current host-chain block for signer approval certificate: %w",
+			err,
+		)
+	}
+	if endBlock <= startBlock {
+		return nil, covenantsigner.NewInputError(
+			fmt.Sprintf(
+				"endBlock [%d] must be greater than the current host-chain block [%d]",
+				endBlock,
+				startBlock,
+			),
+		)
+	}
+
+	return signingExecutor.issueSignerApprovalCertificate(
+		ctx,
+		approvalDigest,
+		startBlock,
+		endBlock,
+	)
 }
 
 func (cse *covenantSignerEngine) submitSelfV1(

--- a/pkg/tbtc/signer_approval_certificate_test.go
+++ b/pkg/tbtc/signer_approval_certificate_test.go
@@ -1031,3 +1031,139 @@ func TestSignerApprovalCertificateSigningDigestMatchesCrossLanguageVectorAboveUi
 		)
 	}
 }
+
+func TestCovenantSignerEngineIssueSignerApprovalCertificateHappyPath(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+	cse := &covenantSignerEngine{node: node}
+
+	executor, ok, err := node.getSigningExecutor(walletPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("node is supposed to control wallet signers")
+	}
+	startBlock, err := executor.getCurrentBlockFn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	approvalDigest := sha256.Sum256([]byte("engine-issue-happy-path"))
+	walletPublicKeyHash := bitcoin.PublicKeyHash(walletPublicKey)
+
+	certificate, err := cse.IssueSignerApprovalCertificate(
+		context.Background(),
+		walletPublicKeyHash,
+		approvalDigest[:],
+		startBlock+100000,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if certificate == nil {
+		t.Fatal("expected a certificate")
+	}
+	if !strings.EqualFold(
+		certificate.ApprovalDigest,
+		"0x"+hex.EncodeToString(approvalDigest[:]),
+	) {
+		t.Fatalf("unexpected approval digest: %s", certificate.ApprovalDigest)
+	}
+	if certificate.EndBlock == nil || *certificate.EndBlock != startBlock+100000 {
+		t.Fatalf("unexpected end block: %v", certificate.EndBlock)
+	}
+}
+
+func TestCovenantSignerEngineIssueSignerApprovalCertificateRejectsUnknownWallet(t *testing.T) {
+	node, _, _ := setupCovenantSignerTestNode(t)
+	cse := &covenantSignerEngine{node: node}
+
+	approvalDigest := sha256.Sum256([]byte("unknown-wallet"))
+	var unknownPKH [20]byte
+	copy(unknownPKH[:], bytes.Repeat([]byte{0x11}, 20))
+
+	_, err := cse.IssueSignerApprovalCertificate(
+		context.Background(),
+		unknownPKH,
+		approvalDigest[:],
+		math.MaxUint64,
+	)
+	if err == nil || !strings.Contains(err.Error(), "controlled by this node") {
+		t.Fatalf("expected uncontrolled-wallet rejection, got %v", err)
+	}
+}
+
+func TestCovenantSignerEngineIssueSignerApprovalCertificateRejectsBadDigestLength(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+	cse := &covenantSignerEngine{node: node}
+
+	_, err := cse.IssueSignerApprovalCertificate(
+		context.Background(),
+		bitcoin.PublicKeyHash(walletPublicKey),
+		[]byte("too-short"),
+		math.MaxUint64,
+	)
+	if err == nil || !strings.Contains(err.Error(), "exactly 32 bytes") {
+		t.Fatalf("expected digest-length rejection, got %v", err)
+	}
+}
+
+func TestCovenantSignerEngineIssueSignerApprovalCertificateRejectsEndBlockNotAfterCurrent(
+	t *testing.T,
+) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+	cse := &covenantSignerEngine{node: node}
+
+	executor, ok, err := node.getSigningExecutor(walletPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("node is supposed to control wallet signers")
+	}
+	startBlock, err := executor.getCurrentBlockFn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	approvalDigest := sha256.Sum256([]byte("end-block-too-soon"))
+	_, err = cse.IssueSignerApprovalCertificate(
+		context.Background(),
+		bitcoin.PublicKeyHash(walletPublicKey),
+		approvalDigest[:],
+		startBlock,
+	)
+	if err == nil || !strings.Contains(err.Error(), "must be greater than the current host-chain block") {
+		t.Fatalf("expected endBlock rejection, got %v", err)
+	}
+}
+
+func TestCovenantSignerEngineIssueSignerApprovalCertificateRejectsClosedWallet(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+	cse := &covenantSignerEngine{node: node}
+
+	localChain, ok := node.chain.(*localChain)
+	if !ok {
+		t.Fatal("expected local chain implementation")
+	}
+
+	walletPublicKeyHash := bitcoin.PublicKeyHash(walletPublicKey)
+	existing, err := localChain.GetWallet(walletPublicKeyHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed := *existing
+	closed.State = StateClosed
+	localChain.setWallet(walletPublicKeyHash, &closed)
+
+	approvalDigest := sha256.Sum256([]byte("closed-wallet"))
+	_, err = cse.IssueSignerApprovalCertificate(
+		context.Background(),
+		walletPublicKeyHash,
+		approvalDigest[:],
+		math.MaxUint64,
+	)
+	if err == nil || !strings.Contains(err.Error(), "not eligible for covenant signing") {
+		t.Fatalf("expected closed-wallet rejection, got %v", err)
+	}
+}

--- a/pkg/tbtc/signer_approval_certificate_test.go
+++ b/pkg/tbtc/signer_approval_certificate_test.go
@@ -1093,6 +1093,30 @@ func TestCovenantSignerEngineIssueSignerApprovalCertificateRejectsUnknownWallet(
 	}
 }
 
+func TestCovenantSignerEngineIssueSignerApprovalCertificateRejectsMissingOnChainWallet(t *testing.T) {
+	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
+	cse := &covenantSignerEngine{node: node}
+
+	localChain, ok := node.chain.(*localChain)
+	if !ok {
+		t.Fatal("expected local chain implementation")
+	}
+	walletPublicKeyHash := bitcoin.PublicKeyHash(walletPublicKey)
+	localChain.walletsMutex.Lock()
+	delete(localChain.wallets, walletPublicKeyHash)
+	localChain.walletsMutex.Unlock()
+
+	approvalDigest := sha256.Sum256([]byte("missing-on-chain-wallet"))
+	_, err := cse.IssueSignerApprovalCertificate(
+		context.Background(),
+		walletPublicKeyHash,
+		approvalDigest[:],
+		math.MaxUint64,
+	)
+	if err == nil || !strings.Contains(err.Error(), "must resolve to a registered on-chain wallet") {
+		t.Fatalf("expected missing on-chain wallet rejection, got %v", err)
+	}
+}
 func TestCovenantSignerEngineIssueSignerApprovalCertificateRejectsBadDigestLength(t *testing.T) {
 	node, _, walletPublicKey := setupCovenantSignerTestNode(t)
 	cse := &covenantSignerEngine{node: node}


### PR DESCRIPTION
## Summary
- Stacked on #4169: expose `POST /v1/admin/signer-approval-certificates` so operators can obtain a real v2 `SignerApprovalCertificate` for live Submit.
- Reuses existing threshold-signing issuance (`issueSignerApprovalCertificate`); request binds `walletPublicKeyHash` + `approvalDigest` + `endBlock` (digest must match the job’s artifact-approval payload).
- Auth / rate-limit / 5-minute timeout match submit; engines without the issuer interface return 501.

## Test plan
- [x] `go test ./pkg/covenantsigner/ -run 'TestServerIssuesSignerApprovalCertificate|TestServerReturns501|TestServerRequiresBearerTokenForCertificateIssuer|TestServerRejectsUnknownFieldsOnCertificateIssuer|TestServerRejectsInvalidCertificateIssuerInput'`
- [x] `go test ./pkg/tbtc/ -run 'TestCovenantSignerEngineIssueSignerApprovalCertificate'`
- [ ] Sepolia smoke: issue cert for wallet `0x12b3fd…` with a real VBA approval digest → Submit REDEEM → Poll; observe whether other ops join the signing round


Made with [Cursor](https://cursor.com)