### PR TITLE
fix(tbtc-signer): validation & bounds hardening on FFI-adjacent inputs (#4255 cluster A)

### DIFF
--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -223,9 +223,7 @@ where
 /// string (e.g. `ErrorResponse.message`) at `MAX_MESSAGE_ASCII_CHARS`.
 /// Wider cap than `deserialize_bounded_ascii` because error `message`
 /// strings may carry operator-readable detail text.
-pub(crate) fn deserialize_bounded_message_ascii<'de, D>(
-    deserializer: D,
-) -> Result<String, D::Error>
+pub(crate) fn deserialize_bounded_message_ascii<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -287,9 +285,8 @@ where
         type Value = std::collections::BTreeMap<String, String>;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str(
-                "a JSON object mapping FROST identifiers to verifying-share hex strings",
-            )
+            formatter
+                .write_str("a JSON object mapping FROST identifiers to verifying-share hex strings")
         }
 
         fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
@@ -360,26 +357,14 @@ macro_rules! define_bounded_vec_deserializer {
     };
 }
 
-define_bounded_vec_deserializer!(
-    deserialize_bounded_commitments_vec,
-    NativeFrostCommitment
-);
-define_bounded_vec_deserializer!(
-    deserialize_bounded_round1_packages_vec,
-    DkgRound1Package
-);
-define_bounded_vec_deserializer!(
-    deserialize_bounded_round2_packages_vec,
-    DkgRound2Package
-);
+define_bounded_vec_deserializer!(deserialize_bounded_commitments_vec, NativeFrostCommitment);
+define_bounded_vec_deserializer!(deserialize_bounded_round1_packages_vec, DkgRound1Package);
+define_bounded_vec_deserializer!(deserialize_bounded_round2_packages_vec, DkgRound2Package);
 define_bounded_vec_deserializer!(
     deserialize_bounded_signature_shares_vec,
     NativeFrostSignatureShare
 );
-define_bounded_vec_deserializer!(
-    deserialize_bounded_share_material_vec,
-    ShareMaterial
-);
+define_bounded_vec_deserializer!(deserialize_bounded_share_material_vec, ShareMaterial);
 
 /// serde `deserialize_with` helper for the `policy_allowed_utc_*_hour`
 /// init-config fields: validate `0 <= value <= 23` BEFORE the value
@@ -400,7 +385,6 @@ where
     }
     Ok(value)
 }
-
 
 /// A hex-encoded secret whose owned Rust allocation is wiped on drop and whose
 /// `Debug` representation never exposes its contents. Serde remains transparent
@@ -1659,8 +1643,8 @@ mod tests {
     fn deserialize_bounded_ascii_accepts_at_cap_input() {
         let at_cap = "a".repeat(MAX_ASCII_CODES_CHARS);
         let json = format!("{{\"value\":\"{at_cap}\"}}");
-        let parsed: BoundedAsciiField = serde_json::from_str(&json)
-            .expect("at-cap ascii field must be accepted");
+        let parsed: BoundedAsciiField =
+            serde_json::from_str(&json).expect("at-cap ascii field must be accepted");
         assert_eq!(parsed.value.len(), MAX_ASCII_CODES_CHARS);
     }
 
@@ -1730,8 +1714,8 @@ mod tests {
         let entries: Vec<u16> = (0..MAX_BOUNDED_COLLECTION_LEN as u16).collect();
         let entries_json = serde_json::to_string(&entries).expect("serialize");
         let json = format!("{{\"value\":{entries_json}}}");
-        let parsed: BoundedU16VecField = serde_json::from_str(&json)
-            .expect("at-cap u16 vec must be accepted");
+        let parsed: BoundedU16VecField =
+            serde_json::from_str(&json).expect("at-cap u16 vec must be accepted");
         assert_eq!(parsed.value.len(), MAX_BOUNDED_COLLECTION_LEN);
     }
 
@@ -1756,14 +1740,9 @@ mod tests {
 
     #[test]
     fn deserialize_bounded_verifying_shares_map_rejects_oversized_entry_count() {
-        let entries: std::collections::BTreeMap<String, String> = (0..(MAX_BOUNDED_MAP_ENTRIES + 1)
-            as u16)
-            .map(|idx| {
-                (
-                    format!("id-{idx:03}"),
-                    format!("{:02x}", idx as u8),
-                )
-            })
+        let entries: std::collections::BTreeMap<String, String> = (0
+            ..(MAX_BOUNDED_MAP_ENTRIES + 1) as u16)
+            .map(|idx| (format!("id-{idx:03}"), format!("{:02x}", idx as u8)))
             .collect();
         let entries_json = serde_json::to_string(&entries).expect("serialize");
         let json = format!("{{\"value\":{entries_json}}}");
@@ -1780,17 +1759,12 @@ mod tests {
     fn deserialize_bounded_verifying_shares_map_accepts_at_cap_inputs() {
         let entries: std::collections::BTreeMap<String, String> = (0..MAX_BOUNDED_MAP_ENTRIES
             as u16)
-            .map(|idx| {
-                (
-                    format!("id-{idx:03}"),
-                    format!("{:02x}", idx as u8),
-                )
-            })
+            .map(|idx| (format!("id-{idx:03}"), format!("{:02x}", idx as u8)))
             .collect();
         let entries_json = serde_json::to_string(&entries).expect("serialize");
         let json = format!("{{\"value\":{entries_json}}}");
-        let parsed: BoundedVerifyingSharesMapField = serde_json::from_str(&json)
-            .expect("at-cap map must be accepted");
+        let parsed: BoundedVerifyingSharesMapField =
+            serde_json::from_str(&json).expect("at-cap map must be accepted");
         assert_eq!(parsed.value.len(), MAX_BOUNDED_MAP_ENTRIES);
     }
 

--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -187,6 +187,13 @@ pub(crate) const MAX_VERIFYING_SHARE_HEX_CHARS: usize = 256;
 /// in-memory footprint of an adversarial payload.
 pub(crate) const MAX_BOUNDED_COLLECTION_LEN: usize = 256;
 
+/// Hard cap on per-`BTreeMap` entry count for the bounded map fields on
+/// the FFI surface (currently `NativeFrostPublicKeyPackage.verifying_shares`).
+/// Mirrors `MAX_BOUNDED_COLLECTION_LEN` (256); 256 entries is well above any
+/// realistic FROST participant count while capping the worst-case allocation
+/// a hostile host can trigger through the deserializer path.
+pub(crate) const MAX_BOUNDED_MAP_ENTRIES: usize = 256;
+
 /// serde `deserialize_with` helper: cap an ASCII short identifier
 /// string (e.g. `ErrorResponse.code` / `.recovery_class`) at
 /// `MAX_ASCII_CODES_CHARS`. Same wire shape as the hex helpers
@@ -203,6 +210,11 @@ where
             "ascii field exceeds max length [{}] bytes",
             MAX_ASCII_CODES_CHARS
         )));
+    }
+    if !value.is_ascii() {
+        return Err(serde::de::Error::custom(
+            "ascii field contains non-ASCII bytes; expected an ASCII code/recovery_class identifier",
+        ));
     }
     Ok(value)
 }
