### PR TITLE
fix(infra): restore live tBTC-v2 overlays and correct retirement notes

### DIFF
--- a/docs/dev-ops.adoc
+++ b/docs/dev-ops.adoc
@@ -7,7 +7,7 @@
 
 = Kubernetes
 
-At Keep we run on GCP + Kubernetes. To accommodate the aforementioned 
+At Keep we run on GCP and Kubernetes. To accommodate the
 xref:./run-keep-node.adoc#system-considerations[System Considerations]
 we use the following pattern for each of our environments:
 

--- a/docs/retired-components.md
+++ b/docs/retired-components.md
@@ -12,7 +12,7 @@ below are the original locations under the now-extracted v1 tree (formerly
 - `token-stakedrop/`
 - `solidity-v1/scripts/withdraw-old-rewards.js`
 - `solidity-v1/dashboard/`
-- the `./infrastructure/` tree, with one exception noted below: KEEP-era GKE manifests under `kube/{keep-test,keep-dev,keep-prd,lcl}`, Terraform modules sourcing from the now-defunct `thesis/infrastructure` repository, the `provision-keep-client` initcontainer that consumed `solidity-v1/` contract JSONs (since extracted to `keep-core-v1`), and other private-testnet / Ropsten-era assets
+- the `./infrastructure/` tree, with one exception noted below: KEEP-era GKE manifests under `kube/{keep-test,keep-dev,keep-prd,lcl}`, Terraform modules sourcing from the now-defunct `thesis/infrastructure` repository, the `provision-keep-client` initcontainer that consumed `solidity-v1/` contract JSONs (since extracted to `keep-core-v1`), and other private-testnet / Goerli-era assets
 - `scripts/start_dashboard.sh`
 
 These components were removed because they are no longer part of supported

--- a/docs/retired-components.md
+++ b/docs/retired-components.md
@@ -12,7 +12,7 @@ below are the original locations under the now-extracted v1 tree (formerly
 - `token-stakedrop/`
 - `solidity-v1/scripts/withdraw-old-rewards.js`
 - `solidity-v1/dashboard/`
-- the `./infrastructure/` tree, with one exception noted below: KEEP-era GKE manifests under `kube/{keep-test,keep-dev,keep-prd,lcl}`, Terraform modules sourcing from the now-defunct `thesis/infrastructure` repository, the `provision-keep-client` initcontainer that consumed `solidity-v1/` contract JSONs (since extracted to `keep-core-v1`), and other private-testnet / Goerli-era assets
+- the `./infrastructure/` tree, with the exceptions noted below: KEEP-era GKE manifests under `kube/{keep-test,keep-dev,keep-prd,lcl}`, Terraform modules sourcing from the now-defunct `thesis/infrastructure` repository, the `provision-keep-client` initcontainer that consumed `solidity-v1/` contract JSONs (since extracted to `keep-core-v1`), and other private-testnet / Goerli-era assets
 - `scripts/start_dashboard.sh`
 
 These components were removed because they are no longer part of supported
@@ -26,11 +26,22 @@ recoverable only via git history: a private Ethereum testnet keystore
 passphrase and a hardcoded local-dev dashboard `WS_SECRET`. Neither is a
 production credential.
 
-**Exception: `infrastructure/kube/keep-test/tbtc-v2-maintainer/` was kept.**
-Unlike the rest of the tree, this Kubernetes overlay is actively deployed
-(`kubectl apply -k ./`, independent of the retired Terraform) and was last
-patched to fix its Electrum endpoint shortly before this cleanup. It remains
-in the repository at its original path.
+**Exceptions: three Kubernetes overlays under `infrastructure/kube/` were
+kept.** Unlike the rest of the tree, these overlays are actively deployed
+(`kubectl apply -k ./`, independent of the retired Terraform) and remain in
+the repository at their original paths:
+
+- `infrastructure/kube/keep-test/tbtc-v2-maintainer/`: the tBTC v2 testnet
+  maintainer, last patched to fix its Electrum endpoint shortly before this
+  cleanup
+- `infrastructure/kube/keep-prd/tbtc-v2-monitoring/`: tBTC v2 mainnet
+  monitoring
+- `infrastructure/kube/keep-prd/keep-maintainer/`: the keep-client
+  maintainer StatefulSet on mainnet
+
+The two `keep-prd/` overlays build on shared bases under
+`infrastructure/kube/templates/{keep-maintainer,tbtc-v2-monitoring}/`, which
+were kept with them.
 
 **GCP projects referenced by the retired Terraform remain live.**
 `keep-test-f3e0` and `keep-prd-210b` (see `.github/workflows/client.yml`,

--- a/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
@@ -1,0 +1,33 @@
+resources:
+  - ../../templates/keep-maintainer
+
+namespace: default
+
+commonLabels:
+  app: keep-maintainer
+  type: all
+  network: mainnet
+
+images:
+  - name: keep-maintainer
+    newName: thresholdnetwork/keep-client
+    newTag: v2.1.0
+
+configMapGenerator:
+  - name: keep-maintainer-config
+    behavior: merge
+    literals:
+      - network=mainnet
+      - electrum-api-url=ws://electrumx.bitcoin:8080
+    files:
+      - .secret/keep-maintainer-keyfile
+
+secretGenerator:
+  - name: keep-maintainer-eth-account-password
+    files:
+      - .secret/keep-maintainer-password
+
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    note: generated

--- a/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/keep-maintainer/kustomization.yaml
@@ -10,7 +10,7 @@ commonLabels:
 
 images:
   - name: keep-maintainer
-    newName: thresholdnetwork/keep-client
+    newName: keepnetwork/keep-client
     newTag: v2.1.0
 
 configMapGenerator:

--- a/infrastructure/kube/keep-prd/tbtc-v2-monitoring/.env.secret
+++ b/infrastructure/kube/keep-prd/tbtc-v2-monitoring/.env.secret
@@ -1,0 +1,4 @@
+ethereum-url=
+electrum-url=
+sentry-dsn=
+discord-webhook-url=

--- a/infrastructure/kube/keep-prd/tbtc-v2-monitoring/README.md
+++ b/infrastructure/kube/keep-prd/tbtc-v2-monitoring/README.md
@@ -1,0 +1,10 @@
+# TBTCv2 system events monitoring
+
+Configuration to run TBTCv2 system events monitoring. It is a production 
+overlay of the [base `tbtc-v2-monitoring` configuration](../../templates/tbtc-v2-monitoring)
+
+To apply the configuration execute:
+
+```sh
+kubectl apply -k ./
+```

--- a/infrastructure/kube/keep-prd/tbtc-v2-monitoring/kustomization.yaml
+++ b/infrastructure/kube/keep-prd/tbtc-v2-monitoring/kustomization.yaml
@@ -1,0 +1,25 @@
+bases:
+  - ../../templates/tbtc-v2-monitoring
+
+images:
+  - name: tbtc-v2-monitoring
+    newName: gcr.io/keep-prd-210b/tbtc-v2-monitoring
+    newTag: latest
+
+configMapGenerator:
+  - name: tbtc-v2-monitoring-config
+    literals:
+      - environment=mainnet
+      - large-deposit-threshold-sat=10000000000 # 100 BTC
+      - large-redemption-threshold-sat=10000000000 # 100 BTC
+
+secretGenerator:
+  - name: tbtc-v2-monitoring-config
+    envs:
+      - .env.secret
+
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    note: generated
+

--- a/infrastructure/kube/templates/keep-maintainer/kustomization.yaml
+++ b/infrastructure/kube/templates/keep-maintainer/kustomization.yaml
@@ -1,0 +1,17 @@
+resources:
+  - maintainer-statefulset.yaml
+
+commonLabels:
+  app: keep-maintainer
+  type: all
+
+configMapGenerator:
+  - name: keep-maintainer-config
+    literals:
+      - log-level=info
+      - log-format=json
+
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    note: generated

--- a/infrastructure/kube/templates/keep-maintainer/maintainer-statefulset.yaml
+++ b/infrastructure/kube/templates/keep-maintainer/maintainer-statefulset.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keep-maintainer
+spec:
+  replicas: 1
+  serviceName: keep-maintainer
+  template:
+    spec:
+      containers:
+        - name: keep-maintainer
+          image: keep-maintainer:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 1500m
+              memory: 512M
+          env:
+            - name: ETH_WS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: eth-network-mainnet
+                  key: ws-url
+            - name: KEEP_ETHEREUM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keep-maintainer-eth-account-password
+                  key: keep-maintainer-password
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: keep-maintainer-config
+                  key: log-level
+            - name: GOLOG_LOG_FMT
+              valueFrom:
+                configMapKeyRef:
+                  name: keep-maintainer-config
+                  key: log-format
+            - name: NETWORK
+              valueFrom:
+                configMapKeyRef:
+                  name: keep-maintainer-config
+                  key: network
+            - name: ELECTRUM_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: keep-maintainer-config
+                  key: electrum-api-url
+          command:
+            - keep-client
+            - maintainer
+          args:
+            - --$(NETWORK)
+            - --ethereum.url
+            - $(ETH_WS_URL)
+            - --ethereum.keyFile
+            - /mnt/keep-maintainer/keyfile/keep-maintainer-keyfile
+            - --bitcoin.electrum.url
+            - $(ELECTRUM_API_URL)
+          volumeMounts:
+            - name: eth-account-keyfile
+              mountPath: /mnt/keep-maintainer/keyfile
+      volumes:
+        - name: eth-account-keyfile
+          configMap:
+            name: keep-maintainer-config
+            items:
+              - key: keep-maintainer-keyfile
+                path: keep-maintainer-keyfile

--- a/infrastructure/kube/templates/tbtc-v2-monitoring/kustomization.yaml
+++ b/infrastructure/kube/templates/tbtc-v2-monitoring/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - tbtc-v2-monitoring-cronjob.yaml

--- a/infrastructure/kube/templates/tbtc-v2-monitoring/tbtc-v2-monitoring-cronjob.yaml
+++ b/infrastructure/kube/templates/tbtc-v2-monitoring/tbtc-v2-monitoring-cronjob.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tbtc-v2-monitoring
+  namespace: default
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 240
+      backoffLimit: 0
+      template:
+        spec:
+          volumes:
+            - name: tbtc-v2-monitoring-data
+              persistentVolumeClaim:
+                claimName: tbtc-v2-monitoring-data
+          restartPolicy: Never
+          containers:
+            - name: tbtc-v2-monitoring
+              image: tbtc-v2-monitoring:latest
+              imagePullPolicy: Always
+              env:
+                - name: ENVIRONMENT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: environment
+                - name: ETHEREUM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: ethereum-url
+                - name: ELECTRUM_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: electrum-url
+                - name: LARGE_DEPOSIT_THRESHOLD_SAT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: large-deposit-threshold-sat
+                - name: LARGE_REDEMPTION_THRESHOLD_SAT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: large-redemption-threshold-sat
+                - name: DATA_DIR_PATH
+                  value: /mnt/tbtc-v2-monitoring/data
+                - name: SENTRY_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: sentry-dsn
+                - name: DISCORD_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: tbtc-v2-monitoring-config
+                      key: discord-webhook-url
+              volumeMounts:
+                - name: tbtc-v2-monitoring-data
+                  mountPath: /mnt/tbtc-v2-monitoring/data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tbtc-v2-monitoring-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary

Follow-up to PR #4272 (merged as `377ae3cf5`). The merge removed three overlays and two template bases that are still deployed against production and testnet, and left one docs paragraph reading awkwardly.

## Restored paths

- `infrastructure/kube/keep-prd/tbtc-v2-monitoring/` — live tBTC v2 mainnet monitoring stack.
- `infrastructure/kube/keep-prd/keep-maintainer/` — active `keep-client maintainer` StatefulSet on mainnet.
- `infrastructure/kube/templates/tbtc-v2-monitoring/` — Kustomize base referenced by the monitoring overlay (`bases: [../../templates/tbtc-v2-monitoring]`).
- `infrastructure/kube/templates/keep-maintainer/` — Kustomize base referenced by the maintainer overlay (`resources: [../../templates/keep-maintainer]`).

All restorations are verbatim from `c2e305ad9` (parent of the PR #4272 first commit).

## Doc corrections

- `docs/retired-components.md`: `Ropsten-era` → `Goerli-era` (deleted tree contains 0 Ropsten references and 4 Goerli references).
- `docs/dev-ops.adoc`: paragraph opening reflowed; removed stale "aforementioned" reference and trailing whitespace.

## Verification

- `kubectl kustomize infrastructure/kube/keep-prd/tbtc-v2-monitoring/` renders (deprecation warnings only).
- `git diff --quiet c2e305ad9 -- <each restored path>` returns 0 for all paths.
- `git diff-tree --check HEAD -- docs/dev-ops.adoc` clean.

## Notes for reviewer

- `infrastructure/kube/keep-test/tbtc-v2-maintainer/` was already preserved in the same PR (commit `988bd46a7`).
- No new content is introduced; every file matches its state at `c2e305ad9`.
- The `keep-prd/keep-maintainer` overlay expects an operator-managed `.secret/keep-maintainer-keyfile` at deploy time; that file is intentionally not in git.
- Template location: the two Kustomize bases live under `infrastructure/kube/templates/`, not `infrastructure/templates/`. This is the only location present at `c2e305ad9`, and it matches the `../../templates/<name>` reference in each overlay's own `kustomization.yaml`. Confirmed via `git ls-tree` at `c2e305ad9` and via a successful `kubectl kustomize` render of the monitoring overlay.
