### PR TITLE
fix(monitoring): upgrade grafana to 12.4.10

### DIFF
--- a/infrastructure/kube/keep-prd/monitoring/README.adoc
+++ b/infrastructure/kube/keep-prd/monitoring/README.adoc
@@ -18,6 +18,11 @@ The monitoring stack has the following components:
 
 The production monitoring is based on the configuration described in the link:../../keep-test/monitoring/README.adoc[keep-test monitoring documentation].
 
+Before updating Grafana, follow the
+link:../../keep-test/monitoring/README.adoc#upgrading-grafana[Grafana upgrade procedure],
+including the legacy alerting check and stopped-volume backup. Validate the
+upgrade in `keep-test` before applying it to production.
+
 Resources are exposed publicly under the following URLs:
 
 [cols="^1s,2m"]

--- a/infrastructure/kube/keep-prd/monitoring/grafana/config/datasources.yaml
+++ b/infrastructure/kube/keep-prd/monitoring/grafana/config/datasources.yaml
@@ -1,6 +1,7 @@
 apiVersion: 1
 datasources:
   - name: Trickster
+    uid: P09205B1DD12FB1C6
     type: prometheus
     access: proxy
     editable: true

--- a/infrastructure/kube/keep-prd/monitoring/grafana/grafana-deployment.yaml
+++ b/infrastructure/kube/keep-prd/monitoring/grafana/grafana-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: grafana
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: grafana
@@ -17,7 +19,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: grafana
-          image: grafana/grafana:9.2.5
+          image: grafana/grafana:12.4.10@sha256:c132a683b2430fff9115a29b2a79c8ab97540cdcc90846e3c81878c778ca3596
           env:
             - name: GF_SERVER_DOMAIN
               value: monitoring.threshold.network

--- a/infrastructure/kube/keep-prd/monitoring/grafana/grafana-deployment.yaml
+++ b/infrastructure/kube/keep-prd/monitoring/grafana/grafana-deployment.yaml
@@ -49,6 +49,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 2
+          startupProbe:
+            tcpSocket:
+              port: grafana
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             initialDelaySeconds: 30
             tcpSocket:
@@ -72,6 +77,8 @@ spec:
               mountPath: /var/lib/grafana
             - name: grafana-dashboards-keep
               mountPath: /var/lib/grafana/dashboards/keep
+            - name: grafana-tmp
+              mountPath: /tmp
           securityContext:
             readOnlyRootFilesystem: true
       volumes:
@@ -99,3 +106,5 @@ spec:
             items:
               - key: grafana.ini
                 path: grafana.ini
+        - name: grafana-tmp
+          emptyDir: {}

--- a/infrastructure/kube/keep-test/monitoring/README.adoc
+++ b/infrastructure/kube/keep-test/monitoring/README.adoc
@@ -242,23 +242,29 @@ missing from the previous 9.2.5 image. Updating the manifests does not update an
 already running instance; complete and verify the rollout in each environment.
 
 1. Record the running image, configuration, installed plugins, dashboards and
-alerting state. Check the database for legacy alerting before crossing Grafana
-11: if it is still in use, migrate through Grafana 10.4 first using the
+alerting state. Stop Grafana before taking a consistent backup of the complete
+`grafana-pvc` volume, configuration and required secrets. Take this backup before
+starting any migration, including Grafana 10.4, and retain it unchanged with the
+original image reference until the upgrade is verified.
+2. Restore the backup to a separate volume and rehearse the complete upgrade
+there, with outbound alert notifications disabled or routed to a test receiver.
+Check the restored database for legacy alerting before crossing Grafana 11: if it
+is still in use, migrate the restored copy through Grafana 10.4 first using the
 link:https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v11-0/[vendor migration procedure].
