### PR TITLE
perf(tbtc-signer): avoid double-clone of pending session ids per retire cycle (#4255 cluster C)

### DIFF
--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -685,7 +685,14 @@ fn compact_retired_per_message_sessions_to_total(
     // `retire_idle_per_message_session_ids`, which uses the same set for the
     // retire pass above) pass it through `pending_session_ids` to avoid
     // taking the PERSISTENCE_PENDING_OPERATIONS mutex a second time and
-    // re-cloning the full set inside a single persist cycle.
+    // re-cloning the full set inside a single persist cycle. This is safe
+    // only because every caller holds the engine-state mutex for the whole
+    // window from the snapshot to this use: `mark_persistence_pending` /
+    // `clear_persistence_pending_operation` cannot run concurrently and
+    // stale the snapshot mid-cycle. A future call site that takes the
+    // snapshot outside the engine-state lock (or across an await/drop of
+    // the guard) must not reuse this parameter — it must pass `None` so a
+    // fresh snapshot is taken under the lock instead.
     let pending_session_ids_owned;
     let pending_session_ids = match pending_session_ids {
         Some(ids) => ids,

--- a/pkg/tbtc/signer/src/engine/state.rs
+++ b/pkg/tbtc/signer/src/engine/state.rs
@@ -629,6 +629,11 @@ pub(crate) fn retire_idle_per_message_session_ids(
     protected_session_id: Option<&str>,
 ) -> Vec<String> {
     let retired_at = now_unix().max(1);
+    // Clone once per retire cycle. The same in-memory snapshot is reused by
+    // the compaction step below; cloning it a second time under the same
+    // PERSISTENCE_PENDING_OPERATIONS mutex would re-allocate the full set
+    // (size scales with max_sessions_limit, default 1024) for every retire
+    // call inside the persist path.
     let pending_session_ids = persistence_pending_session_ids();
     let mut newly_retired = Vec::new();
     for (session_id, session) in &mut engine_state.sessions {
@@ -642,9 +647,11 @@ pub(crate) fn retire_idle_per_message_session_ids(
         }
     }
 
-    drop(compact_retired_per_message_sessions(
+    drop(compact_retired_per_message_sessions_to_total(
         engine_state,
+        max_sessions_limit(),
         protected_session_id,
+        Some(&pending_session_ids),
     ));
     newly_retired.retain(|session_id| engine_state.sessions.contains_key(session_id));
     newly_retired
@@ -658,6 +665,7 @@ pub(crate) fn compact_retired_per_message_sessions(
         engine_state,
         max_sessions_limit(),
         protected_session_id,
+        None,
     )
 }
 
@@ -665,13 +673,27 @@ fn compact_retired_per_message_sessions_to_total(
     engine_state: &mut EngineState,
     max_total_sessions: usize,
     protected_session_id: Option<&str>,
+    pending_session_ids: Option<&HashSet<String>>,
 ) -> Vec<(String, SessionState)> {
     // A post-replacement persistence failure leaves the replacement snapshot's
     // marker in memory and records a process-local repair operation. Evicting
     // that session before a later successful snapshot would persist the
     // marker's absence and then clear the repair record. Protect every
     // session-scoped pending operation until a successful snapshot covers it.
-    let pending_session_ids = persistence_pending_session_ids();
+    //
+    // Callers that already hold a snapshot of the pending-session set (e.g.
+    // `retire_idle_per_message_session_ids`, which uses the same set for the
+    // retire pass above) pass it through `pending_session_ids` to avoid
+    // taking the PERSISTENCE_PENDING_OPERATIONS mutex a second time and
+    // re-cloning the full set inside a single persist cycle.
+    let pending_session_ids_owned;
+    let pending_session_ids = match pending_session_ids {
+        Some(ids) => ids,
+        None => {
+            pending_session_ids_owned = persistence_pending_session_ids();
+            &pending_session_ids_owned
+        }
+    };
     let mut removed = Vec::new();
     // Schema version 1 readers predating retirement enforce this same bound on
     // the TOTAL map. Retired tombstones therefore consume only the portion of
@@ -827,6 +849,7 @@ pub(crate) fn ensure_session_insert_capacity(
     let compacted = compact_retired_per_message_sessions_to_total(
         engine_state,
         max_sessions.saturating_sub(1),
+        None,
         None,
     );
     if engine_state.sessions.len() >= max_sessions {


### PR DESCRIPTION
## Summary

Performance cluster of the lower-priority findings: avoid cloning the per-session pending-operation set twice in a single retire cycle.

## Change

`retire_idle_per_message_session_ids` in `engine/state.rs` already snapshots `persistence_pending_session_ids()` for its own retire pass. The subsequent `compact_retired_per_message_sessions` call re-derived the same set under the same `PERSISTENCE_PENDING_OPERATIONS` mutex, re-cloning the full set (size scales with `max_sessions_limit`, default 1024) per cycle.

Thread the already-cloned set through an optional `pending_session_ids: Option<&HashSet<String>>` parameter on `compact_retired_per_message_sessions_to_total` so the persist path clones once per cycle instead of twice. Callers without a pre-cloned snapshot still work via the `None` path that re-clones.

## Tests

- 278 lib tests pass, 1 pre-existing ignore unrelated to this change.
- 78 interactive + 3 persistence sub-suite tests pass.

## Out of scope

- General persist-path profiling (separate concern).
- Persist path on the cold-start path (this only addresses the hot retire cycle).