### PR TITLE
fix(tbtcpg): use RedemptionParameters struct return, not old 8-tuple

### DIFF
--- a/pkg/tbtcpg/redemptions.go
+++ b/pkg/tbtcpg/redemptions.go
@@ -222,7 +222,7 @@ func (rt *RedemptionTask) ProposeRedemption(
 	if fee <= 0 {
 		taskLogger.Infof("estimating redemption transaction fee")
 
-		_, _, txMaxFee, txMaxTotalFee, _, _, _, err := rt.chain.GetRedemptionParameters()
+		redemptionParameters, err := rt.chain.GetRedemptionParameters()
 		if err != nil {
 			return nil, fmt.Errorf(
 				"cannot get redemption tx max total fee: [%w]",
@@ -233,7 +233,7 @@ func (rt *RedemptionTask) ProposeRedemption(
 		estimatedFee, err := EstimateRedemptionFee(
 			rt.btcChain,
 			redeemersOutputScripts,
-			txMaxTotalFee,
+			redemptionParameters.TxMaxTotalFee,
 		)
 		if err != nil {
 			return nil, fmt.Errorf(
@@ -259,13 +259,13 @@ func (rt *RedemptionTask) ProposeRedemption(
 		// diagnostic rather than an exact predictor.
 		requestsCount := int64(len(redeemersOutputScripts))
 		maxShare := fee/requestsCount + fee%requestsCount
-		if uint64(maxShare) > txMaxFee {
+		if uint64(maxShare) > redemptionParameters.TxMaxFee {
 			taskLogger.Warnf(
 				"floored redemption fee share [%d] exceeds the per-request "+
 					"maximum fee [%d]; the proposal will likely be rejected "+
 					"by on-chain validation",
 				maxShare,
-				txMaxFee,
+				redemptionParameters.TxMaxFee,
 			)
 		}
 	}


### PR DESCRIPTION
## Problem

`main` currently fails to build. `client-scan`, `client-vet`, `client-lint`, and `client-build-test-publish` all fail on the latest `main` commit (`fac4b79b1`):

```
pkg/tbtcpg/redemptions.go:225:50: assignment mismatch: 8 variables but rt.chain.GetRedemptionParameters returns 2 values
```

## Root cause

Two same-day (2026-07-23) divergent commits landed without either being an ancestor of the other:
- `c4cc0addd` refactored `GetRedemptionParameters()` from an 8-value positional return to a single `tbtc.RedemptionParameters` struct + error.
- `ad89b38d9`/`6a7060800` (separate branch, same day) added a *new* call site in `redemptions.go:225` still using the old 8-value destructuring.

The merge that combined both branches didn't catch the mismatch.

## Fix

Use the already-fetched `redemptionParameters` struct (same pattern as the call site at line 155) instead of the stale positional destructuring. `txMaxFee`/`txMaxTotalFee` become `redemptionParameters.TxMaxFee`/`redemptionParameters.TxMaxTotalFee`.

## Verification

- `go vet ./pkg/tbtcpg/...` clean.
- `go build ./pkg/tbtcpg/...` succeeds.
- `go test ./pkg/tbtcpg/... -run TestEstimate` — all pass (TestEstimateRedemptionFee, TestEstimateDepositsSweepFee_MinimumFloorAndBuffer, TestEstimateMovedFundsSweepFee, TestEstimateMovingFundsFee).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redemption fee estimation and fee-share warnings by using the correct transaction fee limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->