-Keep any intermediate migration instance isolated from public traffic.
-2. Stop Grafana before taking a consistent backup of the complete `grafana-pvc`
-volume, configuration and required secrets. Retain the original image reference
-with the backup. Test the upgrade against a separate restored copy first, with
-outbound alert notifications disabled or routed to a test receiver.
-3. Check plugins retained on the volume for Grafana 12 compatibility, including
-any separately installed image renderer. Angular plugins are no longer
-supported. Verify the Kubernetes Deployments dashboard's legacy graph panels
-migrate and render correctly; inspect dashboards saved only in the database too.
-4. Render the target environment's configuration with `kubectl kustomize grafana`
-from its monitoring directory, then apply it using `kubectl apply -k grafana`
-after the backup and migration checks pass. The `Recreate` deployment strategy
-prevents old and new Grafana pods writing to the same database during rollout.
-Expect a Grafana outage while the single replica restarts and migrates storage.
+Keep all rehearsal and intermediate migration instances isolated from public
+traffic.
+3. On the restored copy, check plugins retained on the volume for Grafana 12
+compatibility, including any separately installed image renderer. Angular plugins
+are no longer supported. Verify the Kubernetes Deployments dashboard's legacy
+graph panels migrate and render correctly; inspect dashboards saved only in the
+database too.
+4. Once the rehearsal and compatibility checks pass, repeat any required Grafana
+10.4 migration on the original volume. Render the target environment's
+configuration with `kubectl kustomize grafana` from its monitoring directory, then
+apply it using `kubectl apply -k grafana` after that migration succeeds. The
+`Recreate` deployment strategy prevents old and new Grafana pods writing to the
+same database during rollout. Expect a Grafana outage while the single replica
+restarts and migrates storage.
 5. Confirm the running image digest and `/grafana/api/health` version. Check
 Google sign-in and existing roles, GitHub sign-in in `keep-test`, dashboard
 queries through Trickster, existing public dashboard links and alert delivery.
@@ -267,9 +273,10 @@ normal traffic. A successful pod health check alone does not establish these
 behaviors.
 
 Grafana 12.4 can migrate dashboards, folders and playlists to unified storage.
-To roll back, stop the new instance, restore the complete pre-upgrade volume and
-configuration, and start the recorded previous image. Do not run an older image
-against the migrated database. See the
+To roll back from any upgrade stage, including Grafana 10.4, stop Grafana, restore
+the complete pre-upgrade volume and configuration from the unchanged original
+backup, and start the recorded previous image. Do not run an older image against
+the migrated database. See the
 link:https://grafana.com/docs/grafana/latest/upgrade-guide/upgrade-v12.4/[Grafana upgrade guide]
 for backup and migration details.
 