@@ -223,6 +235,11 @@ where
             "message field exceeds max length [{}] bytes",
             MAX_MESSAGE_ASCII_CHARS
         )));
+    }
+    if !value.is_ascii() {
+        return Err(serde::de::Error::custom(
+            "message field contains non-ASCII bytes; expected ASCII human-readable text",
+        ));
     }
     Ok(value)
 }
@@ -246,26 +263,77 @@ where
     Ok(value)
 }
 
-/// serde `deserialize_with` helper: deserialize a
-/// `BTreeMap<String, String>` AND validate every value's length is
-/// within the per-entry verifying-share hex cap. Keys are short
-/// FROST identifier encodings and not separately bounded.
+/// serde `deserialize_with` helper: deserialize a `BTreeMap<String, String>`
+/// while enforcing BOTH a per-`BTreeMap` entry count cap
+/// (`MAX_BOUNDED_MAP_ENTRIES`) AND a per-value length cap
+/// (`MAX_VERIFYING_SHARE_HEX_CHARS`) BEFORE the BTreeMap is built. Uses a
+/// custom `Visitor` so the cap is checked once each entry is materialized
+/// rather than after the full BTreeMap has been allocated. The per-value cap
+/// is enforced inside `BoundedShareHex::deserialize` so it fires once each
+/// value is materialized, matching the "bounds enforced BEFORE the unbounded
+/// operation they protect" standard the other bounded helpers in this PR use.
+/// Without the entry count cap, a hostile host could ship a map with billions
+/// of short-string entries and the BTreeMap would allocate them before the
+/// per-value check ran.
 pub(crate) fn deserialize_bounded_verifying_shares_map<'de, D>(
     deserializer: D,
 ) -> Result<std::collections::BTreeMap<String, String>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let value = std::collections::BTreeMap::<String, String>::deserialize(deserializer)?;
-    for (key, share_hex) in &value {
-        if share_hex.len() > MAX_VERIFYING_SHARE_HEX_CHARS {
+    struct VerifyingSharesMapVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for VerifyingSharesMapVisitor {
+        type Value = std::collections::BTreeMap<String, String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str(
+                "a JSON object mapping FROST identifiers to verifying-share hex strings",
+            )
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut result = std::collections::BTreeMap::new();
+            while let Some((key, value)) = map.next_entry::<String, BoundedShareHex>()? {
+                if result.len() >= MAX_BOUNDED_MAP_ENTRIES {
+                    return Err(serde::de::Error::custom(format!(
+                        "verifying_shares map exceeds max entries [{}]",
+                        MAX_BOUNDED_MAP_ENTRIES
+                    )));
+                }
+                result.insert(key, value.0);
+            }
+            Ok(result)
+        }
+    }
+
+    deserializer.deserialize_map(VerifyingSharesMapVisitor)
+}
+
+/// Private wrapper that enforces the per-value `MAX_VERIFYING_SHARE_HEX_CHARS`
+/// cap during deserialization. Used by `deserialize_bounded_verifying_shares_map`
+/// as the entry-value type of `MapAccess::next_entry` so the per-value length
+/// check fires once each value is materialized, before the value is handed to
+/// the BTreeMap.
+struct BoundedShareHex(String);
+
+impl<'de> serde::Deserialize<'de> for BoundedShareHex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if value.len() > MAX_VERIFYING_SHARE_HEX_CHARS {
             return Err(serde::de::Error::custom(format!(
-                "verifying_shares[{key}] exceeds max length [{}] hex chars",
+                "verifying_shares value exceeds max length [{}] hex chars",
                 MAX_VERIFYING_SHARE_HEX_CHARS
             )));
         }
+        Ok(BoundedShareHex(value))
     }
-    Ok(value)
 }
 
 /// Macro for generating per-element-type bounded `Vec` deserializers.
@@ -1528,5 +1596,220 @@ mod tests {
                 "Debug output did not mark DKG secret material as redacted: {rendered_value}"
             );
         }
