### PR TITLE
docs(tbtc-signer): fix doc drift and stale/unclear comments (#4255 cluster D)

### DIFF
--- a/pkg/tbtc/signer/README.md
+++ b/pkg/tbtc/signer/README.md
@@ -55,7 +55,15 @@ in `docs/rust-rewrite-bootstrap.md`.
 
 ## Not yet implemented
 
-- ROAST coordinator logic.
+- End-to-end ROAST coordinator orchestration (timeouts -> blame -> advance to a
+  new attempt): the crate has the cryptographic primitives that drive it
+  (deterministic coordinator selection via `select_coordinator_identifier`,
+  canonical `AttemptContext` derivation/validation, `attempt_id` and
+  included-participants fingerprinting, and `roast_liveness_policy`
+  metadata) plus the per-attempt interactive-signing FFI
+  (`InteractiveSessionOpen` / `Round1` / `Round2` / `Abort` / `Aggregate`),
+  but the coordinator failover loop that ties them together lives outside
+  this crate (host-side Go layer).
 - Full Taproot script-tree construction/signing policy semantics (current
   `BuildTaprootTx` path assembles validated unsigned transactions from provided
   inputs/outputs).
@@ -305,11 +313,11 @@ Failure-mode responses:
 
 ## Benchmarks
 
-The coarse-path `phase5_roast` Criterion target was retired with
-StartSignRound/FinalizeSignRound. There is currently no supported benchmark
-command. Promotion evidence comes from fresh interactive latency windows and the
-exact-filter chaos suite below; do not archive a missing benchmark as a passed
-rollout gate.
+The coarse-path Criterion target was retired along with the coarse operations
+it measured. There is currently no supported benchmark command. Promotion
+evidence comes from fresh interactive latency windows and the exact-filter
+chaos suite below; do not archive a missing benchmark as a passed rollout
+gate.
 
 ## Chaos Suite (Phase 5)
 

--- a/pkg/tbtc/signer/docs/rust-rewrite-bootstrap.md
+++ b/pkg/tbtc/signer/docs/rust-rewrite-bootstrap.md
@@ -2,6 +2,16 @@
 
 Date: 2026-02-23
 
+> **Scope note.** This document captures an *earlier* bootstrap milestone of
+> the `tbtc-signer` Rust rewrite: the coarse
+> `frost_tbtc_run_dkg` / `frost_tbtc_start_sign_round` /
+> `frost_tbtc_finalize_sign_round` operations it lists no longer exist in the
+> crate's FFI surface (the crate now ships fine-grained `DkgPart1/2/3` plus
+> the interactive `SessionOpen`/`Round1`/`Round2`/`Abort`/`Aggregate` family).
+> The historical narrative below is preserved as-is. For the *current* FFI
+> surface, see `pkg/tbtc/signer/README.md` ("Current scope" / "Not yet
+> implemented") and `pkg/tbtc/signer/include/frost_tbtc.h`.
+
 This document tracks the initial code bootstrap for the `tbtc-signer` Rust
 rewrite architecture.
 

--- a/pkg/tbtc/signer/src/engine/codec.rs
+++ b/pkg/tbtc/signer/src/engine/codec.rs
@@ -86,6 +86,9 @@ pub(crate) fn aggregate_candidate_culprits(error: &frost::Error) -> Vec<u16> {
 /// two to be zero and reads the trailing two big-endian. Returns None for an
 /// identifier that does not fit a u16.
 pub(crate) fn frost_identifier_to_u16(identifier: frost::Identifier) -> Option<u16> {
+    // FROST serializes the identifier as a fixed-width scalar; we read a u16
+    // from the trailing 2 bytes, so an identifier with fewer than 2 bytes
+    // has nothing to extract.
     let bytes = identifier.serialize();
     let split = bytes.len().checked_sub(2)?;
     if bytes[..split].iter().any(|&b| b != 0) {

--- a/pkg/tbtc/signer/src/engine/interactive.rs
+++ b/pkg/tbtc/signer/src/engine/interactive.rs
@@ -92,13 +92,12 @@ fn maybe_hold_interactive_aggregate_after_unlock_for_tests() {
     }
 }
 
-// Multi-seat: a session's interactive consumed-nonce markers are keyed per
-// (attempt_id, member_identifier), so independent local seats can each consume
-// their own nonces for the same attempt without colliding. The marker is written
-// BEFORE a share leaves the engine (consumption-before-release). Legacy bare
-// attempt_id markers (written by the pre-multi-seat single-member engine, and
-// possibly reloaded from durable state) are honored FAIL-CLOSED on read: a bare
-// marker means the attempt is consumed for every member.
+// Multi-seat marker keying: `m{member_identifier}@{attempt_id}` lets each local
+// seat consume its own nonces for the same attempt without colliding. Markers
+// are written BEFORE a share leaves the engine (consumption-before-release).
+// Legacy bare `attempt_id` markers (pre-multi-seat or durable-state carryover)
+// are honored FAIL-CLOSED: a bare marker means the attempt is consumed for
+// every member.
 pub(crate) fn interactive_consumed_marker(attempt_id: &str, member_identifier: u16) -> String {
     // Keep the schema-1 wire representation understood by the immediately
     // previous signer. A binary rollback must continue to see the attempt as
@@ -2021,18 +2020,11 @@ pub(crate) fn zeroize_interactive_round1(interactive: &mut InteractiveSigningSta
 // time anything touches the engine after expiry. Expiry has abort
 // semantics - the durable consumption markers are untouched.
 /// Resolve the session that holds the DKG key material for `key_group`.
-///
-/// Interactive signing runs under a fresh RoastSessionID per message, but a wallet's
-/// DKG key material is a WALLET-level asset that lives under the session its DKG
-/// completed in. This returns that wallet session so any per-signing session can reach
-/// the material by key_group:
-///  - prefer `session_id` itself if it already holds this wallet's DKG output (the
-///    co-located case: DKG and signing share one session, as in the coarse path and
-///    the single-session tests);
-///  - otherwise find the session whose completed DKG produced `key_group`.
-///
-/// Returns None when no completed DKG for `key_group` exists (i.e. no wallet key), which
-/// callers map to DkgNotReady.
+/// Returns the session that owns the wallet DKG producing `key_group`. The
+/// request's own `session_id` is preferred when it already holds that DKG (the
+/// co-located case: DKG and signing share one session); otherwise the wallet
+/// session whose completed DKG produced `key_group` is returned. `None` means
+/// no wallet DKG exists for `key_group`; callers map that to `DkgNotReady`.
 pub(crate) fn resolve_wallet_session_id(
     engine_state: &EngineState,
     session_id: &str,
@@ -2163,11 +2155,11 @@ pub(crate) fn interactive_session_ttl_seconds() -> u64 {
 fn interactive_open_request_fingerprint(
     request: &InteractiveSessionOpenRequest,
 ) -> Result<String, EngineError> {
-    // The serialized request transiently holds the signing inputs
-    // (message_hex and the rest of the request) in plaintext; wipe the
-    // buffer once the fingerprint digest is taken. No key material is
-    // carried in the request - it is resolved from DKG state - so only
-    // the request inputs are exposed here.
+    // Hashes the request payload. No key material is included (the request
+    // does not carry it; it is resolved from DKG state), so the fingerprint
+    // only commits to the signing inputs. The serialized buffer is zeroized
+    // after the digest is taken because it transiently holds those inputs
+    // in plaintext.
     let mut canonical = serde_json::to_vec(request).map_err(|e| {
         EngineError::Internal(format!(
             "failed to serialize InteractiveSessionOpen request for fingerprint: {e}"

--- a/pkg/tbtc/signer/src/engine/tests.rs
+++ b/pkg/tbtc/signer/src/engine/tests.rs
@@ -6798,6 +6798,11 @@ fn reset_for_tests_clears_installed_signer_config() {
 
 #[test]
 fn init_signer_config_request_rejects_unknown_fields() {
+    // The misspelled field name below is intentional: the request type is
+    // `#[serde(deny_unknown_fields)]`, so a non-existent key must fail the
+    // parse. A correctly-spelled `policy_max_output_count` would either be
+    // accepted (if the field exists) or fail for the wrong reason, defeating
+    // the test.
     let parsed: Result<InitSignerConfigRequest, _> =
         serde_json::from_str(r#"{"polciy_max_output_count": 1}"#);
     assert!(parsed.is_err(), "typo'd field names must fail the parse");


### PR DESCRIPTION
## Summary

Doc-drift and comment cleanup cluster of the lower-priority findings.

## Changes

- `README.md` — clarifies what the crate provides for the ROAST coordinator vs what lives in the host-side Go layer (the coordinator failover loop), and drops the stale reference to the retired `phase5_roast` Criterion target's specific name (the target was retired along with the coarse operations it measured; the README now says so generically).
- `docs/rust-rewrite-bootstrap.md` — adds a scope note flagging the FFI surface it documents (`frost_tbtc_run_dkg`, `frost_tbtc_start_sign_round`, `frost_tbtc_finalize_sign_round`) as historical; the present surface is the fine-grained `DkgPart1/2/3` plus the interactive `SessionOpen`/`Round1`/`Round2`/`Abort`/`Aggregate` family, documented in the README and `include/frost_tbtc.h`.
- `engine/codec.rs` and `engine/interactive.rs` — reworded comments that referenced removed functions or described implementation history rather than current behavior.
- `engine/tests.rs` — added a comment documenting why the intentionally-misspelled `polciy_max_output_count` field name in the `deny_unknown_fields` regression test must stay misspelled (correcting it would either pass the parse or fail for the wrong reason, defeating the test).

## Out of scope

- New documentation (this is drift cleanup, not docs expansion).