--- a/infrastructure/kube/keep-test/monitoring/README.adoc
+++ b/infrastructure/kube/keep-test/monitoring/README.adoc
@@ -232,6 +232,47 @@ Read more about health checks in the link:https://github.com/trickstercache/tric
 [#grafana]
 ## Grafana
 
+[#upgrading-grafana]
+### Upgrading Grafana
+
+Both environments pin Grafana 12.4.10 by its multi-platform image digest. This
+supported release includes the
+link:https://grafana.com/security/security-advisories/cve-2025-4123/[CVE-2025-4123 fix]
+missing from the previous 9.2.5 image. Updating the manifests does not update an
+already running instance; complete and verify the rollout in each environment.
+
+1. Record the running image, configuration, installed plugins, dashboards and
+alerting state. Check the database for legacy alerting before crossing Grafana
+11: if it is still in use, migrate through Grafana 10.4 first using the
+link:https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v11-0/[vendor migration procedure].
+Keep any intermediate migration instance isolated from public traffic.
+2. Stop Grafana before taking a consistent backup of the complete `grafana-pvc`
+volume, configuration and required secrets. Retain the original image reference
+with the backup. Test the upgrade against a separate restored copy first, with
+outbound alert notifications disabled or routed to a test receiver.
+3. Check plugins retained on the volume for Grafana 12 compatibility, including
+any separately installed image renderer. Angular plugins are no longer
+supported. Verify the Kubernetes Deployments dashboard's legacy graph panels
+migrate and render correctly; inspect dashboards saved only in the database too.
+4. Render the target environment's configuration with `kubectl kustomize grafana`
+from its monitoring directory, then apply it using `kubectl apply -k grafana`
+after the backup and migration checks pass. The `Recreate` deployment strategy
+prevents old and new Grafana pods writing to the same database during rollout.
+Expect a Grafana outage while the single replica restarts and migrates storage.
+5. Confirm the running image digest and `/grafana/api/health` version. Check
+Google sign-in and existing roles, GitHub sign-in in `keep-test`, dashboard
+queries through Trickster, existing public dashboard links and alert delivery.
+Check logs for database, plugin and provisioning failures before restoring
+normal traffic. A successful pod health check alone does not establish these
+behaviors.
+
+Grafana 12.4 can migrate dashboards, folders and playlists to unified storage.
+To roll back, stop the new instance, restore the complete pre-upgrade volume and
+configuration, and start the recorded previous image. Do not run an older image
+against the migrated database. See the
+link:https://grafana.com/docs/grafana/latest/upgrade-guide/upgrade-v12.4/[Grafana upgrade guide]
+for backup and migration details.
+
 ### Config Map
 
 Grafana configuration files are held in Config Maps that are generated with <<kustomization>> tool.

--- a/infrastructure/kube/keep-test/monitoring/README.adoc
+++ b/infrastructure/kube/keep-test/monitoring/README.adoc
@@ -289,6 +289,11 @@ metadata:
   namespace: monitoring
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    runAsNonRoot: true
   containers:
     - name: grafana
       image: grafana/grafana:10.4.x@sha256:<pinned-digest> # pin a verified digest, as above

--- a/infrastructure/kube/keep-test/monitoring/README.adoc
+++ b/infrastructure/kube/keep-test/monitoring/README.adoc
@@ -256,21 +256,92 @@ traffic.
 3. On the restored copy, check plugins retained on the volume for Grafana 12
 compatibility, including any separately installed image renderer. Angular plugins
 are no longer supported. Verify the Kubernetes Deployments dashboard's legacy
-graph panels migrate and render correctly; inspect dashboards saved only in the
-database too.
-4. Once the rehearsal and compatibility checks pass, repeat any required Grafana
-10.4 migration on the original volume. Render the target environment's
-configuration with `kubectl kustomize grafana` from its monitoring directory, then
-apply it using `kubectl apply -k grafana` after that migration succeeds. The
-`Recreate` deployment strategy prevents old and new Grafana pods writing to the
-same database during rollout. Expect a Grafana outage while the single replica
-restarts and migrates storage.
-5. Confirm the running image digest and `/grafana/api/health` version. Check
+graph panels render via Grafana's compatibility shim; this dashboard is file-
+provisioned from a read-only ConfigMap mount, so Grafana can never persist a
+graph-to-timeseries conversion back to the JSON -- it re-derives from disk on
+every load. Converting the 4 `type: graph` panels to `timeseries` directly in
+the repo JSON is the durable fix and is tracked as follow-up work, not a gate
+on this upgrade; inspect dashboards saved only in the database too, since
+those genuinely do persist their migration.
+Record peak container memory during this rehearsal; if it approaches the
+`1Gi` limit set in `grafana-deployment.yaml`, raise the limit before the
+production rollout.
+4. Once the rehearsal and compatibility checks pass, scale the running
+Deployment to zero and wait for its pod to terminate before touching the
+original volume:
++
+[source,bash]
+----
+kubectl scale deployment/grafana --replicas=0 -n monitoring
+kubectl wait --for=delete pod -l app=grafana -n monitoring --timeout=120s
+----
++
+If a Grafana 10.4 migration is still required (see step 2), run it as a
+one-shot ad-hoc Pod against the original `grafana-pvc`, not the pinned
+12.4.10 manifest -- `kubectl apply -k grafana` only ever renders 12.4.10:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: grafana-migrate-10-4
+  namespace: monitoring
+spec:
+  restartPolicy: Never
+  containers:
+    - name: grafana
+      image: grafana/grafana:10.4.x@sha256:<pinned-digest> # pin a verified digest, as above
+      volumeMounts:
+        - name: grafana-storage
+          mountPath: /var/lib/grafana
+        - name: grafana-grafana-ini
+          mountPath: /etc/grafana/grafana.ini
+          subPath: grafana.ini
+  volumes:
+    - name: grafana-storage
+      persistentVolumeClaim:
+        claimName: grafana-pvc
+    - name: grafana-grafana-ini
+      configMap:
+        name: grafana-config
+        items:
+          - key: grafana.ini
+            path: grafana.ini
+----
++
+This is a bare Pod, not a Job: the Grafana server process never exits on its
+own, so there is no automated completion to track. Watch the pod's logs until
+they show the migration completed, then delete it manually
+(`kubectl delete pod grafana-migrate-10-4 -n monitoring`) before continuing.
++
+Render the target environment's configuration with `kubectl kustomize grafana`
+from its monitoring directory. Before applying, remove the `rollingUpdate`
+subobject the API server defaulted onto the existing Deployment the first time
+it was created without `spec.strategy`; the API rejects `type: Recreate` while
+that subobject is still present:
++
+[source,bash]
+----
+kubectl patch deployment grafana -n monitoring --type=json \
+  -p '[{"op":"remove","path":"/spec/strategy/rollingUpdate"}]' || true
+kubectl apply -k grafana
+----
++
+The `Recreate` deployment strategy prevents old and new Grafana pods writing to
+the same database during rollout. Expect a Grafana outage while the single
+replica restarts and migrates storage.
+5. Because the GKE Ingress derives its backend health check from the
+readiness probe, public traffic resumes on the new pod automatically the
+moment it passes -- there is no manual pause before cutover. Keep the
+previous image reference and the step-1 backup staged and immediately
+restorable before starting step 4, then run these checks right after cutover:
+confirm the running image digest and `/grafana/api/health` version, check
 Google sign-in and existing roles, GitHub sign-in in `keep-test`, dashboard
-queries through Trickster, existing public dashboard links and alert delivery.
-Check logs for database, plugin and provisioning failures before restoring
-normal traffic. A successful pod health check alone does not establish these
-behaviors.
+queries through Trickster, existing public dashboard links and alert
+delivery, and check logs for database, plugin and provisioning failures. A
+successful pod health check alone does not establish these behaviors; if any
+check fails, restore the staged backup and previous image immediately.
 
 Grafana 12.4 can migrate dashboards, folders and playlists to unified storage.
 To roll back from any upgrade stage, including Grafana 10.4, stop Grafana, restore

--- a/infrastructure/kube/keep-test/monitoring/grafana/config/datasources.yaml
+++ b/infrastructure/kube/keep-test/monitoring/grafana/config/datasources.yaml
@@ -1,6 +1,7 @@
 apiVersion: 1
 datasources:
   - name: Trickster
+    uid: P09205B1DD12FB1C6
     type: prometheus
     access: proxy
     editable: true
@@ -10,6 +11,7 @@ datasources:
     isDefault: true
 
   - name: Prometheus
+    uid: P1809F7CD0C75ACF3
     type: prometheus
     access: proxy
     editable: true

--- a/infrastructure/kube/keep-test/monitoring/grafana/grafana-deployment.yaml
+++ b/infrastructure/kube/keep-test/monitoring/grafana/grafana-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: grafana
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: grafana
@@ -17,7 +19,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: grafana
-          image: grafana/grafana:9.2.5
+          image: grafana/grafana:12.4.10@sha256:c132a683b2430fff9115a29b2a79c8ab97540cdcc90846e3c81878c778ca3596
           env:
             - name: GF_SERVER_DOMAIN
               value: monitoring.test.keep.network

--- a/infrastructure/kube/keep-test/monitoring/grafana/grafana-deployment.yaml
+++ b/infrastructure/kube/keep-test/monitoring/grafana/grafana-deployment.yaml
@@ -59,6 +59,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 2
+          startupProbe:
+            tcpSocket:
+              port: grafana
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             initialDelaySeconds: 30
             tcpSocket:
@@ -84,6 +89,8 @@ spec:
               mountPath: /var/lib/grafana/dashboards/infrastructure
             - name: grafana-dashboards-keep
               mountPath: /var/lib/grafana/dashboards/keep
+            - name: grafana-tmp
+              mountPath: /tmp
           securityContext:
             readOnlyRootFilesystem: true
       volumes:
@@ -114,3 +121,5 @@ spec:
             items:
               - key: grafana.ini
                 path: grafana.ini
+        - name: grafana-tmp
+          emptyDir: {}


### PR DESCRIPTION
The production and test monitoring deployments still use Grafana 9.2.5, which predates the [CVE-2025-4123 fix](https://grafana.com/security/security-advisories/cve-2025-4123/). Upgrade both to Grafana 12.4.10, pinned to the verified multi-platform image digest.

Use `Recreate` for the single Grafana replica so the old and new versions cannot write to the same database during rollout. Add an upgrade procedure covering legacy alert migration, stopped-volume backups, plugin compatibility, production checks and restoring the original database on rollback.

Validation:

- `kubectl kustomize infrastructure/kube/keep-prd/monitoring/grafana` and the equivalent `keep-test` command passed; `git diff --check` passed.
- Upgraded disposable databases from 9.2.5 to the exact pinned image with each environment's rendered provisioning, UID/GID 1000 and read-only root filesystem. Health/version, provisioned dashboards, datasource UIDs and a saved dashboard control passed.
- Chrome login and dashboard checks passed under `/grafana/`; all four legacy graph panels in Kubernetes Deployments opened as Time series panels without browser exceptions. Production metrics were not queried.
- Security remediation was checked against the vendor's patched release boundary, registry digest and running version. No exploit payload was replayed.

This PR does not deploy the upgrade. Before production rollout, rehearse against a separate copy of the real volume and verify OAuth/roles, public dashboard links, installed plugins, Trickster queries and alert delivery. Grafana 12.4 changes persistent storage; rollback requires the pre-upgrade backup.

Related to https://github.com/threshold-network/tbtc-v2/issues/894. Keep the deployment report open until the running instance is verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Grafana has been upgraded from version 9.2.5 to the pinned 12.4.10 release in test and production environments.
  * Deployments now use a recreate rollout strategy, startup checks, and temporary storage to support safer upgrades.
  * Grafana data sources now use fixed identifiers for consistent dashboard connections.

* **Documentation**
  * Added procedures for backups, staged migration, validation, isolated rehearsal, and rollback.
  * Production upgrades require prior validation in the test environment.
  * Rollback guidance covers restoring the original backup and previous Grafana image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->