### PR TITLE
fix(net/local): bound release-boundary settle drain in TestReleaseBroadcastChannel

### DIFF
--- a/pkg/net/local/broadcast_channel_manager_test.go
+++ b/pkg/net/local/broadcast_channel_manager_test.go
@@ -96,7 +96,9 @@ func TestReleaseBroadcastChannel(t *testing.T) {
 	// sent, not a sign the ticker "kept firing" - so absorb it in a short
 	// settle window before asserting the real invariant this test cares
 	// about: no further deliveries once release has taken effect.
-	drain(ch1Deliveries, RetransmissionTick)
+	if got := drain(ch1Deliveries, RetransmissionTick); got > 1 {
+		t.Errorf("expected at most one straggler tick after release, got %d", got)
+	}
 
 	if got := drain(ch1Deliveries, RetransmissionTick*3); got != 0 {
 		t.Errorf("expected no deliveries after release, got %d", got)


### PR DESCRIPTION
Follow-up to #4283.

That PR fixed `TestReleaseBroadcastChannel`'s flake (reproduced pre-existing on clean `origin/reservations-epic` at the time, ~2/5 failure rate in isolation - #4279's bug, not introduced by #4283's merge) by absorbing the one straggler tick `NewTimeTicker`'s cancel-vs-elapsed-timer race can let through after `ReleaseBroadcastChannel`.

That fix's settle-window drain discarded its count unchecked, so a genuine regression where the ticker fires more than once after release would only surface at the second, stricter assertion - not at the settle step itself, where the failure is easier to diagnose. This bounds the settle window: at most one straggler, asserted explicitly.

Verified 20/20 locally (`go test ./pkg/net/local/... -run TestReleaseBroadcastChannel -count=1`, repeated); full `go build`/`go vet`/`gofmt -l` clean.