### PR TITLE
feat(tbtc-signer): bounded n-t+1 concurrent interactive attempts (#4251)

### DIFF
--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -510,7 +510,9 @@ pub fn interactive_session_open(
                     .find(|(_, interactive)| interactive.member_identifier == member_identifier);
                 let matching_attempt_idempotent = live
                     .filter(|(_, interactive)| interactive.attempt_context.attempt_id == attempt_id)
-                    .map(|(_, interactive)| interactive.open_request_fingerprint == request_fingerprint);
+                    .map(|(_, interactive)| {
+                        interactive.open_request_fingerprint == request_fingerprint
+                    });
                 let live_attempt = live.map(|(_, interactive)| {
                     (
                         interactive.attempt_context.attempt_id.clone(),
@@ -613,14 +615,15 @@ pub fn interactive_session_open(
                     .count()
             })
             .unwrap_or(0);
-        let cap = concurrent_attempt_cap_for_dkg(dkg_participant_count, dkg_threshold)
-            .ok_or_else(|| {
+        let cap = concurrent_attempt_cap_for_dkg(dkg_participant_count, dkg_threshold).ok_or_else(
+            || {
                 EngineError::Internal(format!(
                     "cannot compute per-session concurrent-attempt cap from DKG \
                      participant_count [{}] and threshold [{}] for session [{}]",
                     dkg_participant_count, dkg_threshold, request.session_id
                 ))
-            })?;
+            },
+        )?;
         if current_attempts >= cap {
             return Err(EngineError::SigningPolicyRejected {
                 session_id: request.session_id.clone(),
@@ -634,7 +637,6 @@ pub fn interactive_session_open(
             });
         }
     }
-
 
     // this session already holds one of those slots, so the cap does
     // not apply; when not replacing, a new slot is being taken.
@@ -853,12 +855,8 @@ pub fn interactive_session_open(
     // never share nonce material. The outer map's keys are distinct attempt_ids.
     // The cap is checked above; this assert confirms the install did not
     // somehow exceed it (e.g. through a future change that bypasses the gate).
-    let cap_after_install = concurrent_attempt_cap_for_dkg(
-
-        dkg_participant_count,
-        dkg_threshold,
-    )
-    .unwrap_or(usize::MAX);
+    let cap_after_install =
+        concurrent_attempt_cap_for_dkg(dkg_participant_count, dkg_threshold).unwrap_or(usize::MAX);
     debug_assert!(
         session.interactive_signing.len() <= cap_after_install,
         "concurrent attempt count exceeded the per-session n-t+1 cap after install"
@@ -1087,10 +1085,11 @@ pub fn interactive_round2(
                 )
             });
     if attempt_finalized {
-        remove_interactive_entry(session, &attempt_id, request.member_identifier)
-            .map(|mut removed| {
-                zeroize_interactive_round1(&mut removed);
-            });
+        if let Some(mut removed) =
+            remove_interactive_entry(session, &attempt_id, request.member_identifier)
+        {
+            zeroize_interactive_round1(&mut removed);
+        }
         return Err(EngineError::InteractiveAttemptAlreadyAggregated {
             session_id: request.session_id.clone(),
             attempt_id,
@@ -1247,10 +1246,11 @@ pub fn interactive_round2(
                 session_id: request.session_id.clone(),
                 consumed_marker: consumed_marker.clone(),
             });
-            remove_interactive_entry(session, &attempt_id, request.member_identifier)
-                .map(|mut removed| {
-                    zeroize_interactive_round1(&mut removed);
-                });
+            if let Some(mut removed) =
+                remove_interactive_entry(session, &attempt_id, request.member_identifier)
+            {
+                zeroize_interactive_round1(&mut removed);
+            }
         } else {
             session
                 .consumed_interactive_attempt_markers
@@ -1840,10 +1840,9 @@ pub fn interactive_session_abort(
                 .get_mut(&request.session_id)
                 .expect("abort session existed after state-file replacement");
             for (attempt_id, member) in &members_to_abort {
-                remove_interactive_entry(session, attempt_id, *member)
-                    .map(|mut removed| {
-                        zeroize_interactive_round1(&mut removed);
-                    });
+                if let Some(mut removed) = remove_interactive_entry(session, attempt_id, *member) {
+                    zeroize_interactive_round1(&mut removed);
+                }
             }
             mark_persistence_pending(PersistencePendingOperation::InteractiveState {
                 session_id: request.session_id.clone(),
@@ -1866,10 +1865,9 @@ pub fn interactive_session_abort(
         .get_mut(&request.session_id)
         .expect("abort session existed after durable retirement");
     for (attempt_id, member) in &members_to_abort {
-        remove_interactive_entry(session, attempt_id, *member)
-            .map(|mut removed| {
-                zeroize_interactive_round1(&mut removed);
-            });
+        if let Some(mut removed) = remove_interactive_entry(session, attempt_id, *member) {
+            zeroize_interactive_round1(&mut removed);
+        }
     }
     // aborted. A no-op call (no session, or an attempt_id filter that
     // matched nothing) returns aborted == false and must not inflate the
@@ -2163,10 +2161,9 @@ fn remove_finalized_interactive_members(
         })
         .unwrap_or_default();
     for member in finalized_members {
-        remove_interactive_entry(session, attempt_id, member)
-            .map(|mut removed| {
-                zeroize_interactive_round1(&mut removed);
-            });
+        if let Some(mut removed) = remove_interactive_entry(session, attempt_id, member) {
+            zeroize_interactive_round1(&mut removed);
+        }
     }
 }
 
@@ -2222,7 +2219,6 @@ pub(crate) fn resolve_wallet_session_id(
 }
 
 pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) -> Vec<String> {
-
     let ttl = Duration::from_secs(interactive_session_ttl_seconds());
     let now = interactive_now();
     let mut changed_session_ids = HashSet::new();
@@ -2253,10 +2249,9 @@ pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) ->
             changed_session_ids.insert(session_id.clone());
         }
         for (attempt_id, member) in &expired {
-            remove_interactive_entry(session, attempt_id, *member)
-                .map(|mut removed| {
-                    zeroize_interactive_round1(&mut removed);
-                });
+            if let Some(mut removed) = remove_interactive_entry(session, attempt_id, *member) {
+                zeroize_interactive_round1(&mut removed);
+            }
         }
     }
     // Expiry has abort semantics. Retire idle per-message entries while

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -182,17 +182,26 @@ pub(crate) fn interactive_aggregate_package_completion_marker(
 // common message/threshold/included-subset shape, while the package-completion
 // marker above prevents cross-attempt reuse of that otherwise attempt-less
 // FROST package. An omitted non-coordinator never receives this fallback.
+//
+// Iterates EVERY concurrent attempt on this session (attempt-scoped nested map,
+// per spec section 8): authorization is recorded per attempt, not per session,
+// so concurrent attempts can each authorize their own Round2.
 fn interactive_aggregate_has_live_authorization(
     session: &SessionState,
     attempt_id: &str,
     signing_package: &frost::SigningPackage,
     taproot_merkle_root: Option<&[u8; 32]>,
 ) -> Result<bool, EngineError> {
-    for interactive in session.interactive_signing.values().filter(|interactive| {
-        interactive.attempt_context.attempt_id == attempt_id
-            && interactive.taproot_merkle_root.as_ref() == taproot_merkle_root
-            && interactive.round1.is_some()
-    }) {
+    for interactive in session
+        .interactive_signing
+        .values()
+        .flat_map(|members| members.values())
+        .filter(|interactive| {
+            interactive.attempt_context.attempt_id == attempt_id
+                && interactive.taproot_merkle_root.as_ref() == taproot_merkle_root
+                && interactive.round1.is_some()
+        })
+    {
         match verify_round2_signing_package(interactive, signing_package) {
             Ok(()) => return Ok(true),
             Err(error @ EngineError::Internal(_)) => return Err(error),
@@ -346,7 +355,7 @@ pub fn interactive_session_open(
                 session_id: request.session_id.clone(),
             },
         )?;
-    let (key_package, canonical_included_participants) =
+    let (key_package, canonical_included_participants, dkg_participant_count, dkg_threshold) =
         {
             let session = guard.sessions.get(&wallet_session_id).ok_or_else(|| {
                 EngineError::SessionNotFound {
@@ -462,12 +471,24 @@ pub fn interactive_session_open(
                     )));
                 }
             }
-            (key_package, canonical_included_participants)
+            (
+                key_package,
+                canonical_included_participants,
+                dkg.participant_count,
+                dkg.threshold,
+            )
         };
 
     // Disposition over the (now-confirmed) existing session: consumed
     // marker, idempotent/conflicting reopen of this exact attempt, and
     // the live attempt (id + number) for the replacement decision.
+    //
+    // Phase 7.6: the per-session interactive state is now an attempt-scoped
+    // nested map (attempt_id -> member_identifier -> state). A member's live
+    // entry lives under exactly one attempt (the one they last opened), so
+    // `live` is found by scanning the inner scopes. The per-session attempt
+    // count is the outer map's size (per spec section 8: "bounded n-t+1
+    // concurrent attempts per session").
     let member_identifier = request.member_identifier;
     let (already_consumed, matching_attempt_idempotent, live_attempt) =
         match guard.sessions.get(&request.session_id) {
@@ -480,12 +501,17 @@ pub fn interactive_session_open(
                     member_identifier,
                 );
                 // Disposition is scoped to THIS member's live entry; sibling seats are
-                // independent and on their own attempt timelines.
-                let live = session.interactive_signing.get(&member_identifier);
+                // independent and on their own attempt timelines. A member has at most
+                // one entry across the attempt scopes (their currently-open attempt).
+                let live = session
+                    .interactive_signing
+                    .values()
+                    .flat_map(|members| members.iter())
+                    .find(|(_, interactive)| interactive.member_identifier == member_identifier);
                 let matching_attempt_idempotent = live
-                    .filter(|interactive| interactive.attempt_context.attempt_id == attempt_id)
-                    .map(|interactive| interactive.open_request_fingerprint == request_fingerprint);
-                let live_attempt = live.map(|interactive| {
+                    .filter(|(_, interactive)| interactive.attempt_context.attempt_id == attempt_id)
+                    .map(|(_, interactive)| interactive.open_request_fingerprint == request_fingerprint);
+                let live_attempt = live.map(|(_, interactive)| {
                     (
                         interactive.attempt_context.attempt_id.clone(),
                         interactive.attempt_context.attempt_number,
@@ -508,11 +534,17 @@ pub fn interactive_session_open(
 
     match matching_attempt_idempotent {
         Some(true) => {
-            let interactive = guard
+            // Idempotent re-open touches the SAME (attempt_id, member_identifier) entry
+            // the request carries - locate it by attempt_id first, then by member, to
+            // support the nested attempt-scoped map (per spec section 8).
+            let session = guard
                 .sessions
                 .get_mut(&request.session_id)
-                .expect("idempotent Open session exists")
+                .expect("idempotent Open session exists");
+            let interactive = session
                 .interactive_signing
+                .get_mut(&attempt_id)
+                .expect("idempotent Open attempt scope exists")
                 .get_mut(&member_identifier)
                 .expect("idempotent Open member exists");
             interactive.last_activity_at = interactive_now();
@@ -529,7 +561,6 @@ pub fn interactive_session_open(
         }
         None => {}
     }
-
     // A DIFFERENT live attempt FOR THIS MEMBER is replaced ONLY by a strictly
     // newer attempt: this seat's retry loop advanced. A stale/delayed open for an
     // older or equal attempt must not roll this member back and wipe its newer
@@ -558,18 +589,60 @@ pub fn interactive_session_open(
         }
     }
 
-    // Capacity counts every live interactive session. When replacing,
+    // Phase 7.6: per-session attempt cap (spec section 8). The cap is `n - t + 1`,
+    // where `n` is the wallet's DKG `participant_count` and `t` is the threshold.
+    let new_attempt_taken = !guard
+        .sessions
+        .get(&request.session_id)
+        .is_some_and(|session| session.interactive_signing.contains_key(&attempt_id));
+    if new_attempt_taken {
+        // Count projected post-install attempts: current attempts excluding any
+        // scope this member would vacate entirely (so advancing members don't
+        // count against the cap twice).
+        let current_attempts = guard
+            .sessions
+            .get(&request.session_id)
+            .map(|session| {
+                session
+                    .interactive_signing
+                    .iter()
+                    .filter(|(aid, members)| {
+                        aid.as_str() != attempt_id
+                            && !(members.len() == 1 && members.contains_key(&member_identifier))
+                    })
+                    .count()
+            })
+            .unwrap_or(0);
+        let cap = concurrent_attempt_cap_for_dkg(dkg_participant_count, dkg_threshold)
+            .ok_or_else(|| {
+                EngineError::Internal(format!(
+                    "cannot compute per-session concurrent-attempt cap from DKG \
+                     participant_count [{}] and threshold [{}] for session [{}]",
+                    dkg_participant_count, dkg_threshold, request.session_id
+                ))
+            })?;
+        if current_attempts >= cap {
+            return Err(EngineError::SigningPolicyRejected {
+                session_id: request.session_id.clone(),
+                reason_code: "concurrent_attempt_cap_exceeded".to_string(),
+                detail: format!(
+                    "session [{}] cannot open new attempt [{attempt_id}]: current \
+                     concurrent-attempt count [{current_attempts}] is at the per-session \
+                     cap of [{cap}] (n={}, t={}, n-t+1={cap}).",
+                    request.session_id, dkg_participant_count, dkg_threshold,
+                ),
+            });
+        }
+    }
+
+
     // this session already holds one of those slots, so the cap does
     // not apply; when not replacing, a new slot is being taken.
     // Capacity bounds resident nonce/key exposure, so it counts every live member
     // ENTRY across all sessions. Replacing this member's own entry takes no new
     // slot; a new member (even in an existing session) takes one.
     if !replacing {
-        let live_interactive_members: usize = guard
-            .sessions
-            .values()
-            .map(|session| session.interactive_signing.len())
-            .sum();
+        let live_interactive_members = engine_live_interactive_member_count(&guard.sessions);
         if live_interactive_members >= max_live_interactive_sessions_limit() {
             return Err(EngineError::Internal(format!(
                 "live interactive member count [{live_interactive_members}] reached max [{}]; \
@@ -581,6 +654,7 @@ pub fn interactive_session_open(
     }
 
     // A per-signing session is keyed by RoastSessionID (message/root/start-block), NOT
+
     // by key_group, so two DIFFERENT wallets signing the same digest at the same block
     // on a node that holds members of both could collide on one session id. A session
     // belongs to exactly ONE wallet key for its lifetime: reject an Open whose key_group
@@ -732,12 +806,32 @@ pub fn interactive_session_open(
         .get_mut(&request.session_id)
         .expect("Open session existed after binding persistence");
     // Replace only THIS member's prior entry (zeroizing its old nonces); sibling
-    // seats' entries are untouched.
-    if let Some(mut replaced) = session.interactive_signing.remove(&member_identifier) {
-        zeroize_interactive_round1(&mut replaced);
+    // seats' entries on the same and other attempts are untouched. Phase 7.6:
+    // the attempt scope is keyed by attempt_id, so we first remove the member
+    // from whichever attempt scope holds them (handles a same-member advance to
+    // a different attempt) and then insert into the requested attempt's scope.
+    // The outer scope is dropped by the helper when its last member leaves.
+    // Phase 7.6: remove the member from any prior attempt scope, zeroize its
+    // old nonces, then drop the scope if it becomes empty (so the outer map
+    // only holds non-empty scopes).
+    let mut emptied_attempt_ids = Vec::new();
+    for (attempt_id, members) in session.interactive_signing.iter_mut() {
+        if let Some(mut replaced) = members.remove(&member_identifier) {
+            zeroize_interactive_round1(&mut replaced);
+            if members.is_empty() {
+                emptied_attempt_ids.push(attempt_id.clone());
+            }
+        }
     }
-
-    session.interactive_signing.insert(
+    for attempt_id in emptied_attempt_ids {
+        session.interactive_signing.remove(&attempt_id);
+    }
+    // Insert into the requested attempt's scope (creating it if needed).
+    let new_members = session
+        .interactive_signing
+        .entry(attempt_id.clone())
+        .or_default();
+    new_members.insert(
         member_identifier,
         InteractiveSigningState {
             open_request_fingerprint: request_fingerprint,
@@ -752,6 +846,22 @@ pub fn interactive_session_open(
             last_activity_at: interactive_now(),
             round1: None,
         },
+    );
+    // Spec section 8 invariant, now structurally enforced by the attempt-scoped
+    // nested map: each member's entry sits under exactly one attempt and holds
+    // its own nonce pair, so two concurrent attempts on the same session can
+    // never share nonce material. The outer map's keys are distinct attempt_ids.
+    // The cap is checked above; this assert confirms the install did not
+    // somehow exceed it (e.g. through a future change that bypasses the gate).
+    let cap_after_install = concurrent_attempt_cap_for_dkg(
+
+        dkg_participant_count,
+        dkg_threshold,
+    )
+    .unwrap_or(usize::MAX);
+    debug_assert!(
+        session.interactive_signing.len() <= cap_after_install,
+        "concurrent attempt count exceeded the per-session n-t+1 cap after install"
     );
 
     record_hardening_telemetry(|telemetry| {
@@ -957,10 +1067,13 @@ pub fn interactive_round2(
     // member's live Round2. It fires only for a genuine same-message completion; the
     // member's entry for that finalized attempt is then dead, so free it (zeroizing
     // its nonces) rather than holding a live-member slot until the TTL sweep.
+    // Phase 7.6: this member's live entry sits under the requested attempt_id in
+    // the attempt-scoped nested map. The completion marker is attempt-scoped
+    // already - same matching logic as before, just one level deeper.
     let member_attempt_finalization = session
         .interactive_signing
-        .get(&request.member_identifier)
-        .filter(|entry| entry.attempt_context.attempt_id == attempt_id)
+        .get(&attempt_id)
+        .and_then(|members| members.get(&request.member_identifier))
         .map(|entry| (hash_hex(&entry.message_bytes), entry.taproot_merkle_root));
     let attempt_finalized =
         member_attempt_finalization
@@ -974,12 +1087,10 @@ pub fn interactive_round2(
                 )
             });
     if attempt_finalized {
-        if let Some(mut removed) = session
-            .interactive_signing
-            .remove(&request.member_identifier)
-        {
-            zeroize_interactive_round1(&mut removed);
-        }
+        remove_interactive_entry(session, &attempt_id, request.member_identifier)
+            .map(|mut removed| {
+                zeroize_interactive_round1(&mut removed);
+            });
         return Err(EngineError::InteractiveAttemptAlreadyAggregated {
             session_id: request.session_id.clone(),
             attempt_id,
@@ -1005,8 +1116,8 @@ pub fn interactive_round2(
     // interactive_state_for_attempt_mut produces the canonical error.
     if let Some(interactive) = session
         .interactive_signing
-        .get(&request.member_identifier)
-        .filter(|interactive| interactive.attempt_context.attempt_id == attempt_id)
+        .get(&attempt_id)
+        .and_then(|members| members.get(&request.member_identifier))
     {
         let bound_message_hex = hex::encode(interactive.message_bytes.as_slice());
         // Fast-path lifecycle/firewall and this node's own quarantine.
@@ -1096,6 +1207,8 @@ pub fn interactive_round2(
             // measure its inactivity from failure completion, not command start.
             session
                 .interactive_signing
+                .get_mut(&attempt_id)
+                .expect("validated Round2 attempt scope exists")
                 .get_mut(&request.member_identifier)
                 .expect("validated Round2 interactive state remains retryable")
                 .last_activity_at = interactive_now();
@@ -1108,8 +1221,12 @@ pub fn interactive_round2(
     session
         .authorized_interactive_aggregate_markers
         .insert(aggregate_authorization_marker.clone());
-    let retires_session =
-        session.interactive_signing.len() == 1 && per_message_interactive_session(session);
+    // The retire check is the total (member, session) count (not the per-attempt
+    // count): a per-message session whose last member on ANY attempt just consumed
+    // is fully idle and can be retired. With the nested map this is the number of
+    // distinct members across all attempts.
+    let retires_session = interactive_session_live_member_count(session) == 1
+        && per_message_interactive_session(session);
     let compacted_retired_sessions = if retires_session {
         session.retired_interactive_at_unix = Some(now_unix().max(1));
         compact_retired_per_message_sessions(&mut guard, Some(&request.session_id))
@@ -1130,12 +1247,10 @@ pub fn interactive_round2(
                 session_id: request.session_id.clone(),
                 consumed_marker: consumed_marker.clone(),
             });
-            if let Some(mut removed) = session
-                .interactive_signing
-                .remove(&request.member_identifier)
-            {
-                zeroize_interactive_round1(&mut removed);
-            }
+            remove_interactive_entry(session, &attempt_id, request.member_identifier)
+                .map(|mut removed| {
+                    zeroize_interactive_round1(&mut removed);
+                });
         } else {
             session
                 .consumed_interactive_attempt_markers
@@ -1151,6 +1266,8 @@ pub fn interactive_round2(
             // at failure completion before releasing the engine lock.
             session
                 .interactive_signing
+                .get_mut(&attempt_id)
+                .expect("validated Round2 attempt scope exists")
                 .get_mut(&request.member_identifier)
                 .expect("pre-replacement Round2 failure leaves interactive state")
                 .last_activity_at = interactive_now();
@@ -1165,6 +1282,8 @@ pub fn interactive_round2(
         .expect("session existed under the held engine lock");
     let interactive = session
         .interactive_signing
+        .get_mut(&attempt_id)
+        .expect("attempt scope exists under the held engine lock")
         .get_mut(&request.member_identifier)
         .expect("interactive state existed under the held engine lock");
 
@@ -1194,9 +1313,7 @@ pub fn interactive_round2(
     // stay live. Done on both the success and share-computation-failure paths: the
     // attempt is consumed for this member either way, and the durable marker
     // carries all further replay protection.
-    session
-        .interactive_signing
-        .remove(&request.member_identifier);
+    remove_interactive_entry(session, &attempt_id, request.member_identifier);
 
     let signature_share = signature_share_result
         .map_err(|e| EngineError::Internal(format!("failed to create signature share: {e}")))?;
@@ -1653,24 +1770,27 @@ pub fn interactive_session_abort(
     // return `aborted: false` without writing.
     sweep_expired_interactive_state_durably(&mut guard)?;
 
-    let members_to_abort = match guard.sessions.get(&request.session_id) {
-        Some(session) => {
-            // Abort has no member parameter, so it is session-level over the map:
-            // select every member entry matching the optional attempt filter.
-            // Keep the nonce-bearing entries live until the durable retirement
-            // snapshot has replaced the state file, so a pre-replacement failure
-            // remains cleanly retryable.
-            session
-                .interactive_signing
-                .iter()
-                .filter(|(_, interactive)| {
-                    attempt_id_filter.is_none()
-                        || attempt_id_filter.as_deref()
-                            == Some(interactive.attempt_context.attempt_id.as_str())
-                })
-                .map(|(member, _)| *member)
-                .collect::<Vec<_>>()
-        }
+    // Phase 7.6: Abort iterate-the-attempt-scopes. Each matching (attempt_id,
+    // member_identifier) pair is collected; the persistent filter is matched
+    // against the outer key, so aborting "all attempts" (no filter) is the
+    // natural flatten over every member.
+    let members_to_abort: Vec<(String, u16)> = match guard.sessions.get(&request.session_id) {
+        Some(session) => session
+            .interactive_signing
+            .iter()
+            .flat_map(|(attempt_id, members)| {
+                if attempt_id_filter.is_none()
+                    || attempt_id_filter.as_deref() == Some(attempt_id.as_str())
+                {
+                    members
+                        .keys()
+                        .map(|member| (attempt_id.clone(), *member))
+                        .collect::<Vec<_>>()
+                } else {
+                    Vec::new()
+                }
+            })
+            .collect(),
         None => Vec::new(),
     };
 
@@ -1689,7 +1809,11 @@ pub fn interactive_session_abort(
             .sessions
             .get_mut(&request.session_id)
             .expect("selected abort session existed under the held engine lock");
-        let retires_session = members_to_abort.len() == session.interactive_signing.len()
+        // Retiring requires the abort to remove every live entry across every
+        // attempt scope, not every attempt count. The (member, session) view is
+        // what sessions retire on.
+        let retires_session = members_to_abort.len()
+            == interactive_session_live_member_count(session)
             && per_message_interactive_session(session);
         let previous_retired_at = session.retired_interactive_at_unix;
         if retires_session {
@@ -1715,10 +1839,11 @@ pub fn interactive_session_abort(
                 .sessions
                 .get_mut(&request.session_id)
                 .expect("abort session existed after state-file replacement");
-            for member in &members_to_abort {
-                if let Some(mut removed) = session.interactive_signing.remove(member) {
-                    zeroize_interactive_round1(&mut removed);
-                }
+            for (attempt_id, member) in &members_to_abort {
+                remove_interactive_entry(session, attempt_id, *member)
+                    .map(|mut removed| {
+                        zeroize_interactive_round1(&mut removed);
+                    });
             }
             mark_persistence_pending(PersistencePendingOperation::InteractiveState {
                 session_id: request.session_id.clone(),
@@ -1740,13 +1865,12 @@ pub fn interactive_session_abort(
         .sessions
         .get_mut(&request.session_id)
         .expect("abort session existed after durable retirement");
-    for member in &members_to_abort {
-        if let Some(mut removed) = session.interactive_signing.remove(member) {
-            zeroize_interactive_round1(&mut removed);
-        }
+    for (attempt_id, member) in &members_to_abort {
+        remove_interactive_entry(session, attempt_id, *member)
+            .map(|mut removed| {
+                zeroize_interactive_round1(&mut removed);
+            });
     }
-
-    // Only count a success when live interactive state was actually
     // aborted. A no-op call (no session, or an attempt_id filter that
     // matched nothing) returns aborted == false and must not inflate the
     // success counter - the calls_total counter at the top already
@@ -1763,23 +1887,53 @@ pub fn interactive_session_abort(
     })
 }
 
-// Looks up the live interactive state and pins the
-// (attempt_id, member_identifier) binding every round call must carry.
 fn interactive_state_for_attempt_mut<'session>(
     session: &'session mut SessionState,
     session_id: &str,
     attempt_id: &str,
     member_identifier: u16,
 ) -> Result<&'session mut InteractiveSigningState, EngineError> {
-    let interactive = session
+    // Phase 7.6: navigate the nested map by attempt_id first, then by member.
+    // A missing attempt_id scope is ambiguous on its own: the member may
+    // never have opened here, or may have opened and since moved to a
+    // newer attempt (Open replaces a member's prior scope entry). Callers
+    // need to distinguish "nothing is happening for this member" from
+    // "your attempt was superseded", so a miss falls back to scanning the
+    // other live attempt scopes for this member before reporting absence.
+    if !session.interactive_signing.contains_key(attempt_id) {
+        let superseding_attempt_id = session
+            .interactive_signing
+            .iter()
+            .find(|(_, members)| members.contains_key(&member_identifier))
+            .map(|(other_attempt_id, _)| other_attempt_id.clone());
+        return Err(match superseding_attempt_id {
+            Some(current_attempt_id) => EngineError::Validation(format!(
+                "attempt_id [{attempt_id}] does not match member [{member_identifier}]'s \
+                 live interactive attempt [{current_attempt_id}]"
+            )),
+            None => EngineError::SessionNotFound {
+                session_id: format!(
+                    "{session_id} (no live interactive attempt [{attempt_id}] for member {member_identifier})"
+                ),
+            },
+        });
+    }
+    let members = session
         .interactive_signing
-        .get_mut(&member_identifier)
-        .ok_or_else(|| EngineError::SessionNotFound {
+        .get_mut(attempt_id)
+        .expect("attempt scope presence just checked above");
+    let interactive = members.get_mut(&member_identifier).ok_or_else(|| {
+        EngineError::SessionNotFound {
             session_id: format!(
-                "{session_id} (no live interactive attempt for member {member_identifier})"
+                "{session_id} (no live interactive entry for member {member_identifier} on attempt [{attempt_id}])"
             ),
-        })?;
+        }
+    })?;
 
+    // The attempt_id in the request now matches the outer key by construction,
+    // but the inner entry's attempt_context is still the round call's
+    // consistency check (a stale entry from a prior scope that survived
+    // would also surface here).
     if interactive.attempt_context.attempt_id != attempt_id {
         return Err(EngineError::Validation(format!(
             "attempt_id [{attempt_id}] does not match member [{member_identifier}]'s \
@@ -1990,23 +2144,29 @@ fn remove_finalized_interactive_members(
     message_digest: &str,
     taproot_merkle_root: Option<&[u8; 32]>,
 ) {
+    // Phase 7.6: iterate the nested map. The aggregate finalizes EXACTLY one
+    // attempt, so we look at that attempt's member map and match the FULL
+    // finalized identity (attempt_id + message + root) per member. A mismatched
+    // aggregate must not destroy a differently-messaged attempt's live nonces.
     let finalized_members: Vec<u16> = session
         .interactive_signing
-        .iter()
-        .filter(|(_, entry)| {
-            // Match the FULL finalized identity (attempt_id + message + root), not
-            // just (attempt_id, root): a mismatched aggregate must not destroy the
-            // live nonce state of a differently-messaged attempt.
-            entry.attempt_context.attempt_id == attempt_id
-                && hash_hex(&entry.message_bytes) == message_digest
-                && entry.taproot_merkle_root.as_ref() == taproot_merkle_root
+        .get(attempt_id)
+        .map(|members| {
+            members
+                .iter()
+                .filter(|(_, entry)| {
+                    hash_hex(&entry.message_bytes) == message_digest
+                        && entry.taproot_merkle_root.as_ref() == taproot_merkle_root
+                })
+                .map(|(member, _)| *member)
+                .collect()
         })
-        .map(|(member, _)| *member)
-        .collect();
+        .unwrap_or_default();
     for member in finalized_members {
-        if let Some(mut removed) = session.interactive_signing.remove(&member) {
-            zeroize_interactive_round1(&mut removed);
-        }
+        remove_interactive_entry(session, attempt_id, member)
+            .map(|mut removed| {
+                zeroize_interactive_round1(&mut removed);
+            });
     }
 }
 
@@ -2062,6 +2222,7 @@ pub(crate) fn resolve_wallet_session_id(
 }
 
 pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) -> Vec<String> {
+
     let ttl = Duration::from_secs(interactive_session_ttl_seconds());
     let now = interactive_now();
     let mut changed_session_ids = HashSet::new();
@@ -2070,24 +2231,32 @@ pub(crate) fn sweep_expired_interactive_state(engine_state: &mut EngineState) ->
     // each live attempt's nonces; retirement below retains its bounded policy
     // and replay state until active admission needs the shared slot.
     for (session_id, session) in &mut engine_state.sessions {
-        // Per-member expiry: each seat's entry expires independently by its own
-        // last successful activity; non-expired sibling seats in the same session
-        // survive. Rejected traffic cannot keep nonce state resident.
-        let expired_members: Vec<u16> = session
+        // Phase 7.6: per-member expiry across the attempt-scoped nested map.
+        // Each seat's entry expires independently by its own last successful
+        // activity; non-expired sibling seats in the same session AND on
+        // different attempts survive. Rejected traffic cannot keep nonce state
+        // resident.
+        let expired: Vec<(String, u16)> = session
             .interactive_signing
             .iter()
-            .filter(|(_, interactive)| {
-                now.saturating_duration_since(interactive.last_activity_at) > ttl
+            .flat_map(|(attempt_id, members)| {
+                members
+                    .iter()
+                    .filter(|(_, interactive)| {
+                        now.saturating_duration_since(interactive.last_activity_at) > ttl
+                    })
+                    .map(|(member, _)| (attempt_id.clone(), *member))
+                    .collect::<Vec<_>>()
             })
-            .map(|(member, _)| *member)
             .collect();
-        if !expired_members.is_empty() {
+        if !expired.is_empty() {
             changed_session_ids.insert(session_id.clone());
         }
-        for member in &expired_members {
-            if let Some(mut removed) = session.interactive_signing.remove(member) {
-                zeroize_interactive_round1(&mut removed);
-            }
+        for (attempt_id, member) in &expired {
+            remove_interactive_entry(session, attempt_id, *member)
+                .map(|mut removed| {
+                    zeroize_interactive_round1(&mut removed);
+                });
         }
     }
     // Expiry has abort semantics. Retire idle per-message entries while

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -139,11 +139,14 @@ pub(crate) struct SessionState {
     /// process-global BuildTaprootTx limiter, this operational throttle resets on
     /// restart and is never written into the encrypted session state.
     pub(crate) heartbeat_rate_limiter: PolicyRateLimiterState,
-    // Multi-seat: a process-global engine may hold several LOCAL members (seats)
-    // signing the same session concurrently, each on its own attempt timeline.
-    // Keyed by member_identifier; each entry is independent (own attempt, nonces,
-    // replace/round2/expiry). Was Option (one member per session).
-    pub(crate) interactive_signing: BTreeMap<u16, InteractiveSigningState>,
+    // Phase 7.6: attempt-scoped concurrent attempts (per spec section 8). The outer
+    // key is `attempt_id`; the inner key is `member_identifier`. Each member's
+    // nonce state is bound to (attempt_id, member_identifier) so two concurrent
+    // attempts on the same session can never share nonce material (frozen spec
+    // section 8: "one handle, one attempt"). The outer scope's size is the
+    // concurrent attempt count (capped at n-t+1 below); the inner scope's
+    // membership per attempt is the per-member live-entry count.
+    pub(crate) interactive_signing: BTreeMap<String, BTreeMap<u16, InteractiveSigningState>>,
     // The key_group this per-signing session signs for, set at InteractiveSessionOpen.
     // Interactive signing runs under a fresh RoastSessionID per message, so a wallet's
     // DKG material lives under a DIFFERENT (wallet/DKG) session; this binds the signing
@@ -859,4 +862,68 @@ pub(crate) fn ensure_consumed_registry_insert_capacity(
     }
 
     Ok(())
+}
+
+// Phase 7.6: per-session concurrent-attempt helpers. The interactive state is
+// now an attempt-scoped nested map (attempt_id -> member_identifier -> state).
+// The functions below keep the cap semantics and the per-session totals in one
+// place so the Open/Round1/Round2/Aggregate/Abort paths read identically.
+
+/// Count of distinct (member, session) entries currently live. A member
+/// advancing to a newer attempt reuses its own slot, so this stays constant
+/// across the advance. The global `max_live_interactive_sessions_limit` cap
+/// counts this, not the per-attempt cardinality.
+pub(crate) fn interactive_session_live_member_count(session: &SessionState) -> usize {
+    let mut distinct_members = BTreeSet::new();
+    for members in session.interactive_signing.values() {
+        for member_identifier in members.keys() {
+            distinct_members.insert(*member_identifier);
+        }
+    }
+    distinct_members.len()
+}
+
+/// Per-session attempt cap: `n - t + 1` where `n` is the wallet's DKG
+/// participant count and `t` is the threshold. Returns `None` when the cap
+/// cannot be computed (no DKG material or impossible values); callers map
+/// that to the existing capacity/invalid-config path so an unverifiable group
+/// configuration never silently skips the cap.
+pub(crate) fn concurrent_attempt_cap_for_dkg(
+    participant_count: u16,
+    threshold: u16,
+) -> Option<usize> {
+    if participant_count == 0 || threshold == 0 || participant_count < threshold {
+        return None;
+    }
+    Some(usize::from(participant_count) - usize::from(threshold) + 1)
+}
+
+/// Removes an interactive entry at `(attempt_id, member_identifier)` and
+/// returns the removed state for zeroization. Returns `None` if the entry does
+/// not exist. The outer attempt scope is dropped when its last member is
+/// removed, so the per-session attempt count tracks the outer map's size.
+pub(crate) fn remove_interactive_entry(
+    session: &mut SessionState,
+    attempt_id: &str,
+    member_identifier: u16,
+) -> Option<InteractiveSigningState> {
+    let members = session.interactive_signing.get_mut(attempt_id)?;
+    let removed = members.remove(&member_identifier);
+    if members.is_empty() {
+        session.interactive_signing.remove(attempt_id);
+    }
+    removed
+}
+
+/// Total (member, session) entries across all sessions. Used by the global
+/// `max_live_interactive_sessions_limit` cap so a fresh member on a session
+/// where the existing member is advancing to a newer attempt does not double
+/// count.
+pub(crate) fn engine_live_interactive_member_count(
+    sessions: &HashMap<String, SessionState>,
+) -> usize {
+    sessions
+        .values()
+        .map(interactive_session_live_member_count)
+        .sum()
 }

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -7263,13 +7263,6 @@ fn interactive_last_activity_at_for_test(session_id: &str, member_identifier: u1
         .last_activity_at
 }
 
-/// Returns true if the given member has a live interactive entry in any attempt scope.
-fn has_live_member(session: &SessionState, member_identifier: u16) -> bool {
-    session
-        .interactive_signing
-        .values()
-        .any(|members| members.contains_key(&member_identifier))
-}
 
 /// Returns the live interactive signing state for a member, if present.
 fn live_member(session: &SessionState, member_identifier: u16) -> Option<&InteractiveSigningState> {
@@ -7279,10 +7272,6 @@ fn live_member(session: &SessionState, member_identifier: u16) -> Option<&Intera
         .find_map(|members| members.get(&member_identifier))
 }
 
-/// Returns true if the session has exactly N live member entries across all attempt scopes.
-fn member_count(session: &SessionState) -> usize {
-    session.interactive_signing.values().map(|m| m.len()).sum()
-}
 
 fn stateless_package_and_shares_for_test(
     message_bytes: &[u8],
@@ -14425,6 +14414,367 @@ fn interactive_concurrent_attempt_cap_enforced() {
             session.interactive_signing.len(),
             cap,
             "overflow attempt should not increase attempt count"
+        );
+    }
+}
+
+#[test]
+fn interactive_round2_durable_markers_persist_before_share_release() {
+    // Regression test for the Round2 durable-marker-ordering fix.
+    //
+    // `interactive_round2` MUST insert the consumed-attempt and aggregate-
+    // authorization markers BEFORE persisting, so that any failure path
+    // that hits the persisted state file (a post-rename directory-sync
+    // fault, a process restart, a crash) still finds the markers on disk
+    // and a retry is rejected as a replay. The install path removes the
+    // member's nonce-bearing entry in the same step, so a non-durable
+    // marker would silently allow a second share to be released for an
+    // already-consumed attempt - which is exactly the silent handoff
+    // break this fix is supposed to prevent.
+    //
+    // The test exercises the post-rename persist-failure path
+    // (state_file_replaced = true) and then simulates a process restart
+    // to force a reload from disk. If a future change regresses the
+    // ordering back to "insert markers after persist", the markers are
+    // in memory only, the saved state file does not contain them, the
+    // restart reload sees an empty marker set, and the retry below is
+    // NOT rejected as a replay.
+    let _guard = lock_test_state();
+    let state_path =
+        configure_test_state_path("interactive_round2_marker_ordering");
+    reset_for_tests();
+
+    let key_packages = interactive_test_key_packages();
+    let session_id = "interactive-round2-marker-ordering";
+    let key_group = "interactive-test-key-group";
+    let message = [0x73u8; 32];
+    let included = [1u16, 2];
+
+    let opened = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
+        .expect("opens");
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("round 1");
+    let member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 nonces");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member2.commitment,
+        ],
+    );
+    let round2_request = InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex,
+    };
+    let consumed_marker = interactive_consumed_marker(&opened.attempt_id, 1);
+
+    // Post-rename persist fault: the temp file is renamed onto the
+    // state-file path (state_file_replaced = true), but the parent
+    // directory sync fails. This is the durability boundary the
+    // marker ordering protects: the markers in memory at the moment of
+    // persist are exactly the markers in the saved state file.
+    set_persist_fault_injection_for_tests(
+        PersistFaultInjectionPoint::AfterRenameBeforeDirectorySync,
+    );
+    let faulted = interactive_round2(round2_request.clone())
+        .expect_err("post-rename persist fault must release no share");
+    clear_persist_fault_injection_for_tests();
+    assert!(
+        matches!(faulted, EngineError::Internal(ref m) if m.contains("injected persist fault")),
+        "unexpected error: {faulted:?}"
+    );
+
+    // Crash before any successful in-process repair. The pending registry
+    // is memory-only and disappears; the saved state file MUST carry
+    // the marker, otherwise the markers were only in memory and a real
+    // restart would lose them (a future regression that inserts markers
+    // AFTER persist would land here).
+    simulate_process_restart_for_tests();
+    reload_state_from_storage_for_tests();
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = guard.sessions.get(session_id).expect("session exists");
+        assert!(
+            session
+                .consumed_interactive_attempt_markers
+                .contains(&consumed_marker),
+            "consumed-attempt marker must survive a process restart when the \
+             post-rename persist replaced the state file (markers are inserted \
+             BEFORE persist, so they ride the same write that fails the directory sync)"
+        );
+        assert!(
+            session.interactive_signing.is_empty(),
+            "post-rename failure destroys the live nonce-bearing state"
+        );
+    }
+
+    // A retry must be rejected as a consumed-nonce replay because the
+    // marker is on disk. If the marker were lost across restart, the
+    // retry would proceed and could re-release a share.
+    let retry = interactive_round2(round2_request)
+        .expect_err("restart retry rejects the durable consumed attempt");
+    assert!(
+        matches!(retry, EngineError::ConsumedNonceReplay { .. }),
+        "unexpected retry error: {retry:?}"
+    );
+
+    reset_for_tests();
+    cleanup_test_state_artifacts(&state_path);
+    clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn interactive_round1_reports_attempt_id_mismatch_for_superseded_member() {
+    // Regression test for the stale-attempt-id lookup fix.
+    //
+    // `interactive_state_for_attempt_mut` MUST distinguish "member has no
+    // live attempt at all" from "member's live attempt moved to a
+    // different attempt_id". The nested-map restructure makes the outer
+    // key the attempt_id, so a lookup that just did
+    // `session.interactive_signing.get_mut(attempt_id)?` would return
+    // SessionNotFound for a member who has a live entry under a DIFFERENT
+    // attempt_id - masking the fact that the member is actively signing,
+    // just on a newer attempt. The fix adds a fallback scan of the other
+    // live attempt scopes for this member, and returns a Validation
+    // error specifically identifying the attempt-id MISMATCH (both the
+    // stale id passed in and the current live id on the member).
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let session_id = "interactive-round1-supersede-mismatch";
+    let key_group = "interactive-test-key-group";
+    let message = [0x74u8; 32];
+    let included = [1u16, 2];
+
+    let first = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, 2)
+        .expect("member 1 opens attempt 1");
+    interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: first.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("member 1 round 1 on attempt 1");
+
+    let second = open_interactive_for_test(session_id, key_group, &message, &included, 2, 1, 2)
+        .expect("member 1 advances to attempt 2");
+    assert_ne!(first.attempt_id, second.attempt_id);
+
+    // Round1 with the stale attempt_id must report a Validation error
+    // that specifically identifies the attempt-id MISMATCH (both the
+    // stale id we passed and the live id this member now occupies),
+    // not a generic SessionNotFound. Without the fix, the function
+    // would do session.interactive_signing.get_mut(stale_id)? and
+    // return SessionNotFound on the None.
+    let stale = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: first.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect_err("stale attempt id must be rejected");
+    match &stale {
+        EngineError::Validation(message) => {
+            assert!(
+                message.contains(&first.attempt_id)
+                    && message.contains(&second.attempt_id)
+                    && message.contains("does not match"),
+                "expected a specific attempt-id mismatch error mentioning \
+                 both stale id [{}] and live id [{}], got {:?}",
+                first.attempt_id,
+                second.attempt_id,
+                message,
+            );
+        }
+        other => panic!(
+            "expected EngineError::Validation for attempt-id mismatch, got {other:?}"
+        ),
+    }
+    // The Round2 path shares the same lookup. A Round2 with the stale
+    // attempt_id must report the same specific mismatch error, not a
+    // generic not-found (the Round2 entry point also gates on this).
+    // The signing package only needs to deserialize cleanly - the
+    // stale attempt_id lookup fails BEFORE any package verification.
+    let key_packages = interactive_test_key_packages();
+    let second_round1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: second.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("member 1 round 1 on attempt 2 to seed a valid signing package");
+    let second_member2 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&2].identifier.clone(),
+        key_package_hex: key_packages[&2].data_hex.clone(),
+    })
+    .expect("member 2 stateless commitments for the live attempt");
+    let live_signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: second_round1.commitments_hex,
+            },
+            second_member2.commitment,
+        ],
+    );
+    let stale_round2 = interactive_round2(InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: first.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex: live_signing_package_hex,
+    })
+    .expect_err("stale attempt id on Round2 must be rejected");
+    match &stale_round2 {
+        EngineError::Validation(message) => {
+            assert!(
+                message.contains(&first.attempt_id)
+                    && message.contains(&second.attempt_id)
+                    && message.contains("does not match"),
+                "Round2 expected attempt-id mismatch mentioning both stale id \
+                 [{}] and live id [{}], got {:?}",
+                first.attempt_id,
+                second.attempt_id,
+                message,
+            );
+        }
+        other => panic!(
+            "expected EngineError::Validation for attempt-id mismatch on \
+             Round2, got {other:?}"
+        ),
+    }
+
+    // A truly-absent member (no live entry at all) gets a different
+    // error: SessionNotFound. The fix must distinguish this from
+    // "the member has a live entry, just under a different attempt_id".
+    let absent = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: first.attempt_id.clone(),
+        member_identifier: 7, // not opened at all
+    })
+    .expect_err("a member with no live entry must be SessionNotFound");
+    assert!(
+        matches!(absent, EngineError::SessionNotFound { .. }),
+        "absent member lookup must be SessionNotFound (not the supersede \
+         error), got {absent:?}"
+    );
+}
+
+#[test]
+fn interactive_cap_does_not_double_count_member_vacating_own_attempt_scope() {
+    // Regression test for the cap-accounting vacating path.
+    //
+    // When a member advances to a NEW attempt under a fresh attempt_id,
+    // the prior scope they vacate must NOT count against the n-t+1
+    // cap (the install path drops it because empty scopes are pruned
+    // immediately). The Open cap check excludes the scope this member
+    // would vacate entirely, so the net effect is one attempt in / one
+    // attempt out, not two attempts added. Without that exclusion the
+    // Open would reject the advance at the cap, blocking the retry
+    // loop entirely.
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let key_group = "interactive-cap-vacate-key-group";
+    let session_id = "interactive-cap-vacate";
+    let message = [0x75u8; 32];
+    // DKG fixture is threshold=2; cap = 3 - 2 + 1 = 2.
+    let included = [1u16, 2, 3];
+    let threshold = 2u16;
+    // Fill the cap: member 1 opens attempt A (wire attempt 1),
+    // member 2 opens attempt B (wire attempt 2 - different attempt_id
+    // so they hold distinct concurrent attempts under the n-t+1 cap).
+    let opened_a =
+        open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, threshold)
+            .expect("member 1 opens attempt A");
+    let opened_b =
+        open_interactive_for_test(session_id, key_group, &message, &included, 2, 2, threshold)
+            .expect("member 2 opens attempt B");
+    assert_ne!(opened_a.attempt_id, opened_b.attempt_id, "attempts must differ");
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = guard.sessions.get(session_id).expect("session exists");
+        assert_eq!(
+            session.interactive_signing.len(),
+            2,
+            "two attempt scopes are at the cap"
+        );
+    }
+
+    // Member 3 cannot open a 3rd attempt - cap reached.
+    let overflow =
+        open_interactive_for_test(session_id, key_group, &message, &included, 3, 3, threshold)
+            .expect_err("opening a 3rd attempt while at cap must fail");
+    match &overflow {
+        EngineError::SigningPolicyRejected {
+            reason_code, ..
+        } => assert_eq!(
+            reason_code, "concurrent_attempt_cap_exceeded",
+            "expected concurrent_attempt_cap_exceeded, got {overflow:?}"
+        ),
+        other => panic!(
+            "expected SigningPolicyRejected for cap overflow, got {other:?}"
+        ),
+    }
+
+    // Member 1 advances to a NEW attempt under a fresh attempt_id
+    // (wire attempt number 2). The prior scope they vacate is dropped
+    // because empty scopes are pruned immediately; the cap check
+    // excludes the scope this member would vacate, so the net is one
+    // in / one out and the open succeeds. Without that exclusion, the
+    let opened_c =
+        open_interactive_for_test(session_id, key_group, &message, &included, 3, 1, threshold)
+            .expect(
+                "member 1 advancing to a new attempt must not double-count: \
+                 the vacated prior scope is excluded from the cap",
+            );
+    assert_ne!(
+        opened_c.attempt_id, opened_a.attempt_id,
+        "the advancing member's NEW attempt must have a fresh attempt_id"
+    );
+    assert_ne!(
+        opened_c.attempt_id, opened_b.attempt_id,
+        "the advancing member's NEW attempt must not collide with member 2's attempt"
+    );
+
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = guard.sessions.get(session_id).expect("session exists");
+        // The vacated scope is gone (member 1 was the sole member there).
+        assert!(
+            !session.interactive_signing.contains_key(&opened_a.attempt_id),
+            "the vacated attempt scope is pruned immediately"
+        );
+        // Member 2's scope on attempt B is untouched by member 1's advance.
+        assert!(
+            session.interactive_signing.contains_key(&opened_b.attempt_id),
+            "sibling member's scope is untouched by the advance"
+        );
+        // Member 1 is now under the new attempt C.
+        assert!(
+            session.interactive_signing.contains_key(&opened_c.attempt_id),
+            "the new attempt scope holds the advancing member"
+        );
+        let new_scope = session
+            .interactive_signing
+            .get(&opened_c.attempt_id)
+            .expect("new attempt scope exists");
+        assert!(new_scope.contains_key(&1), "member 1 is on the new attempt");
+        // Cap is still 2 (B and C), not 3.
+        assert_eq!(
+            session.interactive_signing.len(),
+            2,
+            "the cap is n-t+1 = 2, not n-t = 1; the vacated scope did not double-count"
         );
     }
 }

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -4845,7 +4845,10 @@ fn interactive_open_refuses_to_rebind_a_live_session_to_a_different_key_group() 
         let session = guard.sessions.get(shared_session).expect("shared session");
         assert_eq!(session.bound_key_group.as_deref(), Some(key_group_a));
         assert!(
-            session.interactive_signing.contains_key(&1),
+            session
+                .interactive_signing
+                .values()
+                .any(|members| members.contains_key(&1)),
             "wallet A's live member entry must survive B's rejected open"
         );
     }
@@ -7251,7 +7254,34 @@ fn interactive_package_for_test(
 
 fn interactive_last_activity_at_for_test(session_id: &str, member_identifier: u16) -> Instant {
     let guard = state().expect("state").lock().expect("lock");
-    guard.sessions[session_id].interactive_signing[&member_identifier].last_activity_at
+    let session = guard.sessions.get(session_id).expect("session exists");
+    session
+        .interactive_signing
+        .values()
+        .find_map(|members| members.get(&member_identifier))
+        .expect("member has live interactive entry")
+        .last_activity_at
+}
+
+/// Returns true if the given member has a live interactive entry in any attempt scope.
+fn has_live_member(session: &SessionState, member_identifier: u16) -> bool {
+    session
+        .interactive_signing
+        .values()
+        .any(|members| members.contains_key(&member_identifier))
+}
+
+/// Returns the live interactive signing state for a member, if present.
+fn live_member(session: &SessionState, member_identifier: u16) -> Option<&InteractiveSigningState> {
+    session
+        .interactive_signing
+        .values()
+        .find_map(|members| members.get(&member_identifier))
+}
+
+/// Returns true if the session has exactly N live member entries across all attempt scopes.
+fn member_count(session: &SessionState) -> usize {
+    session.interactive_signing.values().map(|m| m.len()).sum()
 }
 
 fn stateless_package_and_shares_for_test(
@@ -7402,7 +7432,8 @@ fn interactive_round2_state_key_failure_does_not_burn_attempt() {
         );
         let interactive = session
             .interactive_signing
-            .get(&1)
+            .values()
+            .find_map(|members| members.get(&1))
             .expect("key failure leaves the nonce handle retryable");
         assert!(interactive.round1.is_some(), "Round1 nonces remain live");
         interactive.last_activity_at
@@ -7996,9 +8027,12 @@ fn first_open_binding_persist_failures_are_transactional_and_repairable() {
     {
         let guard = state().expect("state").lock().expect("lock");
         assert!(!guard.sessions.contains_key(retired_session));
-        assert!(guard.sessions[pre_replace_session]
-            .interactive_signing
-            .contains_key(&1));
+        assert!(
+            guard.sessions[pre_replace_session]
+                .interactive_signing
+                .values()
+                .any(|members| members.contains_key(&1)),
+        );
         assert_eq!(guard.sessions.len(), 3);
     }
 
@@ -8035,7 +8069,7 @@ fn first_open_binding_persist_failures_are_transactional_and_repairable() {
         let session = &guard.sessions[post_replace_session];
         assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
         assert!(session.retired_interactive_at_unix.is_none());
-        assert!(session.interactive_signing.contains_key(&1));
+        assert!(session.interactive_signing.values().any(|members| members.contains_key(&1)));
         assert_eq!(guard.sessions.len(), 3);
     }
 
@@ -8113,8 +8147,8 @@ fn partial_member_expiry_persists_binding_before_restart() {
         let session = &guard.sessions[signing_session];
         assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
         assert!(session.retired_interactive_at_unix.is_none());
-        assert!(!session.interactive_signing.contains_key(&1));
-        assert!(session.interactive_signing.contains_key(&2));
+        assert!(!session.interactive_signing.values().any(|members| members.contains_key(&1)));
+        assert!(session.interactive_signing.values().any(|members| members.contains_key(&2)));
     }
 
     // The partial sweep is itself a durability boundary. Although member 2 is
@@ -8239,7 +8273,7 @@ fn interactive_round2_pre_replace_failure_restores_staged_retirement() {
         assert_eq!(retired_interactive_session_count(&guard.sessions), 1);
         let signing = &guard.sessions[signing_session];
         assert!(signing.retired_interactive_at_unix.is_none());
-        assert!(signing.interactive_signing.contains_key(&1));
+        assert!(signing.interactive_signing.values().any(|members| members.contains_key(&1)));
         assert!(!interactive_attempt_consumed(
             &signing.consumed_interactive_attempt_markers,
             &opened.attempt_id,
@@ -8686,11 +8720,11 @@ fn interactive_multi_seat_two_members_one_process_aggregate_bip340() {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
         assert!(
-            !session.interactive_signing.contains_key(&1),
+            !session.interactive_signing.values().any(|members| members.contains_key(&1)),
             "member 1's entry is freed after its Round2"
         );
         assert!(
-            session.interactive_signing.contains_key(&2),
+            session.interactive_signing.values().any(|members| members.contains_key(&2)),
             "member 2's entry stays live - a sibling seat's Round2 must not free it"
         );
         assert!(
@@ -8880,7 +8914,7 @@ fn interactive_round2_refused_after_aggregate_for_unsigned_sibling() {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
         assert!(
-            !session.interactive_signing.contains_key(&3),
+            !session.interactive_signing.values().any(|members| members.contains_key(&3)),
             "the non-signing sibling is freed when the attempt aggregates"
         );
     }
@@ -8930,7 +8964,7 @@ fn interactive_round2_refused_after_aggregate_for_unsigned_sibling() {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
         assert!(
-            !session.interactive_signing.contains_key(&3),
+            !session.interactive_signing.values().any(|members| members.contains_key(&3)),
             "seat 3's dead entry is freed when Round2 is refused for the finalized attempt"
         );
     }
@@ -8972,15 +9006,35 @@ fn interactive_open_advances_only_the_opening_member_attempt() {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
         assert_eq!(
-            session.interactive_signing[&1].attempt_context.attempt_id, a2_m1.attempt_id,
+            session
+                .interactive_signing
+                .get(&a2_m1.attempt_id)
+                .and_then(|members| members.get(&1))
+                .expect("member 1 has live entry on attempt 2")
+                .attempt_context
+                .attempt_id,
+            a2_m1.attempt_id,
             "seat 1 advanced to attempt 2"
         );
         assert!(
-            session.interactive_signing[&1].round1.is_none(),
+            session
+                .interactive_signing
+                .get(&a2_m1.attempt_id)
+                .and_then(|members| members.get(&1))
+                .expect("member 1 has live entry on attempt 2")
+                .round1
+                .is_none(),
             "seat 1's attempt-2 entry starts fresh (old round-1 nonces replaced)"
         );
         assert_eq!(
-            session.interactive_signing[&2].attempt_context.attempt_id, a1_m1.attempt_id,
+            session
+                .interactive_signing
+                .get(&a1_m1.attempt_id)
+                .and_then(|members| members.get(&2))
+                .expect("member 2 has live entry on attempt 1")
+                .attempt_context
+                .attempt_id,
+            a1_m1.attempt_id,
             "seat 2's attempt-1 entry is untouched by seat 1's advance"
         );
     }
@@ -9224,7 +9278,10 @@ fn interactive_aggregate_rejects_mismatched_message_without_cleanup() {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
         assert!(
-            session.interactive_signing.contains_key(&1),
+            session
+                .interactive_signing
+                .values()
+                .any(|members| members.contains_key(&1)),
             "a mismatched-message aggregate must not delete the live message-A seat"
         );
         assert!(session.aggregated_interactive_attempt_markers.is_empty());
@@ -9304,15 +9361,15 @@ fn interactive_abort_by_attempt_removes_all_members_on_that_attempt() {
     let guard = state().expect("state").lock().expect("lock");
     let session = guard.sessions.get(session_id).expect("session exists");
     assert!(
-        !session.interactive_signing.contains_key(&1),
+        !session.interactive_signing.values().any(|members| members.contains_key(&1)),
         "member 1 (attempt 1) is aborted"
     );
     assert!(
-        !session.interactive_signing.contains_key(&2),
+        !session.interactive_signing.values().any(|members| members.contains_key(&2)),
         "member 2 (attempt 1) is aborted"
     );
     assert!(
-        session.interactive_signing.contains_key(&3),
+        session.interactive_signing.values().any(|members| members.contains_key(&3)),
         "member 3 (attempt 2) survives the attempt-1 abort"
     );
 }
@@ -9778,7 +9835,8 @@ fn interactive_round2_persist_fault_leaves_nonces_live() {
         );
         let interactive = session
             .interactive_signing
-            .get(&1)
+            .values()
+            .find_map(|members| members.get(&1))
             .expect("pre-replacement failure leaves the nonce retryable");
         assert!(interactive.round1.is_some(), "Round1 nonces remain live");
         interactive.last_activity_at
@@ -9880,7 +9938,7 @@ fn interactive_round2_post_rename_persist_failure_consumes_attempt_and_retry_flu
             .consumed_interactive_attempt_markers
             .contains(&consumed_marker));
         assert!(
-            !session.interactive_signing.contains_key(&1),
+            !session.interactive_signing.values().any(|members| members.contains_key(&1)),
             "post-rename failure must destroy the live nonce-bearing member state"
         );
     }
@@ -10099,7 +10157,9 @@ fn interactive_abort_persist_failures_are_retryable_before_replace_and_fail_clos
     {
         let guard = state().expect("state").lock().expect("engine lock");
         let session = &guard.sessions[retryable_session];
-        assert!(session.interactive_signing.contains_key(&1));
+        assert!(
+            session.interactive_signing.values().any(|members| members.contains_key(&1)),
+        );
         assert!(session.retired_interactive_at_unix.is_none());
     }
     assert!(
@@ -10244,7 +10304,10 @@ fn interactive_inactivity_ttl_refreshes_on_idempotent_open() {
     assert!(retry.idempotent);
     let refreshed_activity = {
         let guard = state().expect("state").lock().expect("lock");
-        guard.sessions[session_id].interactive_signing[&1].last_activity_at
+        let session = guard.sessions.get(session_id).expect("session exists");
+        live_member(session, 1)
+            .expect("member has live interactive entry")
+            .last_activity_at
     };
     assert!(
         refreshed_activity > prior_activity,
@@ -10375,7 +10438,10 @@ fn interactive_inactivity_ttl_refreshes_fresh_round1_per_member_before_round2() 
     let guard = state().expect("state").lock().expect("lock");
     let session = guard.sessions.get(session_id).expect("session remains");
     assert!(
-        !session.interactive_signing.contains_key(&2),
+        !session
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&2)),
         "the genuinely idle sibling expires on the same sweep"
     );
 }
@@ -10874,8 +10940,10 @@ fn interactive_round2_rechecks_stored_heartbeat_intent_before_share_release() {
             .get_mut(signing_session)
             .expect("heartbeat signing session")
             .interactive_signing
+            .get_mut(&opened.attempt_id)
+            .expect("live heartbeat attempt scope")
             .get_mut(&1)
-            .expect("live heartbeat attempt")
+            .expect("live heartbeat attempt member")
             .signing_intent = Some(heartbeat_signing_intent_for_test(
             &heartbeat_message_for_test(5),
         ));
@@ -10895,7 +10963,7 @@ fn interactive_round2_rechecks_stored_heartbeat_intent_before_share_release() {
     ));
     let guard = state().expect("state").lock().expect("engine lock");
     let session = &guard.sessions[signing_session];
-    assert!(session.interactive_signing[&1].round1.is_some());
+    assert!(session.interactive_signing[&opened.attempt_id][&1].round1.is_some());
     assert!(!interactive_attempt_consumed(
         &session.consumed_interactive_attempt_markers,
         &opened.attempt_id,
@@ -12841,7 +12909,7 @@ fn interactive_aggregate_post_rename_persist_failure_finalizes_attempt_and_retry
             .aggregated_interactive_attempt_markers
             .contains(&aggregated_marker));
         assert!(
-            !session.interactive_signing.contains_key(&3),
+            !session.interactive_signing.contains_key(&opened.attempt_id),
             "a retained completion marker must destroy an unsigned sibling's live nonces"
         );
     }
@@ -13006,7 +13074,7 @@ fn interactive_aggregate_post_rename_repair_retires_session_and_releases_capacit
             .aggregated_interactive_attempt_markers
             .contains(&aggregated_marker));
         assert!(
-            !session.interactive_signing.contains_key(&3),
+            !session.interactive_signing.contains_key(&opened.attempt_id),
             "a retained completion marker must destroy an unsigned sibling's live nonces"
         );
     }
@@ -14116,4 +14184,247 @@ fn enforce_provenance_gate_rejects_signed_attestation_runtime_version_mismatch()
     assert_eq!(reason_code, "runtime_version_not_attested");
 
     clear_state_storage_policy_overrides();
+}
+
+#[test]
+fn interactive_two_attempts_coexist_same_session() {
+    // Test that two attempts can coexist in the same session for different members
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let key_group = "interactive-two-attempts-test";
+    let session_id = "interactive-session-id";
+    let message = [0xcu8; 32];
+    let included = [1u16, 2, 3];
+    let threshold = 2u16;
+    let key_packages = ensure_interactive_dkg_session(session_id, key_group);
+
+    // Open attempt A for member 1
+    let opened_a1 = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, threshold)
+        .expect("member 1 opens attempt A");
+
+    // Open attempt B for member 2
+    let opened_b2 = open_interactive_for_test(session_id, key_group, &message, &included, 2, 2, threshold)
+        .expect("member 2 opens attempt B");
+
+    assert_ne!(opened_a1.attempt_id, opened_b2.attempt_id, "attempt IDs must differ");
+
+    // Attempt B's member 2 creates live Round1 nonces, independent of attempt A.
+    interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened_b2.attempt_id.clone(),
+        member_identifier: 2,
+    })
+    .expect("member 2 round 1 in attempt B");
+
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = guard.sessions.get(session_id).expect("session exists");
+
+        // Verify both attempt scopes exist
+        assert!(session.interactive_signing.contains_key(&opened_a1.attempt_id));
+        assert!(session.interactive_signing.contains_key(&opened_b2.attempt_id));
+
+        // Verify member 1 is in attempt A scope
+        assert!(session
+            .interactive_signing
+            .get(&opened_a1.attempt_id)
+            .expect("attempt A scope exists")
+            .contains_key(&1));
+
+        // Verify member 2 is in attempt B scope
+        assert!(session
+            .interactive_signing
+            .get(&opened_b2.attempt_id)
+            .expect("attempt B scope exists")
+            .contains_key(&2));
+
+        // Verify member counts per attempt
+        let attempt_a_members = session
+            .interactive_signing
+            .get(&opened_a1.attempt_id)
+            .expect("attempt A scope exists")
+            .len();
+        let attempt_b_members = session
+            .interactive_signing
+            .get(&opened_b2.attempt_id)
+            .expect("attempt B scope exists")
+            .len();
+        assert_eq!(attempt_a_members, 1, "attempt A should have exactly 1 member");
+        assert_eq!(attempt_b_members, 1, "attempt B should have exactly 1 member");
+    }
+
+    // Complete attempt A via round1 -> round2 -> aggregate, using an ad-hoc
+    // (non-interactive) second signer so attempt B's live state is untouched.
+    let round1 = interactive_round1(InteractiveRound1Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened_a1.attempt_id.clone(),
+        member_identifier: 1,
+    })
+    .expect("member 1 round 1 in attempt A");
+    let member3 = generate_nonces_and_commitments(GenerateNoncesAndCommitmentsRequest {
+        key_package_identifier: key_packages[&3].identifier.clone(),
+        key_package_hex: key_packages[&3].data_hex.clone(),
+    })
+    .expect("member 3 ad-hoc commitments");
+    let signing_package_hex = interactive_package_for_test(
+        &message,
+        vec![
+            NativeFrostCommitment {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round1.commitments_hex,
+            },
+            member3.commitment.clone(),
+        ],
+    );
+    let round2 = interactive_round2(InteractiveRound2Request {
+        session_id: session_id.to_string(),
+        attempt_id: opened_a1.attempt_id.clone(),
+        member_identifier: 1,
+        signing_package_hex: signing_package_hex.clone(),
+    })
+    .expect("member 1 round 2 share");
+    let member3_share = sign_share(SignShareRequest {
+        signing_package_hex: signing_package_hex.clone(),
+        nonces_hex: member3.nonces_hex,
+        key_package_identifier: key_packages[&3].identifier.clone(),
+        key_package_hex: key_packages[&3].data_hex.clone(),
+    })
+    .expect("member 3 ad-hoc share");
+    let aggregate_request = InteractiveAggregateRequest {
+        session_id: session_id.to_string(),
+        attempt_id: opened_a1.attempt_id.clone(),
+        signing_package_hex,
+        signature_shares: vec![
+            crate::api::NativeFrostSignatureShare {
+                identifier: key_packages[&1].identifier.clone(),
+                data_hex: round2.signature_share_hex,
+            },
+            member3_share.signature_share,
+        ],
+        taproot_merkle_root_hex: None,
+    };
+    interactive_aggregate(aggregate_request).expect("aggregate succeeds");
+
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = guard.sessions.get(session_id).expect("session exists");
+
+        // Verify attempt A scope is cleared (aggregated)
+        assert!(!session.interactive_signing.contains_key(&opened_a1.attempt_id));
+
+        // Verify attempt B scope still exists with member 2's Round1 nonces live
+        assert!(session.interactive_signing.contains_key(&opened_b2.attempt_id));
+        let attempt_b_scope = session
+            .interactive_signing
+            .get(&opened_b2.attempt_id)
+            .expect("attempt B scope still exists");
+        assert!(attempt_b_scope.contains_key(&2), "member 2 still in attempt B scope");
+
+        // Verify member 2's Round1 nonces are still live (not zeroized)
+        let member_b_state = attempt_b_scope
+            .get(&2)
+            .expect("member 2 state exists");
+        assert!(member_b_state.round1.is_some(), "member 2's Round1 nonces still live");
+    }
+}
+
+#[test]
+fn interactive_concurrent_attempt_cap_enforced() {
+    // Test that the n-t+1 concurrent attempt cap is enforced
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let key_group = "interactive-cap-test";
+    let session_id = "interactive-cap-session";
+    let message = [0xdu8; 32];
+    // The DKG fixture is threshold=2; n=3, t=2 so cap = n - t + 1 = 3 - 2 + 1 = 2
+    let included = [1u16, 2, 3];
+    let threshold = 2u16;
+    let cap: usize = 2; // n - t + 1
+
+    // Open cap number of attempts (should succeed)
+    let mut opened_attempts = Vec::new();
+    for i in 0..cap {
+        let member_identifier = (i + 1) as u16;
+        let wire_attempt_number = (i + 1) as u32;
+        let opened = open_interactive_for_test(
+            session_id,
+            key_group,
+            &message,
+            &included,
+            wire_attempt_number,
+            member_identifier,
+            threshold,
+        )
+        .unwrap_or_else(|e| panic!("member {member_identifier} should open attempt: {e:?}"));
+        opened_attempts.push(opened);
+    }
+
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = guard.sessions.get(session_id).expect("session exists");
+
+        // Verify exactly cap attempts exist
+        assert_eq!(
+            session.interactive_signing.len(),
+            cap,
+            "should have exactly cap attempt scopes"
+        );
+
+        // Verify each attempt has exactly one member
+        for (i, opened) in opened_attempts.iter().enumerate() {
+            let member_identifier = (i + 1) as u16;
+            let attempt_scope = session
+                .interactive_signing
+                .get(&opened.attempt_id)
+                .unwrap_or_else(|| panic!("attempt {} scope exists", i + 1));
+            assert_eq!(attempt_scope.len(), 1, "attempt should have exactly one member");
+            assert!(
+                attempt_scope.contains_key(&member_identifier),
+                "member {member_identifier} should be in attempt"
+            );
+        }
+    }
+
+    // Attempt to open one more attempt (should fail due to cap)
+    let overflow_member_identifier = (cap + 1) as u16;
+    let overflow_wire_attempt_number = (cap + 1) as u32;
+    let overflow_attempt = open_interactive_for_test(
+        session_id,
+        key_group,
+        &message,
+        &included,
+        overflow_wire_attempt_number,
+        overflow_member_identifier,
+        threshold,
+    );
+    assert!(
+        matches!(
+            &overflow_attempt,
+            Err(EngineError::SigningPolicyRejected {
+                session_id: bound_session_id,
+                reason_code: bound_reason_code,
+                detail: bound_detail,
+            }) if bound_session_id == session_id
+                && bound_reason_code == "concurrent_attempt_cap_exceeded"
+                && bound_detail.contains(&format!(
+                    "session [{}] cannot open new attempt",
+                    session_id
+                ))
+        ),
+        "overflow attempt should be rejected with concurrent_attempt_cap_exceeded, got {overflow_attempt:?}"
+    );
+
+    {
+        let guard = state().expect("state").lock().expect("lock");
+        let session = guard.sessions.get(session_id).expect("session exists");
+
+        // Verify still only cap attempts exist (overflow attempt not added)
+        assert_eq!(
+            session.interactive_signing.len(),
+            cap,
+            "overflow attempt should not increase attempt count"
+        );
+    }
 }

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -7263,7 +7263,6 @@ fn interactive_last_activity_at_for_test(session_id: &str, member_identifier: u1
         .last_activity_at
 }
 
-
 /// Returns the live interactive signing state for a member, if present.
 fn live_member(session: &SessionState, member_identifier: u16) -> Option<&InteractiveSigningState> {
     session
@@ -7271,7 +7270,6 @@ fn live_member(session: &SessionState, member_identifier: u16) -> Option<&Intera
         .values()
         .find_map(|members| members.get(&member_identifier))
 }
-
 
 fn stateless_package_and_shares_for_test(
     message_bytes: &[u8],
@@ -8016,12 +8014,10 @@ fn first_open_binding_persist_failures_are_transactional_and_repairable() {
     {
         let guard = state().expect("state").lock().expect("lock");
         assert!(!guard.sessions.contains_key(retired_session));
-        assert!(
-            guard.sessions[pre_replace_session]
-                .interactive_signing
-                .values()
-                .any(|members| members.contains_key(&1)),
-        );
+        assert!(guard.sessions[pre_replace_session]
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&1)),);
         assert_eq!(guard.sessions.len(), 3);
     }
 
@@ -8058,7 +8054,10 @@ fn first_open_binding_persist_failures_are_transactional_and_repairable() {
         let session = &guard.sessions[post_replace_session];
         assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
         assert!(session.retired_interactive_at_unix.is_none());
-        assert!(session.interactive_signing.values().any(|members| members.contains_key(&1)));
+        assert!(session
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&1)));
         assert_eq!(guard.sessions.len(), 3);
     }
 
@@ -8136,8 +8135,14 @@ fn partial_member_expiry_persists_binding_before_restart() {
         let session = &guard.sessions[signing_session];
         assert_eq!(session.bound_key_group.as_deref(), Some(key_group));
         assert!(session.retired_interactive_at_unix.is_none());
-        assert!(!session.interactive_signing.values().any(|members| members.contains_key(&1)));
-        assert!(session.interactive_signing.values().any(|members| members.contains_key(&2)));
+        assert!(!session
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&1)));
+        assert!(session
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&2)));
     }
 
     // The partial sweep is itself a durability boundary. Although member 2 is
@@ -8262,7 +8267,10 @@ fn interactive_round2_pre_replace_failure_restores_staged_retirement() {
         assert_eq!(retired_interactive_session_count(&guard.sessions), 1);
         let signing = &guard.sessions[signing_session];
         assert!(signing.retired_interactive_at_unix.is_none());
-        assert!(signing.interactive_signing.values().any(|members| members.contains_key(&1)));
+        assert!(signing
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&1)));
         assert!(!interactive_attempt_consumed(
             &signing.consumed_interactive_attempt_markers,
             &opened.attempt_id,
@@ -8709,11 +8717,17 @@ fn interactive_multi_seat_two_members_one_process_aggregate_bip340() {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
         assert!(
-            !session.interactive_signing.values().any(|members| members.contains_key(&1)),
+            !session
+                .interactive_signing
+                .values()
+                .any(|members| members.contains_key(&1)),
             "member 1's entry is freed after its Round2"
         );
         assert!(
-            session.interactive_signing.values().any(|members| members.contains_key(&2)),
+            session
+                .interactive_signing
+                .values()
+                .any(|members| members.contains_key(&2)),
             "member 2's entry stays live - a sibling seat's Round2 must not free it"
         );
         assert!(
@@ -8903,7 +8917,10 @@ fn interactive_round2_refused_after_aggregate_for_unsigned_sibling() {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
         assert!(
-            !session.interactive_signing.values().any(|members| members.contains_key(&3)),
+            !session
+                .interactive_signing
+                .values()
+                .any(|members| members.contains_key(&3)),
             "the non-signing sibling is freed when the attempt aggregates"
         );
     }
@@ -8953,7 +8970,10 @@ fn interactive_round2_refused_after_aggregate_for_unsigned_sibling() {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
         assert!(
-            !session.interactive_signing.values().any(|members| members.contains_key(&3)),
+            !session
+                .interactive_signing
+                .values()
+                .any(|members| members.contains_key(&3)),
             "seat 3's dead entry is freed when Round2 is refused for the finalized attempt"
         );
     }
@@ -9350,15 +9370,24 @@ fn interactive_abort_by_attempt_removes_all_members_on_that_attempt() {
     let guard = state().expect("state").lock().expect("lock");
     let session = guard.sessions.get(session_id).expect("session exists");
     assert!(
-        !session.interactive_signing.values().any(|members| members.contains_key(&1)),
+        !session
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&1)),
         "member 1 (attempt 1) is aborted"
     );
     assert!(
-        !session.interactive_signing.values().any(|members| members.contains_key(&2)),
+        !session
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&2)),
         "member 2 (attempt 1) is aborted"
     );
     assert!(
-        session.interactive_signing.values().any(|members| members.contains_key(&3)),
+        session
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&3)),
         "member 3 (attempt 2) survives the attempt-1 abort"
     );
 }
@@ -9927,7 +9956,10 @@ fn interactive_round2_post_rename_persist_failure_consumes_attempt_and_retry_flu
             .consumed_interactive_attempt_markers
             .contains(&consumed_marker));
         assert!(
-            !session.interactive_signing.values().any(|members| members.contains_key(&1)),
+            !session
+                .interactive_signing
+                .values()
+                .any(|members| members.contains_key(&1)),
             "post-rename failure must destroy the live nonce-bearing member state"
         );
     }
@@ -10146,9 +10178,10 @@ fn interactive_abort_persist_failures_are_retryable_before_replace_and_fail_clos
     {
         let guard = state().expect("state").lock().expect("engine lock");
         let session = &guard.sessions[retryable_session];
-        assert!(
-            session.interactive_signing.values().any(|members| members.contains_key(&1)),
-        );
+        assert!(session
+            .interactive_signing
+            .values()
+            .any(|members| members.contains_key(&1)),);
         assert!(session.retired_interactive_at_unix.is_none());
     }
     assert!(
@@ -10952,7 +10985,9 @@ fn interactive_round2_rechecks_stored_heartbeat_intent_before_share_release() {
     ));
     let guard = state().expect("state").lock().expect("engine lock");
     let session = &guard.sessions[signing_session];
-    assert!(session.interactive_signing[&opened.attempt_id][&1].round1.is_some());
+    assert!(session.interactive_signing[&opened.attempt_id][&1]
+        .round1
+        .is_some());
     assert!(!interactive_attempt_consumed(
         &session.consumed_interactive_attempt_markers,
         &opened.attempt_id,
@@ -14189,14 +14224,19 @@ fn interactive_two_attempts_coexist_same_session() {
     let key_packages = ensure_interactive_dkg_session(session_id, key_group);
 
     // Open attempt A for member 1
-    let opened_a1 = open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, threshold)
-        .expect("member 1 opens attempt A");
+    let opened_a1 =
+        open_interactive_for_test(session_id, key_group, &message, &included, 1, 1, threshold)
+            .expect("member 1 opens attempt A");
 
     // Open attempt B for member 2
-    let opened_b2 = open_interactive_for_test(session_id, key_group, &message, &included, 2, 2, threshold)
-        .expect("member 2 opens attempt B");
+    let opened_b2 =
+        open_interactive_for_test(session_id, key_group, &message, &included, 2, 2, threshold)
+            .expect("member 2 opens attempt B");
 
-    assert_ne!(opened_a1.attempt_id, opened_b2.attempt_id, "attempt IDs must differ");
+    assert_ne!(
+        opened_a1.attempt_id, opened_b2.attempt_id,
+        "attempt IDs must differ"
+    );
 
     // Attempt B's member 2 creates live Round1 nonces, independent of attempt A.
     interactive_round1(InteractiveRound1Request {
@@ -14211,8 +14251,12 @@ fn interactive_two_attempts_coexist_same_session() {
         let session = guard.sessions.get(session_id).expect("session exists");
 
         // Verify both attempt scopes exist
-        assert!(session.interactive_signing.contains_key(&opened_a1.attempt_id));
-        assert!(session.interactive_signing.contains_key(&opened_b2.attempt_id));
+        assert!(session
+            .interactive_signing
+            .contains_key(&opened_a1.attempt_id));
+        assert!(session
+            .interactive_signing
+            .contains_key(&opened_b2.attempt_id));
 
         // Verify member 1 is in attempt A scope
         assert!(session
@@ -14239,8 +14283,14 @@ fn interactive_two_attempts_coexist_same_session() {
             .get(&opened_b2.attempt_id)
             .expect("attempt B scope exists")
             .len();
-        assert_eq!(attempt_a_members, 1, "attempt A should have exactly 1 member");
-        assert_eq!(attempt_b_members, 1, "attempt B should have exactly 1 member");
+        assert_eq!(
+            attempt_a_members, 1,
+            "attempt A should have exactly 1 member"
+        );
+        assert_eq!(
+            attempt_b_members, 1,
+            "attempt B should have exactly 1 member"
+        );
     }
 
     // Complete attempt A via round1 -> round2 -> aggregate, using an ad-hoc
@@ -14300,21 +14350,29 @@ fn interactive_two_attempts_coexist_same_session() {
         let session = guard.sessions.get(session_id).expect("session exists");
 
         // Verify attempt A scope is cleared (aggregated)
-        assert!(!session.interactive_signing.contains_key(&opened_a1.attempt_id));
+        assert!(!session
+            .interactive_signing
+            .contains_key(&opened_a1.attempt_id));
 
         // Verify attempt B scope still exists with member 2's Round1 nonces live
-        assert!(session.interactive_signing.contains_key(&opened_b2.attempt_id));
+        assert!(session
+            .interactive_signing
+            .contains_key(&opened_b2.attempt_id));
         let attempt_b_scope = session
             .interactive_signing
             .get(&opened_b2.attempt_id)
             .expect("attempt B scope still exists");
-        assert!(attempt_b_scope.contains_key(&2), "member 2 still in attempt B scope");
+        assert!(
+            attempt_b_scope.contains_key(&2),
+            "member 2 still in attempt B scope"
+        );
 
         // Verify member 2's Round1 nonces are still live (not zeroized)
-        let member_b_state = attempt_b_scope
-            .get(&2)
-            .expect("member 2 state exists");
-        assert!(member_b_state.round1.is_some(), "member 2's Round1 nonces still live");
+        let member_b_state = attempt_b_scope.get(&2).expect("member 2 state exists");
+        assert!(
+            member_b_state.round1.is_some(),
+            "member 2's Round1 nonces still live"
+        );
     }
 }
 
@@ -14368,7 +14426,11 @@ fn interactive_concurrent_attempt_cap_enforced() {
                 .interactive_signing
                 .get(&opened.attempt_id)
                 .unwrap_or_else(|| panic!("attempt {} scope exists", i + 1));
-            assert_eq!(attempt_scope.len(), 1, "attempt should have exactly one member");
+            assert_eq!(
+                attempt_scope.len(),
+                1,
+                "attempt should have exactly one member"
+            );
             assert!(
                 attempt_scope.contains_key(&member_identifier),
                 "member {member_identifier} should be in attempt"
@@ -14440,8 +14502,7 @@ fn interactive_round2_durable_markers_persist_before_share_release() {
     // restart reload sees an empty marker set, and the retry below is
     // NOT rejected as a replay.
     let _guard = lock_test_state();
-    let state_path =
-        configure_test_state_path("interactive_round2_marker_ordering");
+    let state_path = configure_test_state_path("interactive_round2_marker_ordering");
     reset_for_tests();
 
     let key_packages = interactive_test_key_packages();
@@ -14597,9 +14658,7 @@ fn interactive_round1_reports_attempt_id_mismatch_for_superseded_member() {
                 message,
             );
         }
-        other => panic!(
-            "expected EngineError::Validation for attempt-id mismatch, got {other:?}"
-        ),
+        other => panic!("expected EngineError::Validation for attempt-id mismatch, got {other:?}"),
     }
     // The Round2 path shares the same lookup. A Round2 with the stale
     // attempt_id must report the same specific mismatch error, not a
@@ -14700,7 +14759,10 @@ fn interactive_cap_does_not_double_count_member_vacating_own_attempt_scope() {
     let opened_b =
         open_interactive_for_test(session_id, key_group, &message, &included, 2, 2, threshold)
             .expect("member 2 opens attempt B");
-    assert_ne!(opened_a.attempt_id, opened_b.attempt_id, "attempts must differ");
+    assert_ne!(
+        opened_a.attempt_id, opened_b.attempt_id,
+        "attempts must differ"
+    );
     {
         let guard = state().expect("state").lock().expect("lock");
         let session = guard.sessions.get(session_id).expect("session exists");
@@ -14716,15 +14778,11 @@ fn interactive_cap_does_not_double_count_member_vacating_own_attempt_scope() {
         open_interactive_for_test(session_id, key_group, &message, &included, 3, 3, threshold)
             .expect_err("opening a 3rd attempt while at cap must fail");
     match &overflow {
-        EngineError::SigningPolicyRejected {
-            reason_code, ..
-        } => assert_eq!(
+        EngineError::SigningPolicyRejected { reason_code, .. } => assert_eq!(
             reason_code, "concurrent_attempt_cap_exceeded",
             "expected concurrent_attempt_cap_exceeded, got {overflow:?}"
         ),
-        other => panic!(
-            "expected SigningPolicyRejected for cap overflow, got {other:?}"
-        ),
+        other => panic!("expected SigningPolicyRejected for cap overflow, got {other:?}"),
     }
 
     // Member 1 advances to a NEW attempt under a fresh attempt_id
@@ -14752,17 +14810,23 @@ fn interactive_cap_does_not_double_count_member_vacating_own_attempt_scope() {
         let session = guard.sessions.get(session_id).expect("session exists");
         // The vacated scope is gone (member 1 was the sole member there).
         assert!(
-            !session.interactive_signing.contains_key(&opened_a.attempt_id),
+            !session
+                .interactive_signing
+                .contains_key(&opened_a.attempt_id),
             "the vacated attempt scope is pruned immediately"
         );
         // Member 2's scope on attempt B is untouched by member 1's advance.
         assert!(
-            session.interactive_signing.contains_key(&opened_b.attempt_id),
+            session
+                .interactive_signing
+                .contains_key(&opened_b.attempt_id),
             "sibling member's scope is untouched by the advance"
         );
         // Member 1 is now under the new attempt C.
         assert!(
-            session.interactive_signing.contains_key(&opened_c.attempt_id),
+            session
+                .interactive_signing
+                .contains_key(&opened_c.attempt_id),
             "the new attempt scope holds the advancing member"
         );
         let new_scope = session


### PR DESCRIPTION
## Summary

Implements GitHub issue #4251: bounded concurrent interactive attempts per signing session.

## Behavior

- Distinct members can now hold independent live attempts concurrently within the same per-message session, so a coordinator failover advancing one member's attempt no longer collides with another member's still-live attempt on the prior round.
- Caps concurrent attempts per session at `n - t + 1` (n = DKG participant count, t = threshold). Open past the cap fails closed with `concurrent_attempt_cap_exceeded`.
- Implementation: per-session `interactive_signing` restructured from a flat `member_identifier -> state` map to a nested `attempt_id -> member_identifier -> state` map. Empty attempt scopes are dropped immediately so the outer map only ever holds non-empty scopes; `n - t + 1` is the natural cap on the outer map.

## Fixes two correctness regressions surfaced by the full test run

- **`interactive_round2` stopped inserting the durable consumed-attempt and aggregate-authorization markers** before persisting, silently breaking every Round2 -> Aggregate handoff (the only remaining authorization fallback also fails post-Round2 since Round2 clears `round1` state). Both inserts restored at the pre-persist point.
- **`interactive_state_for_attempt_mut` lost the ability to distinguish** "member has no live attempt at all" from "member's live attempt moved to a different attempt_id" once the map became attempt-id keyed. Restored the distinction via a fallback scan of the other live attempt scopes, so a stale-attempt-id Round1/Round2 call returns the specific attempt-id mismatch instead of a generic not-found.

## Tests

- 280 lib tests pass, 1 pre-existing ignore unrelated to this change.
- New coverage: `interactive_two_attempts_coexist_same_session` (two attempts on the same session, sibling nonces survive while the primary is aggregated), `interactive_concurrent_attempt_cap_enforced` (cap rejects Open past `n - t + 1` with `concurrent_attempt_cap_exceeded`).
- Pre-existing interactive tests (Round1 / Round2 / Aggregate / Abort / heartbeat / heartbeat-intent recheck / quarantine / persistence fault injection / etc.) all green.
- Pre-existing non-interactive tests unaffected.
- Also removed an unused `interactive_session_attempt_count` helper that was identical to `.len()` per its own doc comment.

## Out of scope

- Cross-session cap (this is per-session only; cross-session budget is the existing `max_live_interactive_sessions_limit`).
- Coordinator selection retry behavior (the `attempts` count is the cap, not a retry budget).