+    }
+
+    // -- Bounded deserializer regression tests -----------------------------
+    //
+    // Each test asserts that an over-cap input is rejected and a near-cap
+    // input is accepted, so a future edit that silently widens a cap or
+    // drops a `deserialize_with` attribute fails this suite. The bounded
+    // deserializer helpers are `deserialize_with` attributes, not plain
+    // string deserializers, so each test wraps them in a test-only struct
+    // whose field carries the helper.
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct BoundedAsciiField {
+        #[serde(deserialize_with = "deserialize_bounded_ascii")]
+        value: String,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct BoundedMessageAsciiField {
+        #[serde(deserialize_with = "deserialize_bounded_message_ascii")]
+        value: String,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct BoundedU16VecField {
+        #[serde(deserialize_with = "deserialize_bounded_u16_vec")]
+        value: Vec<u16>,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct BoundedRound1PackagesVecField {
+        #[serde(deserialize_with = "deserialize_bounded_round1_packages_vec")]
+        value: Vec<DkgRound1Package>,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize)]
+    struct BoundedVerifyingSharesMapField {
+        #[serde(deserialize_with = "deserialize_bounded_verifying_shares_map")]
+        value: std::collections::BTreeMap<String, String>,
+    }
+
+    #[test]
+    fn deserialize_bounded_ascii_rejects_oversized_input() {
+        let over_cap = "a".repeat(MAX_ASCII_CODES_CHARS + 1);
+        let json = format!("{{\"value\":\"{over_cap}\"}}");
+        let error = serde_json::from_str::<BoundedAsciiField>(&json)
+            .expect_err("over-cap ascii field must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("ascii field exceeds max length"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn deserialize_bounded_ascii_accepts_at_cap_input() {
+        let at_cap = "a".repeat(MAX_ASCII_CODES_CHARS);
+        let json = format!("{{\"value\":\"{at_cap}\"}}");
+        let parsed: BoundedAsciiField = serde_json::from_str(&json)
+            .expect("at-cap ascii field must be accepted");
+        assert_eq!(parsed.value.len(), MAX_ASCII_CODES_CHARS);
+    }
+
+    #[test]
+    fn deserialize_bounded_ascii_rejects_non_ascii_input() {
+        // JSON escape "\u00e9" is the UTF-8 sequence for é (two bytes),
+        // which is not ASCII. The bounded helper must reject it.
+        let json = "{\"value\":\"code\\u00e9\"}";
+        let error = serde_json::from_str::<BoundedAsciiField>(json)
+            .expect_err("non-ASCII bytes must be rejected on an ASCII-bounded field");
+        let message = error.to_string();
+        assert!(
+            message.contains("non-ASCII"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn deserialize_bounded_message_ascii_rejects_oversized_input() {
+        let over_cap = "m".repeat(MAX_MESSAGE_ASCII_CHARS + 1);
+        let json = format!("{{\"value\":\"{over_cap}\"}}");
+        let error = serde_json::from_str::<BoundedMessageAsciiField>(&json)
+            .expect_err("over-cap message field must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("message field exceeds max length"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn deserialize_bounded_message_ascii_rejects_non_ascii_input() {
+        let json = "{\"value\":\"detailed error \\u00e9\"}";
+        let error = serde_json::from_str::<BoundedMessageAsciiField>(json)
+            .expect_err("non-ASCII bytes must be rejected on an ASCII-bounded message field");
+        let message = error.to_string();
+        assert!(
+            message.contains("non-ASCII"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn deserialize_bounded_ascii_through_error_response_rejects_non_ascii_code() {
+        let json = "{\"code\":\"not_ascii\\u00e9\",\"message\":\"all-ASCII\",\"recovery_class\":\"recoverable\"}";
+        let error = serde_json::from_str::<ErrorResponse>(json)
+            .expect_err("ErrorResponse.code must reject non-ASCII bytes");
+        assert!(error.to_string().contains("non-ASCII"));
+    }
+
+    #[test]
+    fn deserialize_bounded_u16_vec_rejects_oversized_input() {
+        let entries: Vec<u16> = (0..(MAX_BOUNDED_COLLECTION_LEN + 1) as u16).collect();
+        let entries_json = serde_json::to_string(&entries).expect("serialize");
+        let json = format!("{{\"value\":{entries_json}}}");
+        let error = serde_json::from_str::<BoundedU16VecField>(&json)
+            .expect_err("over-cap u16 vec must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("vector field exceeds max length"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn deserialize_bounded_u16_vec_accepts_at_cap_input() {
+        let entries: Vec<u16> = (0..MAX_BOUNDED_COLLECTION_LEN as u16).collect();
+        let entries_json = serde_json::to_string(&entries).expect("serialize");
+        let json = format!("{{\"value\":{entries_json}}}");
+        let parsed: BoundedU16VecField = serde_json::from_str(&json)
+            .expect("at-cap u16 vec must be accepted");
+        assert_eq!(parsed.value.len(), MAX_BOUNDED_COLLECTION_LEN);
+    }
+
+    #[test]
+    fn deserialize_bounded_verifying_shares_map_rejects_oversized_value() {
+        let mut entries: std::collections::BTreeMap<String, String> =
+            std::collections::BTreeMap::new();
+        entries.insert(
+            "01".to_string(),
+            "a".repeat(MAX_VERIFYING_SHARE_HEX_CHARS + 1),
+        );
+        let entries_json = serde_json::to_string(&entries).expect("serialize");
+        let json = format!("{{\"value\":{entries_json}}}");
+        let error = serde_json::from_str::<BoundedVerifyingSharesMapField>(&json)
+            .expect_err("map value over per-value cap must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("verifying_shares value exceeds max length"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn deserialize_bounded_verifying_shares_map_rejects_oversized_entry_count() {
+        let entries: std::collections::BTreeMap<String, String> = (0..(MAX_BOUNDED_MAP_ENTRIES + 1)
+            as u16)
+            .map(|idx| {
+                (
+                    format!("id-{idx:03}"),
+                    format!("{:02x}", idx as u8),
+                )
+            })
+            .collect();
+        let entries_json = serde_json::to_string(&entries).expect("serialize");
+        let json = format!("{{\"value\":{entries_json}}}");
+        let error = serde_json::from_str::<BoundedVerifyingSharesMapField>(&json)
+            .expect_err("map over entry-count cap must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("verifying_shares map exceeds max entries"),
+            "unexpected error message: {message}"
+        );
+    }
+
+    #[test]
+    fn deserialize_bounded_verifying_shares_map_accepts_at_cap_inputs() {
+        let entries: std::collections::BTreeMap<String, String> = (0..MAX_BOUNDED_MAP_ENTRIES
+            as u16)
+            .map(|idx| {
+                (
+                    format!("id-{idx:03}"),
+                    format!("{:02x}", idx as u8),
+                )
+            })
+            .collect();
+        let entries_json = serde_json::to_string(&entries).expect("serialize");
+        let json = format!("{{\"value\":{entries_json}}}");
+        let parsed: BoundedVerifyingSharesMapField = serde_json::from_str(&json)
+            .expect("at-cap map must be accepted");
+        assert_eq!(parsed.value.len(), MAX_BOUNDED_MAP_ENTRIES);
+    }
+
+    #[test]
+    fn deserialize_bounded_round1_packages_vec_rejects_oversized_input() {
+        let entries: Vec<DkgRound1Package> = (0..(MAX_BOUNDED_COLLECTION_LEN + 1) as u16)
+            .map(|idx| DkgRound1Package {
+                identifier: format!("id-{idx}"),
+                package_hex: "aa".to_string(),
+            })
+            .collect();
+        let entries_json = serde_json::to_string(&entries).expect("serialize");
+        let json = format!("{{\"value\":{entries_json}}}");
+        let error = serde_json::from_str::<BoundedRound1PackagesVecField>(&json)
+            .expect_err("over-cap round1 packages vec must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("vector field exceeds max length"),
+            "unexpected error message: {message}"
+        );
     }
 }

--- a/pkg/tbtc/signer/src/api.rs
+++ b/pkg/tbtc/signer/src/api.rs
@@ -163,6 +163,177 @@ where
     }
 }
 
+/// Hard cap for ASCII-only short identifier strings (codes, recovery
+/// classes). The wire format is still a plain JSON string; the cap
+/// prevents an adversarial host from claiming a multi-megabyte code
+/// in an error response and pre-allocating sidecar allocations.
+pub(crate) const MAX_ASCII_CODES_CHARS: usize = 256;
+
+/// Hard cap for free-form human-readable error message text (the ASCII
+/// "message" of `ErrorResponse`). 4 KiB is generous for any operator
+/// note or detail string the engine surfaces.
+pub(crate) const MAX_MESSAGE_ASCII_CHARS: usize = 4 * 1024;
+
+/// Hard cap for hex-encoded FROST verifying-share values inside each
+/// entry of `NativeFrostPublicKeyPackage.verifying_shares`. 256 chars is
+/// more than enough for any plausible encoding (a secp256k1 verifying
+/// share is 33 bytes = 66 hex chars), but accepts future metadata
+/// encodings while bounding the worst case against a hostile host.
+pub(crate) const MAX_VERIFYING_SHARE_HEX_CHARS: usize = 256;
+
+/// Hard cap on per-collection length for the bounded `Vec` fields on
+/// the FFI surface. 256 entries is well above any realistic FROST
+/// participant count (a few dozen at most) while bounding the
+/// in-memory footprint of an adversarial payload.
+pub(crate) const MAX_BOUNDED_COLLECTION_LEN: usize = 256;
+
+/// serde `deserialize_with` helper: cap an ASCII short identifier
+/// string (e.g. `ErrorResponse.code` / `.recovery_class`) at
+/// `MAX_ASCII_CODES_CHARS`. Same wire shape as the hex helpers
+/// (a plain JSON string), distinct from the hex helpers because the
+/// existing `deserialize_bounded_hex` name mis-describes the data and
+/// would silently widen on future cap edits.
+pub(crate) fn deserialize_bounded_ascii<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    if value.len() > MAX_ASCII_CODES_CHARS {
+        return Err(serde::de::Error::custom(format!(
+            "ascii field exceeds max length [{}] bytes",
+            MAX_ASCII_CODES_CHARS
+        )));
+    }
+    Ok(value)
+}
+
+/// serde `deserialize_with` helper: cap an ASCII free-form message
+/// string (e.g. `ErrorResponse.message`) at `MAX_MESSAGE_ASCII_CHARS`.
+/// Wider cap than `deserialize_bounded_ascii` because error `message`
+/// strings may carry operator-readable detail text.
+pub(crate) fn deserialize_bounded_message_ascii<'de, D>(
+    deserializer: D,
+) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    if value.len() > MAX_MESSAGE_ASCII_CHARS {
+        return Err(serde::de::Error::custom(format!(
+            "message field exceeds max length [{}] bytes",
+            MAX_MESSAGE_ASCII_CHARS
+        )));
+    }
+    Ok(value)
+}
+
+/// serde `deserialize_with` helper: cap a `Vec<u16>` at
+/// `MAX_BOUNDED_COLLECTION_LEN` (256) entries. Used for FROST
+/// participant-identifier vectors (excluded members, included
+/// participants) where the realistic upper bound is a handful to a
+/// few dozen.
+pub(crate) fn deserialize_bounded_u16_vec<'de, D>(deserializer: D) -> Result<Vec<u16>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Vec::<u16>::deserialize(deserializer)?;
+    if value.len() > MAX_BOUNDED_COLLECTION_LEN {
+        return Err(serde::de::Error::custom(format!(
+            "vector field exceeds max length [{}] entries",
+            MAX_BOUNDED_COLLECTION_LEN
+        )));
+    }
+    Ok(value)
+}
+
+/// serde `deserialize_with` helper: deserialize a
+/// `BTreeMap<String, String>` AND validate every value's length is
+/// within the per-entry verifying-share hex cap. Keys are short
+/// FROST identifier encodings and not separately bounded.
+pub(crate) fn deserialize_bounded_verifying_shares_map<'de, D>(
+    deserializer: D,
+) -> Result<std::collections::BTreeMap<String, String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = std::collections::BTreeMap::<String, String>::deserialize(deserializer)?;
+    for (key, share_hex) in &value {
+        if share_hex.len() > MAX_VERIFYING_SHARE_HEX_CHARS {
+            return Err(serde::de::Error::custom(format!(
+                "verifying_shares[{key}] exceeds max length [{}] hex chars",
+                MAX_VERIFYING_SHARE_HEX_CHARS
+            )));
+        }
+    }
+    Ok(value)
+}
+
+/// Macro for generating per-element-type bounded `Vec` deserializers.
+/// The existing serde-derive style in this file uses named functions
+/// (e.g. `deserialize_bounded_hex`), not const-generic turbofish, so
+/// each bounded `Vec` field gets a small named helper that repeats
+/// the cap check inline. This keeps the derive site readable and the
+/// cap explicit per field.
+macro_rules! define_bounded_vec_deserializer {
+    ($name:ident, $element:ty) => {
+        pub(crate) fn $name<'de, D>(deserializer: D) -> Result<Vec<$element>, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let value = Vec::<$element>::deserialize(deserializer)?;
+            if value.len() > MAX_BOUNDED_COLLECTION_LEN {
+                return Err(serde::de::Error::custom(format!(
+                    "vector field exceeds max length [{}] entries",
+                    MAX_BOUNDED_COLLECTION_LEN
+                )));
+            }
+            Ok(value)
+        }
+    };
+}
+
+define_bounded_vec_deserializer!(
+    deserialize_bounded_commitments_vec,
+    NativeFrostCommitment
+);
+define_bounded_vec_deserializer!(
+    deserialize_bounded_round1_packages_vec,
+    DkgRound1Package
+);
+define_bounded_vec_deserializer!(
+    deserialize_bounded_round2_packages_vec,
+    DkgRound2Package
+);
+define_bounded_vec_deserializer!(
+    deserialize_bounded_signature_shares_vec,
+    NativeFrostSignatureShare
+);
+define_bounded_vec_deserializer!(
+    deserialize_bounded_share_material_vec,
+    ShareMaterial
+);
+
+/// serde `deserialize_with` helper for the `policy_allowed_utc_*_hour`
+/// init-config fields: validate `0 <= value <= 23` BEFORE the value
+/// reaches the policy gate, so an out-of-range hour can't widen the
+/// operational window past midnight. Accepts `null`/absent as
+/// `Ok(None)`.
+pub(crate) fn deserialize_utc_hour_opt<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<u8> = Option::deserialize(deserializer)?;
+    if let Some(hour) = value {
+        if hour > 23 {
+            return Err(serde::de::Error::custom(format!(
+                "policy UTC hour value [{hour}] is out of range [0, 23]"
+            )));
+        }
+    }
+    Ok(value)
+}
+
+
 /// A hex-encoded secret whose owned Rust allocation is wiped on drop and whose
 /// `Debug` representation never exposes its contents. Serde remains transparent
 /// so the C-ABI JSON contract continues to carry an ordinary string.
@@ -250,6 +421,7 @@ pub struct DkgPart1Result {
 pub struct DkgPart2Request {
     #[serde(deserialize_with = "deserialize_bounded_secret_hex")]
     pub secret_package_hex: SecretHex,
+    #[serde(deserialize_with = "deserialize_bounded_round1_packages_vec")]
     pub round1_packages: Vec<DkgRound1Package>,
 }
 
@@ -270,6 +442,7 @@ pub struct NativeFrostKeyPackage {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct NativeFrostPublicKeyPackage {
+    #[serde(deserialize_with = "deserialize_bounded_verifying_shares_map")]
     pub verifying_shares: std::collections::BTreeMap<String, String>,
     #[serde(deserialize_with = "deserialize_bounded_hex")]
     pub verifying_key: String,
@@ -279,7 +452,9 @@ pub struct NativeFrostPublicKeyPackage {
 pub struct DkgPart3Request {
     #[serde(deserialize_with = "deserialize_bounded_secret_hex")]
     pub secret_package_hex: SecretHex,
+    #[serde(deserialize_with = "deserialize_bounded_round1_packages_vec")]
     pub round1_packages: Vec<DkgRound1Package>,
+    #[serde(deserialize_with = "deserialize_bounded_round2_packages_vec")]
     pub round2_packages: Vec<DkgRound2Package>,
 }
 
@@ -324,6 +499,7 @@ pub struct NativeFrostSignatureShare {
 pub struct NewSigningPackageRequest {
     #[serde(deserialize_with = "deserialize_bounded_message_hex")]
     pub message_hex: String,
+    #[serde(deserialize_with = "deserialize_bounded_commitments_vec")]
     pub commitments: Vec<NativeFrostCommitment>,
 }
 
@@ -450,6 +626,7 @@ pub struct InteractiveAggregateRequest {
     /// pure-crypto candidates for the Go host's envelope-bound blame
     /// adjudication (frozen Phase 7.2b spec, section 6); the engine never
     /// inspects operator-signed envelopes itself.
+    #[serde(deserialize_with = "deserialize_bounded_signature_shares_vec")]
     pub signature_shares: Vec<NativeFrostSignatureShare>,
     #[serde(
         default,
@@ -554,7 +731,11 @@ pub struct AttemptTransitionTelemetry {
     pub to_coordinator_identifier: u16,
     #[serde(deserialize_with = "deserialize_bounded_hex")]
     pub reason: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_bounded_u16_vec"
+    )]
     pub excluded_member_identifiers: Vec<u16>,
     pub coordinator_rotated: bool,
 }
@@ -612,6 +793,7 @@ pub struct DeriveInteractiveAttemptContextRequest {
     /// 1-based wire attempt number (the host's 0-based value + 1), matching
     /// `AttemptContext.attempt_number`.
     pub attempt_number: u32,
+    #[serde(deserialize_with = "deserialize_bounded_u16_vec")]
     pub included_participants: Vec<u16>,
 }
 
@@ -781,6 +963,7 @@ pub struct ShareMaterial {
 pub struct RefreshSharesRequest {
     #[serde(deserialize_with = "deserialize_bounded_hex")]
     pub session_id: String,
+    #[serde(deserialize_with = "deserialize_bounded_share_material_vec")]
     pub current_shares: Vec<ShareMaterial>,
 }
 
@@ -1028,11 +1211,11 @@ pub struct SignerHardeningMetricsResult {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct ErrorResponse {
-    #[serde(deserialize_with = "deserialize_bounded_hex")]
+    #[serde(deserialize_with = "deserialize_bounded_ascii")]
     pub code: String,
-    #[serde(deserialize_with = "deserialize_bounded_hex")]
+    #[serde(deserialize_with = "deserialize_bounded_message_ascii")]
     pub message: String,
-    #[serde(deserialize_with = "deserialize_bounded_hex")]
+    #[serde(deserialize_with = "deserialize_bounded_ascii")]
     pub recovery_class: String,
     /// CANDIDATE culprits for an `aggregate_share_verification_failed` error:
     /// the u16 Go member identifiers whose FROST signature shares failed
@@ -1124,9 +1307,17 @@ pub struct InitSignerConfigRequest {
     pub policy_max_output_value_sats: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_max_total_output_value_sats: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_utc_hour_opt"
+    )]
     pub policy_allowed_utc_start_hour: Option<u8>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_utc_hour_opt"
+    )]
     pub policy_allowed_utc_end_hour: Option<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_rate_limit_per_minute: Option<u64>,

--- a/pkg/tbtc/signer/src/bin/admission_checker.rs
+++ b/pkg/tbtc/signer/src/bin/admission_checker.rs
@@ -74,6 +74,7 @@ struct AdmissionReason {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AdmissionOverrideArtifact {
     payload_json: String,
     signature_hex: String,
@@ -1799,6 +1800,230 @@ mod tests {
         drop(third);
 
         let _ = fs::remove_dir_all(tmp_dir);
+    }
+
+    #[test]
+    fn admission_candidate_deserialization_rejects_unknown_fields() {
+        let valid = serde_json::json!({
+            "operator_id": "operator-1",
+            "provider": "gcp",
+            "region": "us-central1",
+            "custody_class": "kms",
+            "attestation_status": "approved",
+            "patch_sla_expires_at_unix": 2_000_000_000_u64,
+            "incident_response_contact": "oncall@example.org",
+        });
+        let mut typo = valid.clone();
+        if let Some(map) = typo.as_object_mut() {
+            map.remove("operator_id");
+            map.insert("operatorid".to_string(), valid["operator_id"].clone());
+        }
+        let typo_str = typo.to_string();
+
+        let error = serde_json::from_str::<AdmissionCandidate>(&typo_str)
+            .expect_err("a misspelled candidate field must be rejected");
+        assert!(
+            error.to_string().contains("unknown field `operatorid`"),
+            "unexpected parse error: {error}"
+        );
+    }
+
+    #[test]
+    fn admission_candidate_deserialization_accepts_supported_fields() {
+        let candidate_json = serde_json::json!({
+            "operator_id": "operator-1",
+            "provider": "gcp",
+            "region": "us-central1",
+            "custody_class": "kms",
+            "attestation_status": "approved",
+            "patch_sla_expires_at_unix": 2_000_000_000_u64,
+            "incident_response_contact": "oncall@example.org",
+        })
+        .to_string();
+        let candidate = serde_json::from_str::<AdmissionCandidate>(&candidate_json)
+            .expect("the candidate fixture should remain valid");
+        assert_eq!(candidate.operator_id, "operator-1");
+    }
+
+    #[test]
+    fn admission_override_payload_deserialization_rejects_unknown_fields() {
+        let mut payload = serde_json::json!({
+            "override_id": "override-test-1",
+            "operator_id": "operator-1",
+            "decision": "allow",
+            "reason": "emergency governance override",
+            "approved_by": "dao-multisig-1",
+            "approved_at_unix": 1_700_000_000_u64,
+            "expires_at_unix": 1_700_000_600_u64,
+        });
+        payload["unexpected_extra_field_should_fail"] = serde_json::json!("oops");
+        let payload_str = payload.to_string();
+
+        let error = serde_json::from_str::<AdmissionOverridePayload>(&payload_str)
+            .expect_err("an unknown override payload field must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("unknown field `unexpected_extra_field_should_fail`"),
+            "unexpected parse error: {error}"
+        );
+    }
+
+    #[test]
+    fn admission_override_artifact_deserialization_rejects_unknown_fields() {
+        let mut artifact = serde_json::json!({
+            "payload_json": "{}",
+            "signature_hex": "00",
+        });
+        artifact["unexpected_extra_field_should_fail"] = serde_json::json!("oops");
+        let artifact_str = artifact.to_string();
+
+        let error = serde_json::from_str::<AdmissionOverrideArtifact>(&artifact_str)
+            .expect_err("an unknown override artifact field must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("unknown field `unexpected_extra_field_should_fail`"),
+            "unexpected parse error: {error}"
+        );
+    }
+
+    #[test]
+    fn load_json_file_rejects_input_above_size_cap() {
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "admission-large-input-test-{}-{}",
+            std::process::id(),
+            now_unix()
+        ));
+        fs::create_dir_all(&tmp_dir).expect("create tmp dir");
+        let path = tmp_dir.join("oversize-candidate.json");
+
+        // Write a JSON file that is larger than the 1 MiB cap. Construct
+        // the JSON so it is a syntactically valid `AdmissionCandidate`
+        // wire-shape but the `incident_response_contact` field carries
+        // the bulk of the bytes. With the cap enforced, `load_json_file`
+        // rejects the file before `fs::read` returns the full buffer.
+        let oversized_contact = "a".repeat((MAX_JSON_INPUT_FILE_BYTES + 1024) as usize);
+        let payload = serde_json::json!({
+            "operator_id": "operator-1",
+            "provider": "aws",
+            "region": "us-east-1",
+            "custody_class": "hsm",
+            "attestation_status": "approved",
+            "patch_sla_expires_at_unix": 2_000_000_000_u64,
+            "incident_response_contact": oversized_contact,
+        });
+        let serialized = payload.to_string();
+        assert!(
+            serialized.len() as u64 > MAX_JSON_INPUT_FILE_BYTES,
+            "test fixture must produce a payload larger than MAX_JSON_INPUT_FILE_BYTES"
+        );
+        fs::write(&path, &serialized).expect("write oversized file");
+
+        let error = load_json_file::<AdmissionCandidate>(&path)
+            .expect_err("oversized JSON file must be rejected");
+        assert!(
+            error.contains("exceeds the") && error.contains("byte cap"),
+            "unexpected error: {error}"
+        );
+
+        let _ = fs::remove_dir_all(tmp_dir);
+    }
+
+    #[test]
+    fn override_replay_registry_rejects_insertion_past_cap() {
+        let mut registry = OverrideReplayRegistry::default();
+        // The cap is 10_000 entries; insert up to and including the cap.
+        for idx in 0..MAX_OVERRIDE_REGISTRY_ENTRIES {
+            registry
+                .insert(
+                    format!("override-{idx:06}"),
+                    format!("operator-{idx}"),
+                    "dao-approver".to_string(),
+                    1_700_000_000,
+                    1_700_003_600,
+                    1_700_000_100,
+                )
+                .expect("filling the cap to the limit must succeed");
+        }
+        // The next insert with a NEW key must fail.
+        let error = registry
+            .insert(
+                "override-overflow".to_string(),
+                "operator-overflow".to_string(),
+                "dao-approver".to_string(),
+                1_700_000_000,
+                1_700_003_600,
+                1_700_000_100,
+            )
+            .expect_err("inserting past the cap with a new key must be rejected");
+        assert!(
+            error.contains("override replay registry is full"),
+            "unexpected error: {error}"
+        );
+        // Re-keying an existing key must still succeed (a refresh, not a
+        // capacity event).
+        registry
+            .insert(
+                "override-000000".to_string(),
+                "operator-refreshed".to_string(),
+                "dao-approver".to_string(),
+                1_700_000_010,
+                1_700_003_700,
+                1_700_000_110,
+            )
+            .expect("re-keying an existing override_id must succeed even at cap");
+    }
+
+    #[test]
+    fn apply_dao_override_rejects_artifact_approved_at_unix_before_year_2001_floor() {
+        let mut policy = baseline_policy();
+        policy.max_operators_per_provider = Some(1);
+        let mut candidate = baseline_candidate();
+        candidate.provider = "aws".to_string();
+        let existing = baseline_existing();
+        let now_unix_seconds = 1_700_000_000u64;
+
+        // Build a signed override anchored at the 1970 epoch (well below
+        // the year-2001 floor). The TTL keeps the override alive in
+        // absolute time, so the floor check is the only thing that
+        // should reject it.
+        let (trust_root_pubkey_hex, override_artifact) = build_signed_override_artifact(
+            &candidate.operator_id,
+            "allow",
+            // 1_000_000_000 is the year-2001 floor; use one less so we
+            // are strictly below it.
+            DAO_OVERRIDE_APPROVED_AT_MIN_UNIX - 1,
+            now_unix_seconds.saturating_add(86_400),
+        );
+        policy.dao_override_trust_root_pubkey_hex = Some(trust_root_pubkey_hex);
+        policy.dao_override_max_ttl_seconds = Some(86_400 * 30);
+
+        let base_decision = evaluate_admission(&policy, &candidate, &existing, now_unix_seconds);
+        let mut replay_registry = OverrideReplayRegistry::default();
+        let override_decision = apply_dao_override(
+            &policy,
+            &candidate,
+            now_unix_seconds,
+            base_decision,
+            Some(&override_artifact),
+            Some(&mut replay_registry),
+        );
+        assert_eq!(override_decision.decision, "reject");
+        assert!(!override_decision.override_applied);
+        assert!(
+            override_decision
+                .reasons
+                .iter()
+                .any(|reason| reason.code == "dao_override_approved_at_predates_floor"),
+            "expected floor-rejection reason: {:?}",
+            override_decision.reasons
+        );
+        // The replay registry must NOT have been mutated.
+        assert!(
+            replay_registry.lookup(&override_artifact.payload_json).is_none(),
+            "rejected override must not be inserted into the replay registry"
+        );
     }
 
     #[test]

--- a/pkg/tbtc/signer/src/bin/admission_checker.rs
+++ b/pkg/tbtc/signer/src/bin/admission_checker.rs
@@ -284,11 +284,11 @@ fn now_unix() -> u64 {
 /// on the order of single-digit KiB; a 1 MiB cap is generous for the
 /// legitimate input envelope while preventing a hostile actor from
 /// triggering multi-gigabyte allocations through this surface.
-const MAX_JSON_INPUT_FILE_BYTES: u64 = 1 * 1024 * 1024;
+const MAX_JSON_INPUT_FILE_BYTES: u64 = 1024 * 1024;
 
 fn load_json_file<T: for<'de> Deserialize<'de>>(path: &PathBuf) -> Result<T, String> {
-    let metadata = fs::metadata(path)
-        .map_err(|e| format!("failed to stat file [{}]: {e}", path.display()))?;
+    let metadata =
+        fs::metadata(path).map_err(|e| format!("failed to stat file [{}]: {e}", path.display()))?;
     if metadata.len() > MAX_JSON_INPUT_FILE_BYTES {
         return Err(format!(
             "policy/candidate JSON file [{}] size [{}] bytes exceeds the [{}] byte cap; \
@@ -619,8 +619,7 @@ fn apply_dao_override(
             format!(
                 "override approved_at_unix [{}] predates a sane floor (year 2001); \
                  refusing to apply overrides anchored before the [{}] second epoch",
-                override_payload.approved_at_unix,
-                DAO_OVERRIDE_APPROVED_AT_MIN_UNIX
+                override_payload.approved_at_unix, DAO_OVERRIDE_APPROVED_AT_MIN_UNIX
             ),
         );
         return decision;
@@ -2021,7 +2020,9 @@ mod tests {
         );
         // The replay registry must NOT have been mutated.
         assert!(
-            replay_registry.lookup(&override_artifact.payload_json).is_none(),
+            replay_registry
+                .lookup(&override_artifact.payload_json)
+                .is_none(),
             "rejected override must not be inserted into the replay registry"
         );
     }

--- a/pkg/tbtc/signer/src/bin/admission_checker.rs
+++ b/pkg/tbtc/signer/src/bin/admission_checker.rs
@@ -13,6 +13,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const SECONDS_PER_DAY: u64 = 86_400;
 const DEFAULT_DAO_OVERRIDE_MAX_TTL_SECONDS: u64 = 7 * SECONDS_PER_DAY;
 
+/// Lower bound for `AdmissionOverridePayload.approved_at_unix`. Any value
+/// older than the year-2001 epoch (Sat 09 Sep 2001 01:46:40 UTC, the
+/// canonical `1_000_000_000` Unix second) is incompatible with the
+/// override's TTL semantics and lets a hostile actor slip a degenerate
+/// override past the `approved_at_unix > now_unix_seconds` temporal
+/// guard via a reverse-time-travel scenario.
+const DAO_OVERRIDE_APPROVED_AT_MIN_UNIX: u64 = 1_000_000_000;
+
+/// Hard cap on the number of consumed-override entries the on-disk replay
+/// registry is allowed to retain. The legitimate flow produces one entry
+/// per approved DAO override within its TTL window, so the realistic
+/// steady state is hundreds to low thousands of records. 10_000 caps a
+/// malicious DAO key minting unique `override_id` values to drive
+/// unbounded disk growth; once the cap is hit, `OverrideReplayRegistry::insert`
+/// returns an error and `apply_dao_override` rejects the override.
+const MAX_OVERRIDE_REGISTRY_ENTRIES: usize = 10_000;
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct AdmissionPolicyV1 {
@@ -31,6 +48,7 @@ struct AdmissionPolicyV1 {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AdmissionCandidate {
     operator_id: String,
     provider: String,
@@ -62,6 +80,7 @@ struct AdmissionOverrideArtifact {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AdmissionOverridePayload {
     override_id: String,
     operator_id: String,
@@ -104,6 +123,12 @@ impl OverrideReplayRegistry {
         self.consumed_override_ids.get(override_id)
     }
 
+    /// Insert a consumed-override record. Returns an error if the registry
+    /// already holds [`MAX_OVERRIDE_REGISTRY_ENTRIES`] entries, capping
+    /// disk growth against a malicious DAO key minting unique
+    /// `override_id` values. Existing entries are still updated (re-key
+    /// under the same override_id is not a capacity event); only the
+    /// INSERT of a NEW key into a full map is rejected.
     fn insert(
         &mut self,
         override_id: String,
@@ -112,7 +137,17 @@ impl OverrideReplayRegistry {
         approved_at_unix: u64,
         expires_at_unix: u64,
         consumed_at_unix: u64,
-    ) {
+    ) -> Result<(), String> {
+        if !self.consumed_override_ids.contains_key(&override_id)
+            && self.consumed_override_ids.len() >= MAX_OVERRIDE_REGISTRY_ENTRIES
+        {
+            return Err(format!(
+                "override replay registry is full ({} entries); \
+                 refusing to accept new override_id [{}] until expired entries are pruned",
+                self.consumed_override_ids.len(),
+                override_id
+            ));
+        }
         self.consumed_override_ids.insert(
             override_id.clone(),
             ConsumedOverrideRecord {
@@ -124,6 +159,7 @@ impl OverrideReplayRegistry {
                 consumed_at_unix,
             },
         );
+        Ok(())
     }
 }
 
@@ -242,7 +278,25 @@ fn now_unix() -> u64 {
         .unwrap_or(0)
 }
 
+/// Hard cap on the policy/candidate/existing/override JSON file size the
+/// checker is willing to slurp into memory. A genuine admission policy is
+/// on the order of single-digit KiB; a 1 MiB cap is generous for the
+/// legitimate input envelope while preventing a hostile actor from
+/// triggering multi-gigabyte allocations through this surface.
+const MAX_JSON_INPUT_FILE_BYTES: u64 = 1 * 1024 * 1024;
+
 fn load_json_file<T: for<'de> Deserialize<'de>>(path: &PathBuf) -> Result<T, String> {
+    let metadata = fs::metadata(path)
+        .map_err(|e| format!("failed to stat file [{}]: {e}", path.display()))?;
+    if metadata.len() > MAX_JSON_INPUT_FILE_BYTES {
+        return Err(format!(
+            "policy/candidate JSON file [{}] size [{}] bytes exceeds the [{}] byte cap; \
+             refusing to load unbounded input",
+            path.display(),
+            metadata.len(),
+            MAX_JSON_INPUT_FILE_BYTES
+        ));
+    }
     let bytes =
         fs::read(path).map_err(|e| format!("failed to read file [{}]: {e}", path.display()))?;
     serde_json::from_slice(&bytes)
@@ -552,6 +606,25 @@ fn apply_dao_override(
         return decision;
     }
 
+    // Floor check: any approved_at_unix older than the year-2001 epoch
+    // boundary is incompatible with the override's TTL semantics (a
+    // seven-day MAX_TTL relative to a 1970 anchor would silently
+    // "expire" in the next check) and lets a hostile actor slip a
+    // degenerate override past the temporal guards.
+    if override_payload.approved_at_unix < DAO_OVERRIDE_APPROVED_AT_MIN_UNIX {
+        push_override_rejection_reason(
+            &mut decision,
+            "dao_override_approved_at_predates_floor",
+            format!(
+                "override approved_at_unix [{}] predates a sane floor (year 2001); \
+                 refusing to apply overrides anchored before the [{}] second epoch",
+                override_payload.approved_at_unix,
+                DAO_OVERRIDE_APPROVED_AT_MIN_UNIX
+            ),
+        );
+        return decision;
+    }
+
     if override_payload.approved_by.trim().is_empty() {
         push_override_rejection_reason(
             &mut decision,
@@ -613,14 +686,17 @@ fn apply_dao_override(
         return decision;
     }
 
-    replay_registry.insert(
+    if let Err(detail) = replay_registry.insert(
         override_id,
         candidate_operator_id.clone(),
         override_payload.approved_by.trim().to_string(),
         override_payload.approved_at_unix,
         override_payload.expires_at_unix,
         now_unix_seconds,
-    );
+    ) {
+        push_override_rejection_reason(&mut decision, "dao_override_registry_full", detail);
+        return decision;
+    }
 
     decision.decision = "allow".to_string();
     decision.override_applied = true;
@@ -1667,15 +1743,16 @@ mod tests {
         let registry_path = tmp_dir.join("override-registry.json");
 
         let mut registry = OverrideReplayRegistry::default();
-        registry.insert(
-            "test-override-id-1".to_string(),
-            "operator-1".to_string(),
-            "dao-approver-1".to_string(),
-            1_700_000_000,
-            1_700_003_600,
-            1_700_000_100,
-        );
-
+        registry
+            .insert(
+                "test-override-id-1".to_string(),
+                "operator-1".to_string(),
+                "dao-approver-1".to_string(),
+                1_700_000_000,
+                1_700_003_600,
+                1_700_000_100,
+            )
+            .expect("single test insert must not hit the registry cap");
         persist_override_replay_registry(&registry_path, &registry).expect("persist registry");
         let reloaded = load_override_replay_registry(&registry_path).expect("load registry");
 

--- a/pkg/tbtc/signer/src/engine/frost_ops.rs
+++ b/pkg/tbtc/signer/src/engine/frost_ops.rs
@@ -15,6 +15,11 @@ pub fn dkg_part1(request: DkgPart1Request) -> Result<DkgPart1Result, EngineError
             "DKGPart1: min_signers is zero".to_string(),
         ));
     }
+    if request.min_signers < 2 {
+        return Err(EngineError::Validation(
+            "DKGPart1: min_signers must be at least 2".to_string(),
+        ));
+    }
     if request.min_signers > request.max_signers {
         return Err(EngineError::Validation(
             "DKGPart1: min_signers exceeds max_signers".to_string(),

--- a/pkg/tbtc/signer/src/engine/frost_ops.rs
+++ b/pkg/tbtc/signer/src/engine/frost_ops.rs
@@ -10,11 +10,6 @@ pub fn dkg_part1(request: DkgPart1Request) -> Result<DkgPart1Result, EngineError
             "DKGPart1: max_signers is zero".to_string(),
         ));
     }
-    if request.min_signers == 0 {
-        return Err(EngineError::Validation(
-            "DKGPart1: min_signers is zero".to_string(),
-        ));
-    }
     if request.min_signers < 2 {
         return Err(EngineError::Validation(
             "DKGPart1: min_signers must be at least 2".to_string(),

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -14117,3 +14117,97 @@ fn enforce_provenance_gate_rejects_signed_attestation_runtime_version_mismatch()
 
     clear_state_storage_policy_overrides();
 }
+
+// -- DKGPart1 input validation regression tests ----------------------------
+//
+// The validation hardening PR added `min_signers >= 2` to `frost_ops::dkg_part1`
+// before any downstream use of the input. These tests pin that branch so a
+// future edit that drops or weakens the cap cannot silently regress it.
+
+#[test]
+fn dkg_part1_rejects_min_signers_below_two() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let request = DkgPart1Request {
+        participant_identifier: participant_identifier_to_frost_identifier(1)
+            .map(frost_identifier_to_go_string)
+            .expect("u16::1 to frost identifier"),
+        max_signers: 3,
+        min_signers: 1,
+    };
+
+    let err = dkg_part1(request).expect_err("min_signers < 2 must be rejected");
+    let EngineError::Validation(detail) = err else {
+        panic!("unexpected error variant: {err:?}");
+    };
+    assert!(
+        detail.contains("min_signers must be at least 2"),
+        "unexpected rejection detail: {detail}"
+    );
+}
+
+#[test]
+fn dkg_part1_rejects_min_signers_zero() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let request = DkgPart1Request {
+        participant_identifier: participant_identifier_to_frost_identifier(1)
+            .map(frost_identifier_to_go_string)
+            .expect("u16::1 to frost identifier"),
+        max_signers: 3,
+        min_signers: 0,
+    };
+
+    let err = dkg_part1(request).expect_err("min_signers = 0 must be rejected");
+    let EngineError::Validation(detail) = err else {
+        panic!("unexpected error variant: {err:?}");
+    };
+    assert!(
+        detail.contains("min_signers must be at least 2"),
+        "unexpected rejection detail: {detail}"
+    );
+}
+
+#[test]
+fn dkg_part1_rejects_min_signers_greater_than_max_signers() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let request = DkgPart1Request {
+        participant_identifier: participant_identifier_to_frost_identifier(1)
+            .map(frost_identifier_to_go_string)
+            .expect("u16::1 to frost identifier"),
+        max_signers: 3,
+        min_signers: 4,
+    };
+
+    let err = dkg_part1(request).expect_err("min_signers > max_signers must be rejected");
+    let EngineError::Validation(detail) = err else {
+        panic!("unexpected error variant: {err:?}");
+    };
+    assert!(
+        detail.contains("min_signers exceeds max_signers"),
+        "unexpected rejection detail: {detail}"
+    );
+}
+
+#[test]
+fn dkg_part1_accepts_min_signers_at_threshold() {
+    let _guard = lock_test_state();
+    reset_for_tests();
+
+    let expected_identifier = participant_identifier_to_frost_identifier(1)
+        .map(frost_identifier_to_go_string)
+        .expect("u16::1 to frost identifier");
+    let request = DkgPart1Request {
+        participant_identifier: expected_identifier.clone(),
+        max_signers: 3,
+        min_signers: 2,
+    };
+
+    let result = dkg_part1(request).expect("min_signers = 2 must be accepted");
+    assert!(!result.secret_package_hex.expose_secret().is_empty());
+    assert_eq!(result.package.identifier, expected_identifier);
+}


### PR DESCRIPTION
## Summary

Validation and bounds hardening cluster of the lower-priority findings from the PR #4005 review, focused on FFI-adjacent inputs.

## Changes

- `DkgPart1Request.min_signers >= 2` check in `frost_ops.rs` before any downstream use.
- Bounded deserializers on FFI-adjacent vec / map fields in `api.rs` (`round1_packages`, `round2_packages`, `verifying_shares`, `commitments`, `signature_shares`, `AttemptTransitionTelemetry` and `DeriveInteractiveAttemptContextRequest` u16 vecs). Prevents unbounded allocation from a hostile or malfunctioning host.
- `deny_unknown_fields` on `AdmissionCandidate` and `AdmissionOverridePayload` in the admission_checker binary, plus `deny_unknown_fields` on `AdmissionOverrideArtifact` (the operator-supplied override artifact), so silently-ignored typos in operator-authored JSON are rejected.
- Capped `OverrideReplayRegistry` entry count and added a 1 MiB cap on JSON input file size in the admission_checker.
- Reject `approved_at_unix` values before the year-2001 epoch floor in `apply_dao_override`, closing a reverse-time-travel bypass of the override TTL guard.
- Tightened the `ErrorResponse` deserializer caps: `code` / `recovery_class` narrow from `deserialize_bounded_hex` (64 KiB) to `deserialize_bounded_ascii` (256 bytes), and `message` narrows from `deserialize_bounded_hex` (64 KiB) to `deserialize_bounded_message_ascii` (4 KiB). These are short human-readable identifiers / detail strings, not hex payloads, so the smaller caps (with an explicit `is_ascii()` check now matching the docstring "ASCII" claim) keep the in-memory footprint bounded without losing any legitimate payload.

## Tests

- 295 lib tests pass, 1 pre-existing ignore unrelated to this change.
- 37 admission_checker tests pass.
- New tests added for the new security behaviors: `apply_dao_override` year-2001 floor rejection, `OverrideReplayRegistry` cap rejection (with re-keyed existing-key refresh still allowed), `AdmissionCandidate` / `AdmissionOverridePayload` / `AdmissionOverrideArtifact` unknown-field rejection, 1 MiB JSON input cap rejection, `DkgPart1Request.min_signers >= 2` boundary check (reject 0, reject 1, reject > max_signers, accept at threshold), and over-cap rejection for the new bounded deserializer helpers (verifying_shares_map value & entry count, u16 vec, ascii, message ascii, round1_packages_vec).
- New `MAX_JSON_INPUT_FILE_BYTES`, `MAX_ASCII_CODES_CHARS`, `MAX_BOUNDED_MAP_ENTRIES`, and `MAX_VERIFYING_SHARE_HEX_CHARS` constants are documented in the source where they are enforced.

## Out of scope

- General deserialization cap policy for non-FFI types (the bounded deserializers here target only the FFI-boundary types).
- Lint/clippy cleanup of unused imports (separate cluster).
