### PR TITLE
feat(maintainer): expose RPC health and SPV processing status

### DIFF
--- a/cmd/maintainer.go
+++ b/cmd/maintainer.go
@@ -77,7 +77,7 @@ func maintainers(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	metricsRecorder := initializeMaintainerMetrics(ctx, blockCounter, btcChain)
+	metricsRecorder := initializeMaintainerMetrics(ctx, blockCounter, tbtcChain, btcChain)
 
 	maintainer.Initialize(
 		ctx,
@@ -99,6 +99,7 @@ func maintainers(cmd *cobra.Command, args []string) error {
 func initializeMaintainerMetrics(
 	ctx context.Context,
 	blockCounter chain.BlockCounter,
+	ethRPC clientinfo.EthereumRPC,
 	btcChain bitcoin.Chain,
 ) spv.MetricsRecorder {
 	registry, isConfigured := clientinfo.Initialize(
@@ -121,7 +122,7 @@ func initializeMaintainerMetrics(
 	registry.ObserveBtcConnectivity(btcChain, clientConfig.ClientInfo.BitcoinMetricsTick)
 	registry.RegisterBtcChainInfoSource(btcChain)
 	healthChecker := clientinfo.NewRPCHealthChecker(
-		registry, blockCounter, btcChain, clientConfig.ClientInfo.RPCHealthCheckInterval,
+		registry, ethRPC, btcChain, clientConfig.ClientInfo.RPCHealthCheckInterval,
 	)
 	// An unavailable RPC must not delay starting the maintainer's control loop.
 	go healthChecker.Start(ctx)

--- a/cmd/maintainer.go
+++ b/cmd/maintainer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keep-network/keep-core/build"
 	"github.com/keep-network/keep-core/config"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/bitcoin/electrum"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/chain/ethereum"
@@ -76,7 +77,7 @@ func maintainers(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	metricsRecorder := initializeMaintainerMetrics(ctx, blockCounter)
+	metricsRecorder := initializeMaintainerMetrics(ctx, blockCounter, btcChain)
 
 	maintainer.Initialize(
 		ctx,
@@ -98,6 +99,7 @@ func maintainers(cmd *cobra.Command, args []string) error {
 func initializeMaintainerMetrics(
 	ctx context.Context,
 	blockCounter chain.BlockCounter,
+	btcChain bitcoin.Chain,
 ) spv.MetricsRecorder {
 	registry, isConfigured := clientinfo.Initialize(
 		ctx,
@@ -116,6 +118,13 @@ func initializeMaintainerMetrics(
 		clientConfig.ClientInfo.EthereumMetricsTick,
 	)
 	registry.RegisterEthChainInfoSource(blockCounter)
+	registry.ObserveBtcConnectivity(btcChain, clientConfig.ClientInfo.BitcoinMetricsTick)
+	registry.RegisterBtcChainInfoSource(btcChain)
+	healthChecker := clientinfo.NewRPCHealthChecker(
+		registry, blockCounter, btcChain, clientConfig.ClientInfo.RPCHealthCheckInterval,
+	)
+	// An unavailable RPC must not delay starting the maintainer's control loop.
+	go healthChecker.Start(ctx)
 
 	logger.Infof(
 		"enabled client info endpoint on port [%v]",

--- a/cmd/maintainer_test.go
+++ b/cmd/maintainer_test.go
@@ -53,7 +53,7 @@ func TestInitializeMaintainerMetricsDisabledWhenPortUnset(t *testing.T) {
 
 	// The block counter is only touched on the configured (enabled) path, so a
 	// nil value is safe for the disabled path under test.
-	recorder := initializeMaintainerMetrics(context.Background(), nil, nil)
+	recorder := initializeMaintainerMetrics(context.Background(), nil, nil, nil)
 
 	if recorder != nil {
 		t.Errorf(

--- a/cmd/maintainer_test.go
+++ b/cmd/maintainer_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/keep-network/keep-core/pkg/bitcoin"
 	"github.com/keep-network/keep-core/pkg/clientinfo"
 )
 
@@ -37,6 +38,92 @@ func (stubBlockCounter) WatchBlocks(ctx context.Context) <-chan uint64 {
 	return ch
 }
 
+// stubEthereumRPC is a minimal clientinfo.EthereumRPC implementation used to
+// exercise the enabled path of initializeMaintainerMetrics without wiring a
+// real Ethereum RPC client. The background RPC health checker goroutine
+// invokes LatestBlockNumber; a nil interface would panic there instead.
+type stubEthereumRPC struct{}
+
+func (stubEthereumRPC) LatestBlockNumber(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+// stubBitcoinChain is a minimal bitcoin.Chain implementation used to
+// exercise the enabled path of initializeMaintainerMetrics without wiring a
+// real Bitcoin chain connection. Only GetLatestBlockHeight is ever invoked
+// (from the registry's background btc-connectivity observer and the RPC
+// health checker); the other methods exist solely to satisfy the interface.
+type stubBitcoinChain struct{}
+
+func (stubBitcoinChain) GetTransaction(bitcoin.Hash) (*bitcoin.Transaction, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetTransactionConfirmations(
+	context.Context,
+	bitcoin.Hash,
+) (uint, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) BroadcastTransaction(*bitcoin.Transaction) error {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetLatestBlockHeight() (uint, error) {
+	return 0, nil
+}
+
+func (stubBitcoinChain) GetBlockHeader(uint) (*bitcoin.BlockHeader, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetTransactionMerkleProof(
+	bitcoin.Hash,
+	uint,
+) (*bitcoin.TransactionMerkleProof, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetTransactionsForPublicKeyHash(
+	[20]byte,
+	int,
+) ([]*bitcoin.Transaction, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetTxHashesForPublicKeyHash(
+	[20]byte,
+) ([]bitcoin.Hash, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetMempoolForPublicKeyHash(
+	[20]byte,
+) ([]*bitcoin.Transaction, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetUtxosForPublicKeyHash(
+	[20]byte,
+) ([]*bitcoin.UnspentTransactionOutput, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetMempoolUtxosForPublicKeyHash(
+	[20]byte,
+) ([]*bitcoin.UnspentTransactionOutput, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) EstimateSatPerVByteFee(uint32) (int64, error) {
+	panic("unsupported")
+}
+
+func (stubBitcoinChain) GetCoinbaseTxHash(uint) (bitcoin.Hash, error) {
+	panic("unsupported")
+}
+
 // TestInitializeMaintainerMetricsDisabledWhenPortUnset verifies the metrics
 // on/off gate: when the client info port is 0 (unset), the maintainer boot path
 // must report the endpoint as not configured and return a genuinely nil
@@ -51,8 +138,8 @@ func TestInitializeMaintainerMetricsDisabledWhenPortUnset(t *testing.T) {
 
 	clientConfig.ClientInfo.Port = 0
 
-	// The block counter is only touched on the configured (enabled) path, so a
-	// nil value is safe for the disabled path under test.
+	// blockCounter, ethRPC, and btcChain are only touched on the configured
+	// (enabled) path, so nil values are safe for the disabled path under test.
 	recorder := initializeMaintainerMetrics(context.Background(), nil, nil, nil)
 
 	if recorder != nil {
@@ -95,10 +182,16 @@ func TestInitializeMaintainerMetricsEnabledWhenPortSet(t *testing.T) {
 
 	clientConfig.ClientInfo.Port = port
 
-	// A stub block counter is used instead of nil: the enabled path starts a
-	// background goroutine that immediately calls blockCounter.CurrentBlock,
-	// which would panic on a nil chain.BlockCounter interface.
-	recorder := initializeMaintainerMetrics(context.Background(), stubBlockCounter{})
+	// Stub block counter, RPC, and chain are used instead of nil: the enabled
+	// path starts background goroutines that immediately call
+	// blockCounter.CurrentBlock, ethRPC.LatestBlockNumber, and
+	// btcChain.GetLatestBlockHeight, which would panic on nil interfaces.
+	recorder := initializeMaintainerMetrics(
+		context.Background(),
+		stubBlockCounter{},
+		stubEthereumRPC{},
+		stubBitcoinChain{},
+	)
 
 	if recorder == nil {
 		t.Fatal("expected a non-nil recorder when the client info port is set")

--- a/cmd/maintainer_test.go
+++ b/cmd/maintainer_test.go
@@ -53,7 +53,7 @@ func TestInitializeMaintainerMetricsDisabledWhenPortUnset(t *testing.T) {
 
 	// The block counter is only touched on the configured (enabled) path, so a
 	// nil value is safe for the disabled path under test.
-	recorder := initializeMaintainerMetrics(context.Background(), nil)
+	recorder := initializeMaintainerMetrics(context.Background(), nil, nil)
 
 	if recorder != nil {
 		t.Errorf(

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -139,7 +139,7 @@ func start(cmd *cobra.Command) error {
 
 			rpcHealthChecker := clientinfo.NewRPCHealthChecker(
 				clientInfoRegistry,
-				blockCounter,
+				tbtcChain,
 				btcChain,
 				clientConfig.ClientInfo.RPCHealthCheckInterval,
 			)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -143,7 +143,9 @@ func start(cmd *cobra.Command) error {
 				btcChain,
 				clientConfig.ClientInfo.RPCHealthCheckInterval,
 			)
-			rpcHealthChecker.Start(ctx)
+			// An unavailable RPC must not delay starting the node's
+			// initialization (beacon and tbtc).
+			go rpcHealthChecker.Start(ctx)
 		}
 
 		err = beacon.Initialize(

--- a/docs/performance-metrics.adoc
+++ b/docs/performance-metrics.adoc
@@ -327,6 +327,13 @@ the SPV loop. Initial RPC probes run asynchronously so an unavailable endpoint
 does not prevent the maintainer from starting. Set `clientInfo.port=0` to disable
 the endpoint and metric recording.
 
+Ethereum health probes fetch the latest header through the chain's RPC client
+on every check. They do not use the subscription-backed block counter, which
+can retain a height after disconnecting. Probes pass cancellation and a
+30-second deadline to the RPC; queuing in the client's rate limiter can delay
+completion. The last-check timestamp advances only after the probe returns.
+A successful response confirms connectivity, not synchronization with chain tip.
+
 All names below have the `performance_` prefix on `/metrics`:
 
 [%header,cols="1,2"]

--- a/docs/performance-metrics.adoc
+++ b/docs/performance-metrics.adoc
@@ -345,7 +345,14 @@ All names below have the `performance_` prefix on `/metrics`:
 |Unix time of the last completed probe, including failures. Zero means no probe
 has completed. Combine freshness with the health value to detect a hung RPC.
 |`rpc_health_check_interval_seconds`
-|Configured probe interval (30 seconds by default).
+|Configured probe interval (60 seconds by default).
+|`rpc_eth_response_time_seconds`, `rpc_btc_response_time_seconds`
+|Duration in seconds of the most recent successful probe; not updated on
+failure.
+|`rpc_btc_health_check_benign_errors_total`
+|Count of known-benign -32602 (`cp_height` not supported) `GetBlockHeader`
+responses. These still mark `rpc_btc_healthy` unhealthy; the counter only
+distinguishes benign header-support gaps from other RPC failures.
 |`spv_maintainer_active`
 |1 while the SPV control loop is running, including its normal backoff; 0 when
 disabled or stopped. Use scrape availability to detect a stopped process.
@@ -356,8 +363,9 @@ that stops advancing indicates stalled processing, even if the HTTP server works
 |Time of the last complete successful pass over all proof tasks. A pass with no
 pending proofs is successful; this metric does not imply a proof was submitted.
 |`spv_maintainer_last_failure_timestamp_seconds`
-|Time of the most recent failed proof task. Compare with the last successful
-cycle to detect failures occurring before the first Prometheus scrape.
+|Time of the most recent failed proof task; zero if none has failed yet.
+Compare against the last-success timestamp to see whether the most recent
+cycle failed or succeeded.
 |`spv_maintainer_max_backoff_seconds`
 |The larger of the configured restart and idle backoffs. Allow this interval plus
 a processing margin when alerting on stale activity.
@@ -372,5 +380,7 @@ Relay-range skips and proof-header-limit skips retain their separate
 `spv_proof_skipped_outside_relay_range_total` and
 `spv_proof_skipped_exceeded_max_headers_total` counters. They are not task failures.
 These counters count attempts, so the same transaction can be counted again in a
-later cycle. Check logs for the affected transaction hashes. Metrics are sampled
-once per minute; allow for that delay when setting alert thresholds.
+later cycle. Check logs for the affected transaction hashes. All SPV maintainer
+gauges and counters update immediately when the underlying event occurs, with
+no polling delay. Only the `rpc_*` health-status metrics above are sampled on
+a 1-minute poll; allow for that delay when alerting on RPC health.

--- a/docs/performance-metrics.adoc
+++ b/docs/performance-metrics.adoc
@@ -318,3 +318,49 @@ these metrics.
 *Type*: Counter
 *Description*: Total number of relay entry timeouts reported on-chain
 *Labels*: None
+
+== Maintainer health
+
+The `maintainer` command exposes client-info metrics when `clientInfo.port` is
+nonzero (default `9601`). Ethereum and Bitcoin connectivity checks run alongside
+the SPV loop. Initial RPC probes run asynchronously so an unavailable endpoint
+does not prevent the maintainer from starting. Set `clientInfo.port=0` to disable
+the endpoint and metric recording.
+
+All names below have the `performance_` prefix on `/metrics`:
+
+[%header,cols="1,2"]
+|===
+|Metric |Meaning
+|`rpc_eth_healthy`, `rpc_btc_healthy`
+|1 after a successful probe; 0 before the first probe or after a failed probe.
+|`rpc_eth_last_check_timestamp_seconds`, `rpc_btc_last_check_timestamp_seconds`
+|Unix time of the last completed probe, including failures. Zero means no probe
+has completed. Combine freshness with the health value to detect a hung RPC.
+|`rpc_health_check_interval_seconds`
+|Configured probe interval (30 seconds by default).
+|`spv_maintainer_active`
+|1 while the SPV control loop is running, including its normal backoff; 0 when
+disabled or stopped. Use scrape availability to detect a stopped process.
+|`spv_maintainer_last_activity_timestamp_seconds`
+|Updated at loop startup and at the start and end of each proof task. A timestamp
+that stops advancing indicates stalled processing, even if the HTTP server works.
+|`spv_maintainer_last_success_timestamp_seconds`
+|Time of the last complete successful pass over all proof tasks. A pass with no
+pending proofs is successful; this metric does not imply a proof was submitted.
+|`spv_maintainer_max_backoff_seconds`
+|The larger of the configured restart and idle backoffs. Allow this interval plus
+a processing margin when alerting on stale activity.
+|`spv_proof_task_failures_total`, `redemption_proof_task_failures_total`
+|Failed proof tasks, including discovery and proof-info errors before submission.
+The second counter includes redemption tasks only. A failed submission increments
+both its existing submission-failure counter and these task counters, so do not
+sum them as independent failures.
+|===
+
+Relay-range skips and proof-header-limit skips retain their separate
+`spv_proof_skipped_outside_relay_range_total` and
+`spv_proof_skipped_exceeded_max_headers_total` counters. They are not task failures.
+These counters count attempts, so the same transaction can be counted again in a
+later cycle. Check logs for the affected transaction hashes. Metrics are sampled
+once per minute; allow for that delay when setting alert thresholds.

--- a/docs/performance-metrics.adoc
+++ b/docs/performance-metrics.adoc
@@ -348,6 +348,9 @@ that stops advancing indicates stalled processing, even if the HTTP server works
 |`spv_maintainer_last_success_timestamp_seconds`
 |Time of the last complete successful pass over all proof tasks. A pass with no
 pending proofs is successful; this metric does not imply a proof was submitted.
+|`spv_maintainer_last_failure_timestamp_seconds`
+|Time of the most recent failed proof task. Compare with the last successful
+cycle to detect failures occurring before the first Prometheus scrape.
 |`spv_maintainer_max_backoff_seconds`
 |The larger of the configured restart and idle backoffs. Allow this interval plus
 a processing margin when alerting on stale activity.

--- a/pkg/chain/ethereum/block_counter.go
+++ b/pkg/chain/ethereum/block_counter.go
@@ -1,7 +1,26 @@
 package ethereum
 
-import "github.com/keep-network/keep-core/pkg/chain"
+import (
+	"context"
+	"fmt"
+
+	"github.com/keep-network/keep-core/pkg/chain"
+)
 
 func (bc *baseChain) BlockCounter() (chain.BlockCounter, error) {
 	return bc.blockCounter, nil
+}
+
+// LatestBlockNumber fetches the latest header through the Ethereum RPC client.
+// Unlike BlockCounter().CurrentBlock(), it does not read subscription cache
+// state, so an unavailable endpoint returns an error even after prior success.
+func (bc *baseChain) LatestBlockNumber(ctx context.Context) (uint64, error) {
+	header, err := bc.client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to fetch latest Ethereum header: [%w]", err)
+	}
+	if header == nil || header.Number == nil || !header.Number.IsUint64() {
+		return 0, fmt.Errorf("latest Ethereum header has no valid block number")
+	}
+	return header.Number.Uint64(), nil
 }

--- a/pkg/chain/ethereum/rpc_health_test.go
+++ b/pkg/chain/ethereum/rpc_health_test.go
@@ -1,0 +1,128 @@
+package ethereum
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
+)
+
+func TestLatestBlockNumberContactsRPCOnEveryCall(t *testing.T) {
+	var unavailable atomic.Bool
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if unavailable.Load() {
+			http.Error(w, "Ethereum unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		var request struct {
+			ID     json.RawMessage
+			Method string
+			Params []json.RawMessage
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("invalid JSON-RPC request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		if request.Method != "eth_getBlockByNumber" || len(request.Params) != 2 ||
+			string(request.Params[0]) != `"latest"` || string(request.Params[1]) != "false" {
+			t.Errorf("expected latest-header RPC, got %+v", request)
+			http.Error(w, "unexpected RPC", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request.ID,
+			"result": &types.Header{
+				Number:     big.NewInt(100),
+				Difficulty: big.NewInt(1),
+				Extra:      []byte{},
+			},
+		}); err != nil {
+			t.Errorf("cannot write JSON-RPC response: %v", err)
+		}
+	}))
+	defer server.Close()
+	client, err := ethclient.Dial(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Deliberately omit the cached block counter. TbtcChain, as passed by both
+	// startup paths, must use its existing RPC client for every health probe.
+	chain := &TbtcChain{baseChain: &baseChain{client: client}}
+	for i := 0; i < 2; i++ {
+		height, err := chain.LatestBlockNumber(context.Background())
+		if err != nil || height != 100 {
+			t.Fatalf("expected live height 100, got %d, %v", height, err)
+		}
+	}
+	unavailable.Store(true)
+	if _, err := chain.LatestBlockNumber(context.Background()); err == nil {
+		t.Fatal("RPC outage was hidden by the previous nonzero height")
+	}
+	unavailable.Store(false)
+	if height, err := chain.LatestBlockNumber(context.Background()); err != nil || height != 100 {
+		t.Fatalf("expected recovery at the same height, got %d, %v", height, err)
+	}
+	if got := calls.Load(); got != 4 {
+		t.Fatalf("expected four RPC requests, got %d", got)
+	}
+}
+
+type latestHeaderClient struct {
+	ethutil.EthereumClient
+	getHeader func(context.Context, *big.Int) (*types.Header, error)
+}
+
+func (c *latestHeaderClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return c.getHeader(ctx, number)
+}
+
+func TestLatestBlockNumberRejectsInvalidHeaders(t *testing.T) {
+	for name, header := range map[string]*types.Header{
+		"missing header":  nil,
+		"missing number":  {},
+		"negative number": {Number: big.NewInt(-1)},
+		"overflow":        {Number: new(big.Int).Lsh(big.NewInt(1), 64)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			chain := &baseChain{client: &latestHeaderClient{
+				getHeader: func(context.Context, *big.Int) (*types.Header, error) {
+					return header, nil
+				},
+			}}
+			if _, err := chain.LatestBlockNumber(context.Background()); err == nil {
+				t.Fatal("invalid header must fail the health probe")
+			}
+		})
+	}
+}
+
+func TestLatestBlockNumberForwardsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	chain := &baseChain{client: &latestHeaderClient{
+		getHeader: func(received context.Context, number *big.Int) (*types.Header, error) {
+			if received != ctx || number != nil {
+				t.Fatal("expected caller context and latest-header query")
+			}
+			return nil, received.Err()
+		},
+	}}
+	if _, err := chain.LatestBlockNumber(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected wrapped context cancellation, got %v", err)
+	}
+}

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -134,6 +134,8 @@ func (pm *PerformanceMetrics) registerCounterMetrics() {
 		MetricDepositSweepProofSubmissionsFailedTotal,
 		MetricSpvProofSkippedOutsideRelayRangeTotal,
 		MetricSpvProofSkippedExceededMaxHeadersTotal,
+		MetricSpvProofTaskFailuresTotal,
+		MetricRedemptionProofTaskFailuresTotal,
 
 		// ----- on-chain action counters -----
 		MetricSigningOperationsTotal,
@@ -324,6 +326,10 @@ func (pm *PerformanceMetrics) registerHistogramMetrics() {
 // registerGaugeMetrics registers all gauge metrics with 0 initial values.
 func (pm *PerformanceMetrics) registerGaugeMetrics() {
 	gauges := []string{
+		MetricSpvMaintainerActive,
+		MetricSpvMaintainerLastActivityTimestamp,
+		MetricSpvMaintainerLastSuccessTimestamp,
+		MetricSpvMaintainerMaxBackoffSeconds,
 		MetricWalletDispatcherActiveActions,
 		MetricIncomingMessageQueueSize,
 		MetricMessageHandlerQueueSize,
@@ -574,6 +580,14 @@ const (
 	MetricDepositSweepProofSubmissionsTotal        = "deposit_sweep_proof_submissions_total"
 	MetricDepositSweepProofSubmissionsSuccessTotal = "deposit_sweep_proof_submissions_success_total"
 	MetricDepositSweepProofSubmissionsFailedTotal  = "deposit_sweep_proof_submissions_failed_total"
+
+	// Maintainer processing metrics cover discovery and proof-info errors too.
+	MetricSpvProofTaskFailuresTotal          = "spv_proof_task_failures_total"
+	MetricRedemptionProofTaskFailuresTotal   = "redemption_proof_task_failures_total"
+	MetricSpvMaintainerActive                = "spv_maintainer_active"
+	MetricSpvMaintainerLastActivityTimestamp = "spv_maintainer_last_activity_timestamp_seconds"
+	MetricSpvMaintainerLastSuccessTimestamp  = "spv_maintainer_last_success_timestamp_seconds"
+	MetricSpvMaintainerMaxBackoffSeconds     = "spv_maintainer_max_backoff_seconds"
 
 	// SPV Proof Skip Metrics (SPV maintainer)
 	// MetricSpvProofSkippedOutsideRelayRangeTotal counts the number of

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -329,6 +329,7 @@ func (pm *PerformanceMetrics) registerGaugeMetrics() {
 		MetricSpvMaintainerActive,
 		MetricSpvMaintainerLastActivityTimestamp,
 		MetricSpvMaintainerLastSuccessTimestamp,
+		MetricSpvMaintainerLastFailureTimestamp,
 		MetricSpvMaintainerMaxBackoffSeconds,
 		MetricWalletDispatcherActiveActions,
 		MetricIncomingMessageQueueSize,
@@ -584,6 +585,7 @@ const (
 	// Maintainer processing metrics cover discovery and proof-info errors too.
 	MetricSpvProofTaskFailuresTotal          = "spv_proof_task_failures_total"
 	MetricRedemptionProofTaskFailuresTotal   = "redemption_proof_task_failures_total"
+	MetricSpvMaintainerLastFailureTimestamp  = "spv_maintainer_last_failure_timestamp_seconds"
 	MetricSpvMaintainerActive                = "spv_maintainer_active"
 	MetricSpvMaintainerLastActivityTimestamp = "spv_maintainer_last_activity_timestamp_seconds"
 	MetricSpvMaintainerLastSuccessTimestamp  = "spv_maintainer_last_success_timestamp_seconds"

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -582,7 +582,10 @@ const (
 	MetricDepositSweepProofSubmissionsSuccessTotal = "deposit_sweep_proof_submissions_success_total"
 	MetricDepositSweepProofSubmissionsFailedTotal  = "deposit_sweep_proof_submissions_failed_total"
 
-	// Maintainer processing metrics cover discovery and proof-info errors too.
+	// SPV Maintainer Health Metrics (proof-task failures and control-loop
+	// lifecycle gauges)
+	// MetricSpvProofTaskFailuresTotal and MetricRedemptionProofTaskFailuresTotal
+	// cover discovery and proof-info errors, not just submission failures.
 	MetricSpvProofTaskFailuresTotal          = "spv_proof_task_failures_total"
 	MetricRedemptionProofTaskFailuresTotal   = "redemption_proof_task_failures_total"
 	MetricSpvMaintainerLastFailureTimestamp  = "spv_maintainer_last_failure_timestamp_seconds"

--- a/pkg/clientinfo/rpc_health.go
+++ b/pkg/clientinfo/rpc_health.go
@@ -98,6 +98,9 @@ func (r *RPCHealthChecker) Start(ctx context.Context) {
 
 // start is the internal implementation of Start. Use Start() for public API.
 func (r *RPCHealthChecker) start(ctx context.Context) {
+	// Export unknown health before making calls, including when an RPC hangs.
+	r.registerMetrics()
+
 	// Perform initial health checks immediately
 	r.checkEthereumHealth(ctx)
 	r.checkBitcoinHealth(ctx)
@@ -106,8 +109,6 @@ func (r *RPCHealthChecker) start(ctx context.Context) {
 	go r.runEthereumHealthChecks(ctx)
 	go r.runBitcoinHealthChecks(ctx)
 
-	// Register metrics observers
-	r.registerMetrics()
 }
 
 // runEthereumHealthChecks runs periodic Ethereum RPC health checks.
@@ -319,6 +320,7 @@ func (r *RPCHealthChecker) GetBitcoinBenignHeaderErrorCount() float64 {
 
 // registerMetrics registers metrics observers for RPC health status.
 func (r *RPCHealthChecker) registerMetrics() {
+	r.registry.ObserveApplicationSource("performance", r.healthSources())
 	// Ethereum RPC response time
 	r.registry.ObserveApplicationSource(
 		"performance",
@@ -351,4 +353,33 @@ func (r *RPCHealthChecker) registerMetrics() {
 			},
 		},
 	)
+}
+
+// healthSources distinguishes a failed RPC from a probe that stopped completing.
+func (r *RPCHealthChecker) healthSources() map[string]Source {
+	health := func(getStatus func() (bool, time.Time, time.Time, error, time.Duration)) Source {
+		return func() float64 {
+			ok, _, _, _, _ := getStatus()
+			if ok {
+				return 1
+			}
+			return 0
+		}
+	}
+	lastCheck := func(getStatus func() (bool, time.Time, time.Time, error, time.Duration)) Source {
+		return func() float64 {
+			_, checked, _, _, _ := getStatus()
+			if checked.IsZero() {
+				return 0
+			}
+			return float64(checked.Unix())
+		}
+	}
+	return map[string]Source{
+		"rpc_eth_healthy":                      health(r.GetEthereumHealthStatus),
+		"rpc_btc_healthy":                      health(r.GetBitcoinHealthStatus),
+		"rpc_eth_last_check_timestamp_seconds": lastCheck(r.GetEthereumHealthStatus),
+		"rpc_btc_last_check_timestamp_seconds": lastCheck(r.GetBitcoinHealthStatus),
+		"rpc_health_check_interval_seconds":    func() float64 { return r.checkInterval.Seconds() },
+	}
 }

--- a/pkg/clientinfo/rpc_health.go
+++ b/pkg/clientinfo/rpc_health.go
@@ -10,10 +10,18 @@ import (
 	"github.com/ipfs/go-log"
 
 	"github.com/keep-network/keep-core/pkg/bitcoin"
-	"github.com/keep-network/keep-core/pkg/chain"
 )
 
 var rpcHealthLogger = log.Logger("keep-rpc-health")
+
+const ethereumRPCProbeTimeout = 30 * time.Second
+
+// EthereumRPC provides an uncached Ethereum endpoint probe. Implementations must
+// contact the endpoint on every call and forward ctx to the underlying RPC.
+// A subscription-backed BlockCounter.CurrentBlock() is not a health probe.
+type EthereumRPC interface {
+	LatestBlockNumber(ctx context.Context) (uint64, error)
+}
 
 // benignBtcHeaderErrorPattern matches the JSON-RPC error code -32602
 // ("invalid params") returned by some Electrum servers that reject the
@@ -43,7 +51,7 @@ type RPCHealthChecker struct {
 	registry *Registry
 
 	// Ethereum health check
-	ethBlockCounter chain.BlockCounter
+	ethRPC          EthereumRPC
 	ethLastCheck    time.Time
 	ethLastSuccess  time.Time
 	ethLastError    error
@@ -72,7 +80,7 @@ type RPCHealthChecker struct {
 // NewRPCHealthChecker creates a new RPC health checker instance.
 func NewRPCHealthChecker(
 	registry *Registry,
-	ethBlockCounter chain.BlockCounter,
+	ethRPC EthereumRPC,
 	btcChain bitcoin.Chain,
 	checkInterval time.Duration,
 ) *RPCHealthChecker {
@@ -81,10 +89,10 @@ func NewRPCHealthChecker(
 	}
 
 	return &RPCHealthChecker{
-		registry:        registry,
-		ethBlockCounter: ethBlockCounter,
-		btcChain:        btcChain,
-		checkInterval:   checkInterval,
+		registry:      registry,
+		ethRPC:        ethRPC,
+		btcChain:      btcChain,
+		checkInterval: checkInterval,
 	}
 }
 
@@ -141,58 +149,47 @@ func (r *RPCHealthChecker) runBitcoinHealthChecks(ctx context.Context) {
 	}
 }
 
-// checkEthereumHealth performs a comprehensive health check on the Ethereum RPC endpoint
-// by making actual RPC calls to verify the service is working properly.
-// It checks:
-// 1. Current block number retrieval
-// 2. Block number is reasonable (not stuck at 0 or extremely old)
+// checkEthereumHealth probes the Ethereum endpoint for a nonzero latest block.
+// The caller's cancellation and a probe deadline are forwarded to the RPC.
+// A successful response confirms connectivity, not chain synchronization.
 func (r *RPCHealthChecker) checkEthereumHealth(ctx context.Context) {
-	if r.ethBlockCounter == nil {
+	if r.ethRPC == nil {
 		return
 	}
 
 	startTime := time.Now()
+	probeCtx, cancel := context.WithTimeout(ctx, ethereumRPCProbeTimeout)
+	defer cancel()
 
-	// First check: Get current block number
-	currentBlock, err := r.ethBlockCounter.CurrentBlock()
-	if err != nil {
-		r.ethMutex.Lock()
-		r.ethLastCheck = startTime
-		r.ethLastError = err
-		r.ethMutex.Unlock()
-		rpcHealthLogger.Warnf(
-			"Ethereum RPC health check failed (CurrentBlock): [%v] (duration: %v)",
-			err,
-			time.Since(startTime),
-		)
-		return
+	currentBlock, err := r.ethRPC.LatestBlockNumber(probeCtx)
+	if err == nil {
+		// Never count a response received after cancellation/deadline as healthy.
+		err = probeCtx.Err()
+	}
+	if err == nil && currentBlock == 0 {
+		err = fmt.Errorf("block number is 0, node may not be synced")
 	}
 
-	// Second check: Verify block number is reasonable
-	// Block number should be > 0 (unless on a very new testnet)
-	// For mainnet/testnet, block numbers should be in thousands/millions
-	if currentBlock == 0 {
-		blockErr := fmt.Errorf("block number is 0, node may not be synced")
-		r.ethMutex.Lock()
-		r.ethLastCheck = startTime
-		r.ethLastError = blockErr
-		r.ethMutex.Unlock()
-		rpcHealthLogger.Warnf(
-			"Ethereum RPC health check failed (block number is 0): [%v] (duration: %v)",
-			blockErr,
-			time.Since(startTime),
-		)
-		return
-	}
-
-	duration := time.Since(startTime)
+	completedAt := time.Now()
+	duration := completedAt.Sub(startTime)
 
 	r.ethMutex.Lock()
-	r.ethLastCheck = startTime
-	r.ethLastSuccess = time.Now()
-	r.ethLastError = nil
-	r.ethLastDuration = duration
+	r.ethLastCheck = completedAt
+	r.ethLastError = err
+	if err == nil {
+		r.ethLastSuccess = completedAt
+		r.ethLastDuration = duration
+	}
 	r.ethMutex.Unlock()
+
+	if err != nil {
+		rpcHealthLogger.Warnf(
+			"Ethereum RPC health check failed (LatestBlockNumber): [%v] (duration: %v)",
+			err,
+			duration,
+		)
+		return
+	}
 
 	rpcHealthLogger.Debugf(
 		"Ethereum RPC health check succeeded (block: %d, duration: %v)",

--- a/pkg/clientinfo/rpc_health.go
+++ b/pkg/clientinfo/rpc_health.go
@@ -85,7 +85,10 @@ func NewRPCHealthChecker(
 	checkInterval time.Duration,
 ) *RPCHealthChecker {
 	if checkInterval == 0 {
-		checkInterval = 30 * time.Second // Default: check every 30 seconds
+		// Default kept comfortably above ethereumRPCProbeTimeout so a probe
+		// that consumes the full deadline during an outage still leaves an
+		// idle gap before the next tick, instead of re-probing back-to-back.
+		checkInterval = 60 * time.Second
 	}
 
 	return &RPCHealthChecker{
@@ -202,8 +205,8 @@ func (r *RPCHealthChecker) checkEthereumHealth(ctx context.Context) {
 // by making actual RPC calls to verify the service is working properly.
 // It checks:
 // 1. Latest block height retrieval
-// 2. Block header retrieval for the latest block (verifies RPC can retrieve block data)
-// 3. Block height is reasonable (not 0)
+// 2. Block height is reasonable (not 0)
+// 3. Block header retrieval for the latest block (verifies RPC can retrieve block data)
 func (r *RPCHealthChecker) checkBitcoinHealth(ctx context.Context) {
 	if r.btcChain == nil {
 		return
@@ -214,8 +217,9 @@ func (r *RPCHealthChecker) checkBitcoinHealth(ctx context.Context) {
 	// First check: Get latest block height
 	latestHeight, err := r.btcChain.GetLatestBlockHeight()
 	if err != nil {
+		completedAt := time.Now()
 		r.btcMutex.Lock()
-		r.btcLastCheck = startTime
+		r.btcLastCheck = completedAt
 		r.btcLastError = err
 		r.btcMutex.Unlock()
 		rpcHealthLogger.Warnf(
@@ -229,8 +233,9 @@ func (r *RPCHealthChecker) checkBitcoinHealth(ctx context.Context) {
 	// Second check: Verify block height is reasonable
 	if latestHeight == 0 {
 		heightErr := fmt.Errorf("block height is 0, node may not be synced")
+		completedAt := time.Now()
 		r.btcMutex.Lock()
-		r.btcLastCheck = startTime
+		r.btcLastCheck = completedAt
 		r.btcLastError = heightErr
 		r.btcMutex.Unlock()
 		rpcHealthLogger.Warnf(
@@ -247,8 +252,9 @@ func (r *RPCHealthChecker) checkBitcoinHealth(ctx context.Context) {
 	if err != nil {
 		headerErr := fmt.Errorf("failed to get block header for height %d: %w", latestHeight, err)
 		benign := isKnownBenignBtcHeaderError(err)
+		completedAt := time.Now()
 		r.btcMutex.Lock()
-		r.btcLastCheck = startTime
+		r.btcLastCheck = completedAt
 		r.btcLastError = headerErr
 		if benign {
 			r.btcBenignHeaderErrors++
@@ -272,11 +278,12 @@ func (r *RPCHealthChecker) checkBitcoinHealth(ctx context.Context) {
 		return
 	}
 
-	duration := time.Since(startTime)
+	completedAt := time.Now()
+	duration := completedAt.Sub(startTime)
 
 	r.btcMutex.Lock()
-	r.btcLastCheck = startTime
-	r.btcLastSuccess = time.Now()
+	r.btcLastCheck = completedAt
+	r.btcLastSuccess = completedAt
 	r.btcLastError = nil
 	r.btcLastDuration = duration
 	r.btcMutex.Unlock()

--- a/pkg/clientinfo/rpc_health_metrics_test.go
+++ b/pkg/clientinfo/rpc_health_metrics_test.go
@@ -1,0 +1,59 @@
+package clientinfo
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	keepclientinfo "github.com/keep-network/keep-common/pkg/clientinfo"
+)
+
+func TestRPCHealthMetricTransitions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eth := &fakeBlockCounter{currentBlock: 100}
+	btc := &fakeBitcoinChain{latestHeight: 100}
+	checker := newTestChecker(eth, btc)
+	checker.registry = &Registry{keepclientinfo.NewRegistry(), ctx}
+	checker.registerMetrics()
+	sources := checker.healthSources()
+	for name := range sources {
+		assertCounterExportedInRegistry(t, checker.registry, name)
+	}
+	for _, network := range []string{"eth", "btc"} {
+		if sources["rpc_"+network+"_healthy"]() != 0 || sources["rpc_"+network+"_last_check_timestamp_seconds"]() != 0 {
+			t.Fatal("unprobed RPC was reported healthy or recently checked")
+		}
+	}
+	before := float64(time.Now().Unix())
+	checker.checkEthereumHealth(ctx)
+	checker.checkBitcoinHealth(ctx)
+	for _, network := range []string{"eth", "btc"} {
+		if sources["rpc_"+network+"_healthy"]() != 1 || sources["rpc_"+network+"_last_check_timestamp_seconds"]() < before {
+			t.Fatalf("%s healthy check was not reflected in metrics", network)
+		}
+	}
+	eth.err = errors.New("Ethereum unavailable")
+	btc.latestErr = errors.New("Bitcoin unavailable")
+	checker.checkEthereumHealth(ctx)
+	checker.checkBitcoinHealth(ctx)
+	if sources["rpc_eth_healthy"]() != 0 || sources["rpc_btc_healthy"]() != 0 {
+		t.Fatal("RPC failures were not reflected in health metrics")
+	}
+}
+
+func TestMaintainerMetricsRegistered(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	registry := &Registry{keepclientinfo.NewRegistry(), ctx}
+	metrics := NewPerformanceMetrics(ctx, registry)
+	defer metrics.Stop()
+	for _, name := range []string{
+		MetricSpvMaintainerActive, MetricSpvMaintainerLastActivityTimestamp,
+		MetricSpvMaintainerLastSuccessTimestamp, MetricSpvMaintainerMaxBackoffSeconds,
+		MetricSpvProofTaskFailuresTotal, MetricRedemptionProofTaskFailuresTotal,
+	} {
+		assertCounterExportedInRegistry(t, registry, name)
+	}
+}

--- a/pkg/clientinfo/rpc_health_metrics_test.go
+++ b/pkg/clientinfo/rpc_health_metrics_test.go
@@ -52,6 +52,7 @@ func TestMaintainerMetricsRegistered(t *testing.T) {
 	for _, name := range []string{
 		MetricSpvMaintainerActive, MetricSpvMaintainerLastActivityTimestamp,
 		MetricSpvMaintainerLastSuccessTimestamp, MetricSpvMaintainerMaxBackoffSeconds,
+		MetricSpvMaintainerLastFailureTimestamp,
 		MetricSpvProofTaskFailuresTotal, MetricRedemptionProofTaskFailuresTotal,
 	} {
 		assertCounterExportedInRegistry(t, registry, name)

--- a/pkg/clientinfo/rpc_health_metrics_test.go
+++ b/pkg/clientinfo/rpc_health_metrics_test.go
@@ -12,7 +12,7 @@ import (
 func TestRPCHealthMetricTransitions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	eth := &fakeBlockCounter{currentBlock: 100}
+	eth := &fakeEthereumRPC{currentBlock: 100}
 	btc := &fakeBitcoinChain{latestHeight: 100}
 	checker := newTestChecker(eth, btc)
 	checker.registry = &Registry{keepclientinfo.NewRegistry(), ctx}
@@ -36,10 +36,85 @@ func TestRPCHealthMetricTransitions(t *testing.T) {
 	}
 	eth.err = errors.New("Ethereum unavailable")
 	btc.latestErr = errors.New("Bitcoin unavailable")
+	_, _, lastSuccess, _, _ := checker.GetEthereumHealthStatus()
+	failedAt := time.Now()
 	checker.checkEthereumHealth(ctx)
 	checker.checkBitcoinHealth(ctx)
 	if sources["rpc_eth_healthy"]() != 0 || sources["rpc_btc_healthy"]() != 0 {
 		t.Fatal("RPC failures were not reflected in health metrics")
+	}
+	_, lastCheck, retainedSuccess, lastError, _ := checker.GetEthereumHealthStatus()
+	if lastCheck.Before(failedAt) || !retainedSuccess.Equal(lastSuccess) || lastError == nil {
+		t.Fatal("failed RPC must complete the check without advancing last success")
+	}
+}
+
+type ethereumRPCFunc func(context.Context) (uint64, error)
+
+func (probe ethereumRPCFunc) LatestBlockNumber(ctx context.Context) (uint64, error) {
+	return probe(ctx)
+}
+
+func TestEthereumProbeDoesNotRefreshMetricsWhilePending(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	checker := NewRPCHealthChecker(nil, ethereumRPCFunc(func(probeCtx context.Context) (uint64, error) {
+		close(started)
+		<-probeCtx.Done()
+		return 0, probeCtx.Err()
+	}), nil, time.Minute)
+	previousCheck := time.Now().Add(-time.Hour)
+	checker.ethLastCheck = previousCheck
+	checker.ethLastSuccess = previousCheck
+	sources := checker.healthSources()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		checker.checkEthereumHealth(ctx)
+	}()
+	<-started
+	if got := sources["rpc_eth_last_check_timestamp_seconds"](); got != float64(previousCheck.Unix()) {
+		t.Errorf("pending RPC refreshed the completed-probe timestamp: %v", got)
+	}
+	cancel()
+	<-done
+	if sources["rpc_eth_healthy"]() != 0 {
+		t.Fatal("cancelled RPC was reported healthy")
+	}
+	_, lastCheck, lastSuccess, lastError, _ := checker.GetEthereumHealthStatus()
+	if !lastCheck.After(previousCheck) || !lastSuccess.Equal(previousCheck) || !errors.Is(lastError, context.Canceled) {
+		t.Fatalf("unexpected cancellation state: %v, %v, %v", lastCheck, lastSuccess, lastError)
+	}
+}
+
+func TestEthereumProbeDeadline(t *testing.T) {
+	for _, expired := range []bool{false, true} {
+		t.Run(map[bool]string{false: "bounded RPC context", true: "expired caller context"}[expired], func(t *testing.T) {
+			ctx := context.Background()
+			if expired {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithDeadline(ctx, time.Now().Add(-time.Second))
+				defer cancel()
+			}
+			checker := NewRPCHealthChecker(nil, ethereumRPCFunc(func(probeCtx context.Context) (uint64, error) {
+				deadline, ok := probeCtx.Deadline()
+				if !ok || time.Until(deadline) > 30*time.Second {
+					t.Fatal("Ethereum RPC did not receive the probe deadline")
+				}
+				// Even a client that returns a cached/late success after cancellation
+				// must not turn the health metric green.
+				return 100, nil
+			}), nil, time.Minute)
+			checker.checkEthereumHealth(ctx)
+			healthy, _, _, lastError, _ := checker.GetEthereumHealthStatus()
+			if healthy == expired {
+				t.Fatalf("unexpected health for expired=%v: %v", expired, healthy)
+			}
+			if expired && !errors.Is(lastError, context.DeadlineExceeded) {
+				t.Fatalf("expected deadline failure, got %v", lastError)
+			}
+		})
 	}
 }
 

--- a/pkg/clientinfo/rpc_health_test.go
+++ b/pkg/clientinfo/rpc_health_test.go
@@ -18,25 +18,13 @@ import (
 
 // --- fakes ---
 
-type fakeBlockCounter struct {
+type fakeEthereumRPC struct {
 	currentBlock uint64
 	err          error
 }
 
-func (f *fakeBlockCounter) CurrentBlock() (uint64, error) {
+func (f *fakeEthereumRPC) LatestBlockNumber(context.Context) (uint64, error) {
 	return f.currentBlock, f.err
-}
-
-func (f *fakeBlockCounter) WaitForBlockHeight(blockNumber uint64) error { return nil }
-func (f *fakeBlockCounter) BlockHeightWaiter(blockNumber uint64) (<-chan uint64, error) {
-	ch := make(chan uint64)
-	close(ch)
-	return ch, nil
-}
-func (f *fakeBlockCounter) WatchBlocks(ctx context.Context) <-chan uint64 {
-	ch := make(chan uint64)
-	go func() { <-ctx.Done(); close(ch) }()
-	return ch
 }
 
 type fakeBitcoinChain struct {
@@ -92,18 +80,18 @@ func (f *fakeBitcoinChain) GetCoinbaseTxHash(blockHeight uint) (bitcoin.Hash, er
 
 // --- helpers ---
 
-func newTestChecker(eth *fakeBlockCounter, btc *fakeBitcoinChain) *RPCHealthChecker {
+func newTestChecker(eth *fakeEthereumRPC, btc *fakeBitcoinChain) *RPCHealthChecker {
 	return &RPCHealthChecker{
-		ethBlockCounter: eth,
-		btcChain:        btc,
-		checkInterval:   time.Minute, // not used in direct call tests
+		ethRPC:        eth,
+		btcChain:      btc,
+		checkInterval: time.Minute, // not used in direct call tests
 	}
 }
 
 // --- Ethereum health tests ---
 
 func TestRPCHealthChecker_EthereumHealthy(t *testing.T) {
-	checker := newTestChecker(&fakeBlockCounter{currentBlock: 12345678}, nil)
+	checker := newTestChecker(&fakeEthereumRPC{currentBlock: 12345678}, nil)
 
 	checker.checkEthereumHealth(context.Background())
 
@@ -125,7 +113,7 @@ func TestRPCHealthChecker_EthereumHealthy(t *testing.T) {
 
 func TestRPCHealthChecker_EthereumUnhealthy_RPCError(t *testing.T) {
 	rpcErr := fmt.Errorf("connection refused")
-	checker := newTestChecker(&fakeBlockCounter{err: rpcErr}, nil)
+	checker := newTestChecker(&fakeEthereumRPC{err: rpcErr}, nil)
 
 	checker.checkEthereumHealth(context.Background())
 
@@ -143,7 +131,7 @@ func TestRPCHealthChecker_EthereumUnhealthy_RPCError(t *testing.T) {
 }
 
 func TestRPCHealthChecker_EthereumUnhealthy_ZeroBlock(t *testing.T) {
-	checker := newTestChecker(&fakeBlockCounter{currentBlock: 0}, nil)
+	checker := newTestChecker(&fakeEthereumRPC{currentBlock: 0}, nil)
 
 	checker.checkEthereumHealth(context.Background())
 
@@ -157,28 +145,28 @@ func TestRPCHealthChecker_EthereumUnhealthy_ZeroBlock(t *testing.T) {
 	}
 }
 
-func TestRPCHealthChecker_EthereumNilBlockCounter(t *testing.T) {
-	// Use a nil interface directly -- not a nil *fakeBlockCounter, which would
+func TestRPCHealthChecker_EthereumNilRPC(t *testing.T) {
+	// Use a nil interface directly -- not a nil *fakeEthereumRPC, which would
 	// create a non-nil interface wrapping a nil pointer and bypass the guard.
 	checker := &RPCHealthChecker{
-		ethBlockCounter: nil, // true nil interface
-		checkInterval:   time.Minute,
+		ethRPC:        nil, // true nil interface
+		checkInterval: time.Minute,
 	}
 
-	// Should not panic when ethBlockCounter is nil.
+	// Should not panic when ethRPC is nil.
 	checker.checkEthereumHealth(context.Background())
 
 	healthy, lastCheck, _, _, _ := checker.GetEthereumHealthStatus()
 	if healthy {
-		t.Error("expected not healthy with nil block counter")
+		t.Error("expected not healthy with nil Ethereum RPC")
 	}
 	if !lastCheck.IsZero() {
-		t.Error("lastCheck should not be set when block counter is nil")
+		t.Error("lastCheck should not be set when Ethereum RPC is nil")
 	}
 }
 
 func TestRPCHealthChecker_EthereumHealthTransition(t *testing.T) {
-	eth := &fakeBlockCounter{currentBlock: 100}
+	eth := &fakeEthereumRPC{currentBlock: 100}
 	checker := newTestChecker(eth, nil)
 
 	// First check: healthy.
@@ -532,7 +520,7 @@ func TestRPCHealthChecker_StartIdempotent(t *testing.T) {
 	defer cancel()
 
 	registry := &Registry{keepclientinfo.NewRegistry(), ctx}
-	eth := &fakeBlockCounter{currentBlock: 12345}
+	eth := &fakeEthereumRPC{currentBlock: 12345}
 	btc := &fakeBitcoinChain{latestHeight: 800000}
 	checker := NewRPCHealthChecker(registry, eth, btc, time.Hour)
 

--- a/pkg/clientinfo/rpc_health_test.go
+++ b/pkg/clientinfo/rpc_health_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -534,5 +535,71 @@ func TestRPCHealthChecker_StartIdempotent(t *testing.T) {
 	healthy, _, _, _, _ := checker.GetEthereumHealthStatus()
 	if !healthy {
 		t.Error("expected healthy after Start")
+	}
+}
+
+// countingEthereumRPC wraps fakeEthereumRPC to count LatestBlockNumber calls,
+// used to detect whether the periodic health-check goroutine keeps running.
+type countingEthereumRPC struct {
+	fakeEthereumRPC
+	calls *int32
+}
+
+func (f *countingEthereumRPC) LatestBlockNumber(ctx context.Context) (uint64, error) {
+	atomic.AddInt32(f.calls, 1)
+	return f.fakeEthereumRPC.LatestBlockNumber(ctx)
+}
+
+// countingBitcoinChain wraps fakeBitcoinChain to count GetLatestBlockHeight
+// calls, used to detect whether the periodic health-check goroutine keeps
+// running.
+type countingBitcoinChain struct {
+	fakeBitcoinChain
+	calls *int32
+}
+
+func (f *countingBitcoinChain) GetLatestBlockHeight() (uint, error) {
+	atomic.AddInt32(f.calls, 1)
+	return f.fakeBitcoinChain.GetLatestBlockHeight()
+}
+
+// TestRPCHealthChecker_GoroutinesStopOnCancel verifies that
+// runEthereumHealthChecks and runBitcoinHealthChecks actually exit on
+// ctx.Done() instead of leaking: it lets several ticks elapse to confirm the
+// periodic goroutines are running, cancels the context, then asserts no
+// further probes occur even though the check interval would otherwise have
+// fired several more times.
+func TestRPCHealthChecker_GoroutinesStopOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var ethCalls, btcCalls int32
+	eth := &countingEthereumRPC{fakeEthereumRPC: fakeEthereumRPC{currentBlock: 100}, calls: &ethCalls}
+	btc := &countingBitcoinChain{fakeBitcoinChain: fakeBitcoinChain{latestHeight: 100}, calls: &btcCalls}
+
+	registry := &Registry{keepclientinfo.NewRegistry(), ctx}
+	checker := NewRPCHealthChecker(registry, eth, btc, 5*time.Millisecond)
+	checker.Start(ctx)
+
+	// Let several ticks elapse so both periodic goroutines are confirmed
+	// running before cancellation.
+	time.Sleep(50 * time.Millisecond)
+	if atomic.LoadInt32(&ethCalls) < 2 || atomic.LoadInt32(&btcCalls) < 2 {
+		t.Fatal("expected multiple periodic health checks before cancellation")
+	}
+
+	cancel()
+	// Allow any tick already in flight at cancellation time to complete.
+	time.Sleep(20 * time.Millisecond)
+	ethAtCancel := atomic.LoadInt32(&ethCalls)
+	btcAtCancel := atomic.LoadInt32(&btcCalls)
+
+	// Wait long enough that several more ticks would have fired had the
+	// goroutines not exited on ctx.Done().
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&ethCalls); got != ethAtCancel {
+		t.Fatalf("runEthereumHealthChecks kept probing after cancellation: %d -> %d", ethAtCancel, got)
+	}
+	if got := atomic.LoadInt32(&btcCalls); got != btcAtCancel {
+		t.Fatalf("runBitcoinHealthChecks kept probing after cancellation: %d -> %d", btcAtCancel, got)
 	}
 }

--- a/pkg/maintainer/spv/health.go
+++ b/pkg/maintainer/spv/health.go
@@ -29,6 +29,7 @@ func (sm *spvMaintainer) runProofTask(
 	err := sm.proveTransactions(getter, submitter)
 	sm.recordActivity()
 	if err != nil && sm.metricsRecorder != nil {
+		sm.setHealthGauge(clientinfo.MetricSpvMaintainerLastFailureTimestamp, float64(time.Now().Unix()))
 		sm.metricsRecorder.IncrementCounter(clientinfo.MetricSpvProofTaskFailuresTotal, 1)
 		if action == tbtc.ActionRedemption {
 			sm.metricsRecorder.IncrementCounter(clientinfo.MetricRedemptionProofTaskFailuresTotal, 1)

--- a/pkg/maintainer/spv/health.go
+++ b/pkg/maintainer/spv/health.go
@@ -1,0 +1,38 @@
+package spv
+
+import (
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+func (sm *spvMaintainer) setHealthGauge(name string, value float64) {
+	if sm.metricsRecorder != nil {
+		sm.metricsRecorder.SetGauge(name, value)
+	}
+}
+
+func (sm *spvMaintainer) recordActivity() {
+	sm.setHealthGauge(clientinfo.MetricSpvMaintainerLastActivityTimestamp, float64(time.Now().Unix()))
+}
+
+// runProofTask includes discovery and proof-info failures that occur before a
+// proof submitter can increment its submission counters. Skipped proofs are
+// counted separately by proveTransactions and are not task failures.
+func (sm *spvMaintainer) runProofTask(
+	action tbtc.WalletActionType,
+	getter unprovenTransactionsGetter,
+	submitter transactionProofSubmitter,
+) error {
+	sm.recordActivity()
+	err := sm.proveTransactions(getter, submitter)
+	sm.recordActivity()
+	if err != nil && sm.metricsRecorder != nil {
+		sm.metricsRecorder.IncrementCounter(clientinfo.MetricSpvProofTaskFailuresTotal, 1)
+		if action == tbtc.ActionRedemption {
+			sm.metricsRecorder.IncrementCounter(clientinfo.MetricRedemptionProofTaskFailuresTotal, 1)
+		}
+	}
+	return err
+}

--- a/pkg/maintainer/spv/health_test.go
+++ b/pkg/maintainer/spv/health_test.go
@@ -35,6 +35,9 @@ func TestProofTaskFailuresBeforeSubmission(t *testing.T) {
 				t.Fatal("expected a task error")
 			}
 			if enabled {
+				if recorder.gauges[clientinfo.MetricSpvMaintainerLastFailureTimestamp] == 0 {
+					t.Fatal("first task failure timestamp was not recorded")
+				}
 				for _, name := range []string{clientinfo.MetricSpvProofTaskFailuresTotal, clientinfo.MetricRedemptionProofTaskFailuresTotal} {
 					if recorder.counters[name] != 1 {
 						t.Errorf("expected one %s failure, got %v", name, recorder.counters[name])

--- a/pkg/maintainer/spv/health_test.go
+++ b/pkg/maintainer/spv/health_test.go
@@ -1,0 +1,72 @@
+package spv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+func TestProofTaskFailuresBeforeSubmission(t *testing.T) {
+	for _, discoveryFails := range []bool{true, false} {
+		for _, enabled := range []bool{true, false} {
+			recorder := &recordingMetricsRecorder{counters: make(map[string]float64)}
+			sm := &spvMaintainer{btcChain: newLocalBitcoinChain(), spvChain: newLocalChain(), btcDiffChain: newLocalChain()}
+			if enabled {
+				sm.metricsRecorder = recorder
+			}
+			getter := func(uint64, int, bitcoin.Chain, Chain) ([]*bitcoin.Transaction, error) {
+				if discoveryFails {
+					return nil, errors.New("cannot fetch redemption requests")
+				}
+				// Proof-info lookup fails because this transaction is unknown to
+				// the Bitcoin backend. The submitter must never be called.
+				return []*bitcoin.Transaction{{Version: 1}}, nil
+			}
+			submitter := func(bitcoin.Hash, uint, bitcoin.Chain, Chain, MetricsRecorder) error {
+				t.Fatal("submission attempted after an earlier failure")
+				return nil
+			}
+			if err := sm.runProofTask(tbtc.ActionRedemption, getter, submitter); err == nil {
+				t.Fatal("expected a task error")
+			}
+			if enabled {
+				for _, name := range []string{clientinfo.MetricSpvProofTaskFailuresTotal, clientinfo.MetricRedemptionProofTaskFailuresTotal} {
+					if recorder.counters[name] != 1 {
+						t.Errorf("expected one %s failure, got %v", name, recorder.counters[name])
+					}
+				}
+				if recorder.gauges[clientinfo.MetricSpvMaintainerLastActivityTimestamp] == 0 {
+					t.Fatal("task completion did not update activity")
+				}
+			}
+		}
+	}
+}
+
+func TestMaintainerHealthLifecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	recorder := &recordingMetricsRecorder{counters: make(map[string]float64)}
+	sm := &spvMaintainer{
+		config:          Config{RestartBackoffTime: time.Hour, IdleBackoffTime: 10 * time.Minute},
+		metricsRecorder: recorder,
+	}
+	sm.startControlLoop(ctx)
+	if recorder.gauges[clientinfo.MetricSpvMaintainerActive] != 0 {
+		t.Fatal("stopped maintainer remains active")
+	}
+	if recorder.gauges[clientinfo.MetricSpvMaintainerMaxBackoffSeconds] != 3600 {
+		t.Fatal("configured restart backoff was not exported")
+	}
+	if recorder.gauges[clientinfo.MetricSpvMaintainerLastSuccessTimestamp] != 0 {
+		t.Fatal("canceled cycle was reported as successful")
+	}
+}
+
+// Proof submission test recorders do not observe lifecycle gauges.
+func (*fakeMetricsRecorder) SetGauge(string, float64) {}

--- a/pkg/maintainer/spv/health_test.go
+++ b/pkg/maintainer/spv/health_test.go
@@ -3,6 +3,7 @@ package spv
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -68,6 +69,63 @@ func TestMaintainerHealthLifecycle(t *testing.T) {
 	}
 	if recorder.gauges[clientinfo.MetricSpvMaintainerLastSuccessTimestamp] != 0 {
 		t.Fatal("canceled cycle was reported as successful")
+	}
+}
+
+func TestMaintainerHealthLifecycle_MaxBackoffIdleLarger(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	recorder := &recordingMetricsRecorder{counters: make(map[string]float64)}
+	sm := &spvMaintainer{
+		config:          Config{RestartBackoffTime: 10 * time.Minute, IdleBackoffTime: time.Hour},
+		metricsRecorder: recorder,
+	}
+	sm.startControlLoop(ctx)
+	if recorder.gauges[clientinfo.MetricSpvMaintainerMaxBackoffSeconds] != 3600 {
+		t.Fatal("expected max backoff to use the larger configured idle backoff")
+	}
+}
+
+// TestMaintainSpv_CancelsBetweenProofTasks verifies the per-action ctx.Err()
+// check inside maintainSpv's loop actually stops the cycle: once the context
+// is canceled while processing one proof type, no other proof type's getter
+// is invoked afterward. proofTypes iteration order is randomized by Go's map
+// semantics, so the fake getter shared by every action treats "first call"
+// as whichever action the runtime visits first, and fails the test if a
+// second call ever happens after cancellation.
+func TestMaintainSpv_CancelsBetweenProofTasks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var callCount int32
+	sharedGetter := func(uint64, int, bitcoin.Chain, Chain) ([]*bitcoin.Transaction, error) {
+		if atomic.AddInt32(&callCount, 1) > 1 {
+			t.Fatal("a proof task's getter ran after the SPV loop's context was canceled")
+		}
+		cancel()
+		return nil, nil
+	}
+	sharedSubmitter := func(bitcoin.Hash, uint, bitcoin.Chain, Chain, MetricsRecorder) error {
+		t.Fatal("submitter must not run when the getter reports no transactions")
+		return nil
+	}
+
+	original := proofTypes
+	defer func() { proofTypes = original }()
+	proofTypes = map[tbtc.WalletActionType]struct {
+		unprovenTransactionsGetter unprovenTransactionsGetter
+		transactionProofSubmitter  transactionProofSubmitter
+	}{
+		tbtc.ActionDepositSweep: {unprovenTransactionsGetter: sharedGetter, transactionProofSubmitter: sharedSubmitter},
+		tbtc.ActionRedemption:   {unprovenTransactionsGetter: sharedGetter, transactionProofSubmitter: sharedSubmitter},
+	}
+
+	sm := &spvMaintainer{btcChain: newLocalBitcoinChain(), spvChain: newLocalChain(), btcDiffChain: newLocalChain()}
+	err := sm.maintainSpv(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled from the canceled loop, got %v", err)
+	}
+	if got := atomic.LoadInt32(&callCount); got != 1 {
+		t.Fatalf("expected exactly one proof task invocation before cancellation, got %d", got)
 	}
 }
 

--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -53,12 +53,13 @@ const (
 	proofSkipExceededMaxHeaders
 )
 
-// MetricsRecorder records counter metrics for SPV proof submissions. It is
+// MetricsRecorder records proof counters and maintainer health gauges. It is
 // satisfied by *clientinfo.PerformanceMetrics. A nil MetricsRecorder is a valid
 // argument that disables metrics recording: callers must treat nil as "metrics
 // off" and guard every invocation against it.
 type MetricsRecorder interface {
 	IncrementCounter(name string, value float64)
+	SetGauge(name string, value float64)
 }
 
 func Initialize(
@@ -114,13 +115,24 @@ type spvMaintainer struct {
 
 func (sm *spvMaintainer) startControlLoop(ctx context.Context) {
 	logger.Info("starting SPV maintainer")
+	sm.setHealthGauge(clientinfo.MetricSpvMaintainerActive, 1)
+	sm.recordActivity()
+	maxBackoff := sm.config.RestartBackoffTime
+	if sm.config.IdleBackoffTime > maxBackoff {
+		maxBackoff = sm.config.IdleBackoffTime
+	}
+	sm.setHealthGauge(clientinfo.MetricSpvMaintainerMaxBackoffSeconds, maxBackoff.Seconds())
 
 	defer func() {
+		sm.setHealthGauge(clientinfo.MetricSpvMaintainerActive, 0)
 		logger.Info("stopping SPV maintainer")
 	}()
 
 	for {
 		err := sm.maintainSpv(ctx)
+		if ctx.Err() != nil {
+			return
+		}
 		if err != nil {
 			logger.Errorf(
 				"error while maintaining SPV: [%v]; restarting maintainer",
@@ -139,9 +151,13 @@ func (sm *spvMaintainer) startControlLoop(ctx context.Context) {
 func (sm *spvMaintainer) maintainSpv(ctx context.Context) error {
 	for {
 		for action, v := range proofTypes {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			logger.Infof("starting [%s] proof task execution...", action)
 
-			if err := sm.proveTransactions(
+			if err := sm.runProofTask(
+				action,
 				v.unprovenTransactionsGetter,
 				v.transactionProofSubmitter,
 			); err != nil {
@@ -154,6 +170,8 @@ func (sm *spvMaintainer) maintainSpv(ctx context.Context) error {
 
 			logger.Infof("[%s] proof task completed", action)
 		}
+
+		sm.setHealthGauge(clientinfo.MetricSpvMaintainerLastSuccessTimestamp, float64(time.Now().Unix()))
 
 		logger.Infof(
 			"proof tasks completed; next run in [%s]",

--- a/pkg/maintainer/spv/spv_test.go
+++ b/pkg/maintainer/spv/spv_test.go
@@ -451,10 +451,18 @@ func TestGetProofInfo_MinDifficultyDetectedByExactTarget(t *testing.T) {
 // proveTransactions invokes it synchronously, so no locking is needed.
 type recordingMetricsRecorder struct {
 	counters map[string]float64
+	gauges   map[string]float64
 }
 
 func (r *recordingMetricsRecorder) IncrementCounter(name string, value float64) {
 	r.counters[name] += value
+}
+
+func (r *recordingMetricsRecorder) SetGauge(name string, value float64) {
+	if r.gauges == nil {
+		r.gauges = make(map[string]float64)
+	}
+	r.gauges[name] = value
 }
 
 // TestProveTransactions covers the caller-side handling of each proofSkipReason
@@ -489,6 +497,7 @@ func TestProveTransactions(t *testing.T) {
 		transactionConfirmations uint
 		expectSubmitted          bool
 		expectedCounter          string
+		submissionError          bool
 	}{
 		// Decisive header (difficulty 8) matches neither epoch -> skipped.
 		"outside relay range is skipped and metered": {
@@ -505,6 +514,13 @@ func TestProveTransactions(t *testing.T) {
 			transactionConfirmations: 150,
 			expectSubmitted:          false,
 			expectedCounter:          "spv_proof_skipped_exceeded_max_headers_total",
+		},
+		"submission failure is counted": {
+			headerDifficultyAt:       func(uint) *big.Int { return big.NewInt(32) },
+			headersTo:                proofStart + 19,
+			transactionConfirmations: 20,
+			expectSubmitted:          true,
+			submissionError:          true,
 		},
 		// All headers at the current epoch difficulty -> proof is submitted.
 		"assemblable proof is submitted": {
@@ -573,11 +589,24 @@ func TestProveTransactions(t *testing.T) {
 					t.Fatal("proof submitter did not receive the maintainer recorder")
 				}
 				submitted = append(submitted, hash)
+				if test.submissionError {
+					return fmt.Errorf("submission failed")
+				}
 				return nil
 			}
 
-			if err := sm.proveTransactions(getter, submitter); err != nil {
-				t.Fatal(err)
+			err := sm.runProofTask(tbtc.ActionRedemption, getter, submitter)
+			if (err != nil) != test.submissionError {
+				t.Fatalf("unexpected task error: %v", err)
+			}
+			wantFailures := float64(0)
+			if test.submissionError {
+				wantFailures = 1
+			}
+			for _, name := range []string{"spv_proof_task_failures_total", "redemption_proof_task_failures_total"} {
+				if got := recorder.counters[name]; got != wantFailures {
+					t.Errorf("%s: want %v, got %v", name, wantFailures, got)
+				}
 			}
 
 			if test.expectSubmitted {

--- a/pkg/maintainer/spv/spv_test.go
+++ b/pkg/maintainer/spv/spv_test.go
@@ -447,8 +447,9 @@ func TestGetProofInfo_MinDifficultyDetectedByExactTarget(t *testing.T) {
 	)
 }
 
-// recordingMetricsRecorder captures IncrementCounter calls for assertions.
-// proveTransactions invokes it synchronously, so no locking is needed.
+// recordingMetricsRecorder captures IncrementCounter and SetGauge calls for
+// assertions. proveTransactions and the maintainer control loop invoke it
+// synchronously, so no locking is needed.
 type recordingMetricsRecorder struct {
 	counters map[string]float64
 	gauges   map[string]float64


### PR DESCRIPTION
The maintainer can keep serving metrics while an RPC probe or SPV task stops making progress. This change exposes RPC health and probe freshness, SPV loop activity and successful-cycle timestamps, and task failures that occur before the existing proof-submission counters run. It also connects Bitcoin diagnostics and the RPC checker to maintainer startup without blocking the control loop on its first probes.

The existing relay-range and proof-header-limit skip counters remain distinct from task failures. The configured maximum backoff is exported so alerts can accommodate intentional idle periods. A last-failure timestamp preserves failures that occur before the first scrape until a later successful cycle. Metrics remain optional through `clientInfo.port=0`.

Ethereum health fetches the latest header through the existing RPC connection on every probe in both node and maintainer startup paths. An outage after startup now records a failed check even when the subscription-backed block counter retains its previous height. Probes forward cancellation and a 30-second deadline to the RPC, preserve the last-success timestamp on failure, and advance freshness only when a check completes. Rate-limiter queuing can delay completion.

Stacked on #4190 (`feat/maintainer-spv-metrics`), which depends on #4187. Refs #3664. Alert configuration is in the stacked #4291; this PR does not close the issue.

Validation:
- Unit tests passed for `cmd`, `pkg/clientinfo`, `pkg/chain/ethereum`, and `pkg/maintainer/...`.
- A local JSON-RPC regression test verifies repeated network requests, outage detection after successful responses, and recovery. Additional tests cover cancellation, invalid headers, deadlines, and freshness while a probe is pending.
- Race tests passed for `pkg/clientinfo` and `pkg/chain/ethereum`; prior SPV race tests also passed.
- Vet passed for the affected packages; `git diff --check` passed.
- Existing repository-wide vet warning remains in `pkg/tecdsa/signing/protocol.go:758` (protobuf lock copied by value); that file is unchanged.
- No live deployment or alert delivery was performed.
