### PR TITLE
docs(tbtc-signer): record crypto/security investigation findings (#4255 cluster E)

### DIFF
--- a/pkg/tbtc/signer/src/engine/audit.rs
+++ b/pkg/tbtc/signer/src/engine/audit.rs
@@ -117,6 +117,19 @@ fn reference_bip341_key_spend_sighash_default(
     sig_msg.extend_from_slice(&sequences_hasher.finalize());
     sig_msg.extend_from_slice(&outputs_hasher.finalize());
     sig_msg.push(0x00); // ext_flag=0, annex_present=0.
+    // BIP-341 specifies the input index as a 4-byte little-endian integer. This
+    // matches rust-bitcoin's actual encoding: the production path's
+    // `SighashCache::taproot_encode_signing_data_to` serializes `input_index`
+    // via `(input_index as u32).consensus_encode(writer)` (bitcoin-0.32.8
+    // src/crypto/sighash.rs:660), and `consensus_encode` for `u32` is
+    // implemented through the `emit_u32` write extension, which writes
+    // `v.to_le_bytes()` (bitcoin-0.32.8 src/consensus/encode.rs:246).
+    // The differential fuzzer's reference leg therefore uses the same byte
+    // order as the production `SighashCache` path. Note: the existing
+    // differential fuzz corpus only exercises `input_index == 0` (single-input
+    // txs), so the test cannot on its own detect a byte-order disagreement
+    // here -- the LE choice is anchored on the rust-bitcoin source above, not
+    // on the fuzz test passing.
     sig_msg.extend_from_slice(&(input_index as u32).to_le_bytes());
 
     let tag_hash = Sha256::digest(b"TapSighash");

--- a/pkg/tbtc/signer/src/engine/audit.rs
+++ b/pkg/tbtc/signer/src/engine/audit.rs
@@ -117,19 +117,19 @@ fn reference_bip341_key_spend_sighash_default(
     sig_msg.extend_from_slice(&sequences_hasher.finalize());
     sig_msg.extend_from_slice(&outputs_hasher.finalize());
     sig_msg.push(0x00); // ext_flag=0, annex_present=0.
-    // BIP-341 specifies the input index as a 4-byte little-endian integer. This
-    // matches rust-bitcoin's actual encoding: the production path's
-    // `SighashCache::taproot_encode_signing_data_to` serializes `input_index`
-    // via `(input_index as u32).consensus_encode(writer)` (bitcoin-0.32.8
-    // src/crypto/sighash.rs:660), and `consensus_encode` for `u32` is
-    // implemented through the `emit_u32` write extension, which writes
-    // `v.to_le_bytes()` (bitcoin-0.32.8 src/consensus/encode.rs:246).
-    // The differential fuzzer's reference leg therefore uses the same byte
-    // order as the production `SighashCache` path. Note: the existing
-    // differential fuzz corpus only exercises `input_index == 0` (single-input
-    // txs), so the test cannot on its own detect a byte-order disagreement
-    // here -- the LE choice is anchored on the rust-bitcoin source above, not
-    // on the fuzz test passing.
+                        // BIP-341 specifies the input index as a 4-byte little-endian integer. This
+                        // matches rust-bitcoin's actual encoding: the production path's
+                        // `SighashCache::taproot_encode_signing_data_to` serializes `input_index`
+                        // via `(input_index as u32).consensus_encode(writer)` (bitcoin-0.32.8
+                        // src/crypto/sighash.rs:660), and `consensus_encode` for `u32` is
+                        // implemented through the `emit_u32` write extension, which writes
+                        // `v.to_le_bytes()` (bitcoin-0.32.8 src/consensus/encode.rs:246).
+                        // The differential fuzzer's reference leg therefore uses the same byte
+                        // order as the production `SighashCache` path. Note: the existing
+                        // differential fuzz corpus only exercises `input_index == 0` (single-input
+                        // txs), so the test cannot on its own detect a byte-order disagreement
+                        // here -- the LE choice is anchored on the rust-bitcoin source above, not
+                        // on the fuzz test passing.
     sig_msg.extend_from_slice(&(input_index as u32).to_le_bytes());
 
     let tag_hash = Sha256::digest(b"TapSighash");

--- a/pkg/tbtc/signer/src/engine/policy.rs
+++ b/pkg/tbtc/signer/src/engine/policy.rs
@@ -893,6 +893,31 @@ pub(crate) fn enforce_signing_message_binding_to_policy_checked_build_tx(
         };
     }
 
+    // Investigated: a caller supplying tx_result=None and signing_intent=None here
+    // gets an unconditional Ok when the firewall is disabled, binding zero
+    // policy-checked artifact to the signing message. This is intentional, not a
+    // gap: the tx_result presence check below (and every deeper check through the
+    // end of this function -- session-id match, hex/consensus decoding, sighash
+    // count/format, output-value bounds, the re-run of current policy, and the
+    // final signing-message-to-sighash binding) are ALL part of the SAME signing
+    // policy firewall; the rejection text below even says so verbatim ("signing
+    // policy firewall requires build_taproot_tx to run"). There is no separate
+    // "basic presence" invariant to peel off from "deeper policy content" --
+    // disabling the firewall means none of this block applies, by design.
+    // Making the tx_result null-check fire unconditionally (moving this early
+    // return below it, after the match) was prototyped and measured: on a clean
+    // `cargo test --lib -- --test-threads=1` run (fresh CARGO_TARGET_DIR, no
+    // reorder) the full lib suite is 278 passed/0 failed; the identical run with
+    // only this reorder applied is 220 passed/58 failed, all newly-broken and all
+    // in interactive-session lifecycle coverage (abort, quarantine, replay,
+    // aggregate, round1/round2, expiry, persistence-fault-injection) that goes
+    // through `open_interactive_for_test` or an equivalent helper opening a
+    // session without a prior build_taproot_tx call under the default
+    // (non-production) firewall-disabled test profile -- a legitimate use of the
+    // dev-mode escape hatch, not a latent bug. The reorder was reverted for this
+    // reason. Production is unaffected either way: signing_policy_firewall_enforced()
+    // always returns true in production (see signer_profile_is_production() and
+    // signing_policy_firewall_is_enforced_in_production_by_default in tests.rs).
     if !signing_policy_firewall_enforced() {
         return Ok(());
     }


### PR DESCRIPTION
## Summary

Crypto / security investigation cluster of the lower-priority findings: two P2/P3 items investigated, confirmed non-issues, and recorded in place so future reviewers do not re-open them.

## Findings documented

- `engine/audit.rs` (sighash differential-fuzzer reference leg, `input_index` byte order): confirmed correct (little-endian), verified against the rust-bitcoin 0.32.8 actual `SighashCache` encoding path with source-line references. Also notes the existing fuzz corpus is single-input only, so this specific property cannot be caught by the test alone — the LE choice is anchored on the rust-bitcoin source, not on the test passing.
- `engine/policy.rs` (apparent "unconditional Ok when firewall disabled" near `BuildTaprootTx`): the apparent gap is not a bypass. The `tx_result` presence check and every deeper check in the function are one firewall, and disabling it correctly skips all of them by design. The reorder that would have moved the presence check before the early return was prototyped, measured, and reverted because it broke 58 interactive-session lifecycle tests that legitimately use the dev-mode escape hatch. Production is unaffected either way since `signing_policy_firewall_enforced()` always returns `true` in production.

## No code behavior changes

Both items are documentation-only. The test suite is unchanged: 278 lib tests pass, 1 pre-existing ignore unrelated.