### PR TITLE
feat(tbtc): expose redemption proposal outcomes and notifications

### DIFF
--- a/docs/performance-metrics.adoc
+++ b/docs/performance-metrics.adoc
@@ -197,6 +197,39 @@ For each action type, the following metrics are available:
 *Description*: Total count of coordination duration samples
 *Labels*: None
 
+=== Redemption Proposal Metrics
+
+These counters are recorded only by the node acting as coordination leader
+for a given wallet and coordination window; a node with no leader elections
+in the observed window will show no increase on these counters.
+
+==== `performance_redemption_proposal_generation_total`
+*Type*: Counter
+*Description*: Total number of redemption proposal generation task invocations, including retries (leader-only)
+*Labels*: None
+
+==== `performance_redemption_proposal_generation_failed_total`
+*Type*: Counter
+*Description*: Total number of failed redemption proposal generation tasks, even when a later action succeeds or returns no-op (leader-only)
+*Labels*: None
+
+==== `performance_redemption_proposal_generation_success_total`
+*Type*: Counter
+*Description*: Total number of redemption proposal generation tasks that produced a proposal (leader-only)
+*Labels*: None
+
+==== `performance_redemption_proposal_broadcast_total`
+*Type*: Counter
+*Description*: Total number of generated redemption proposals accepted by the local broadcast channel (leader-only)
+*Labels*: None
+
+==== `performance_redemption_proposal_broadcast_failed_total`
+*Type*: Counter
+*Description*: Total number of failed attempts to broadcast a generated redemption proposal (leader-only)
+*Labels*: None
+
+See docs/redemption-proposal-monitoring.adoc for alerting guidance.
+
 === Network Metrics
 
 ==== `performance_incoming_message_queue_size`

--- a/docs/redemption-proposal-monitoring.adoc
+++ b/docs/redemption-proposal-monitoring.adoc
@@ -1,0 +1,50 @@
+= Redemption proposal monitoring
+
+Wallet nodes generate redemption proposals off-chain and broadcast them through
+the wallet coordination channel. There is no Ethereum proposal-submitted event
+for the on-chain redemption monitor to observe. Scrape wallet nodes running the
+`start` command to observe this stage; the SPV maintainer runs after the wallet
+has produced the Bitcoin transaction.
+
+The client-info `/metrics` endpoint exposes these counters with the
+`performance_` prefix:
+
+[cols="1,2",options="header"]
+|===
+| Counter | Meaning
+| `redemption_proposal_generation_attempts_total` | Redemption task invocations, including retries.
+| `redemption_proposal_generation_failures_total` | Failed redemption tasks, even when a later action succeeds or returns no-op.
+| `redemption_proposals_generated_total` | Tasks that produced a redemption proposal.
+| `redemption_proposals_broadcast_total` | Generated redemption proposals accepted by the local broadcast channel.
+| `redemption_proposal_broadcast_failures_total` | Failed attempts to send a generated redemption proposal.
+|===
+
+A successful check with no pending requests increments only the attempt counter.
+Other wallet actions do not increment these counters. Broadcast success does not
+prove peer receipt, signing, Bitcoin confirmation, or Ethereum proof acceptance.
+Counters aggregate across wallets on the node and reset on process restart;
+they do not add wallet or redemption IDs as metric labels.
+
+For a notification for each proposal, consume the structured `keep-tbtc` log
+event `event="redemption_proposal_broadcast"`. It includes `walletPKH` and
+`coordinationBlock`; deduplicate using network, wallet PKH, and coordination
+block before forwarding an informational notification to the existing receiver.
+The event is emitted only after the first broadcast succeeds, independently of
+whether metrics are enabled. Retransmissions do not produce additional events.
+Enable JSON logging (`GOLOG_LOG_FMT=json`) in the collector's deployment.
+
+For failure alerts, evaluate
+`increase(performance_redemption_proposal_generation_failures_total[15m]) > 0`
+and
+`increase(performance_redemption_proposal_broadcast_failures_total[15m]) > 0`
+per node, and route them to the existing on-call receiver. Tune the window to
+the coordination schedule and retain `instance` and network labels. Counter
+alerts require an observed increase; inspect initial values during rollout.
+Use the structured log event for individual proposal notifications because an
+aggregate counter alert cannot identify each proposal.
+
+Before completing issue #3664, deploy a client containing this telemetry,
+configure the log collector and receiver, and verify one proposal notification,
+a failed task/broadcast notification, and deduplication in staging. Pair these
+with the on-chain monitor's redemption request, completion, and timeout events.
+No receiver credentials or notification delivery are configured by this code.

--- a/docs/redemption-proposal-monitoring.adoc
+++ b/docs/redemption-proposal-monitoring.adoc
@@ -12,11 +12,11 @@ The client-info `/metrics` endpoint exposes these counters with the
 [cols="1,2",options="header"]
 |===
 | Counter | Meaning
-| `redemption_proposal_generation_attempts_total` | Redemption task invocations, including retries.
-| `redemption_proposal_generation_failures_total` | Failed redemption tasks, even when a later action succeeds or returns no-op.
-| `redemption_proposals_generated_total` | Tasks that produced a redemption proposal.
-| `redemption_proposals_broadcast_total` | Generated redemption proposals accepted by the local broadcast channel.
-| `redemption_proposal_broadcast_failures_total` | Failed attempts to send a generated redemption proposal.
+| `redemption_proposal_generation_total` | Redemption task invocations, including retries.
+| `redemption_proposal_generation_failed_total` | Failed redemption tasks, even when a later action succeeds or returns no-op.
+| `redemption_proposal_generation_success_total` | Tasks that produced a redemption proposal.
+| `redemption_proposal_broadcast_total` | Generated redemption proposals accepted by the local broadcast channel.
+| `redemption_proposal_broadcast_failed_total` | Failed attempts to send a generated redemption proposal.
 |===
 
 A successful check with no pending requests increments only the attempt counter.
@@ -24,6 +24,7 @@ Other wallet actions do not increment these counters. Broadcast success does not
 prove peer receipt, signing, Bitcoin confirmation, or Ethereum proof acceptance.
 Counters aggregate across wallets on the node and reset on process restart;
 they do not add wallet or redemption IDs as metric labels.
+These counters are recorded only by the node acting as coordination leader for a given wallet and coordination window, so a node with no leader elections in the observed window reports no attempts/successes; absence of increase on a single node is not itself a signal. Alerting must key on the failure counters (as the doc already does) rather than on missing successes.
 
 For a notification for each proposal, consume the structured `keep-tbtc` log
 event `event="redemption_proposal_broadcast"`. It includes `walletPKH` and
@@ -34,17 +35,13 @@ whether metrics are enabled. Retransmissions do not produce additional events.
 Enable JSON logging (`GOLOG_LOG_FMT=json`) in the collector's deployment.
 
 For failure alerts, evaluate
-`increase(performance_redemption_proposal_generation_failures_total[15m]) > 0`
+`increase(performance_redemption_proposal_generation_failed_total[15m]) > 0`
 and
-`increase(performance_redemption_proposal_broadcast_failures_total[15m]) > 0`
+`increase(performance_redemption_proposal_broadcast_failed_total[15m]) > 0`
 per node, and route them to the existing on-call receiver. Tune the window to
 the coordination schedule and retain `instance` and network labels. Counter
 alerts require an observed increase; inspect initial values during rollout.
 Use the structured log event for individual proposal notifications because an
 aggregate counter alert cannot identify each proposal.
 
-Before completing issue #3664, deploy a client containing this telemetry,
-configure the log collector and receiver, and verify one proposal notification,
-a failed task/broadcast notification, and deduplication in staging. Pair these
-with the on-chain monitor's redemption request, completion, and timeout events.
-No receiver credentials or notification delivery are configured by this code.
+See issue #3664 for rollout verification.

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -134,6 +134,11 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 		MetricRedemptionExecutionsTotal,
 		MetricRedemptionExecutionsSuccessTotal,
 		MetricRedemptionExecutionsFailedTotal,
+		MetricRedemptionProposalGenerationAttemptsTotal,
+		MetricRedemptionProposalGenerationFailuresTotal,
+		MetricRedemptionProposalsGeneratedTotal,
+		MetricRedemptionProposalsBroadcastTotal,
+		MetricRedemptionProposalBroadcastFailuresTotal,
 		MetricCoordinationWindowsDetectedTotal,
 		MetricCoordinationProceduresExecutedTotal,
 		MetricCoordinationFailedTotal,
@@ -544,6 +549,13 @@ const (
 	MetricRedemptionExecutionsSuccessTotal = "redemption_executions_success_total"
 	MetricRedemptionExecutionsFailedTotal  = "redemption_executions_failed_total"
 	MetricRedemptionActionDurationSeconds  = "redemption_action_duration_seconds"
+
+	// Redemption proposal counters distinguish task generation from P2P broadcast.
+	MetricRedemptionProposalGenerationAttemptsTotal = "redemption_proposal_generation_attempts_total"
+	MetricRedemptionProposalGenerationFailuresTotal = "redemption_proposal_generation_failures_total"
+	MetricRedemptionProposalsGeneratedTotal         = "redemption_proposals_generated_total"
+	MetricRedemptionProposalsBroadcastTotal         = "redemption_proposals_broadcast_total"
+	MetricRedemptionProposalBroadcastFailuresTotal  = "redemption_proposal_broadcast_failures_total"
 
 	// Redemption Proof Submission Metrics (SPV maintainer)
 	MetricRedemptionProofSubmissionsTotal        = "redemption_proof_submissions_total"

--- a/pkg/clientinfo/performance.go
+++ b/pkg/clientinfo/performance.go
@@ -134,11 +134,11 @@ func (pm *PerformanceMetrics) registerAllMetrics() {
 		MetricRedemptionExecutionsTotal,
 		MetricRedemptionExecutionsSuccessTotal,
 		MetricRedemptionExecutionsFailedTotal,
-		MetricRedemptionProposalGenerationAttemptsTotal,
-		MetricRedemptionProposalGenerationFailuresTotal,
-		MetricRedemptionProposalsGeneratedTotal,
-		MetricRedemptionProposalsBroadcastTotal,
-		MetricRedemptionProposalBroadcastFailuresTotal,
+		MetricRedemptionProposalGenerationTotal,
+		MetricRedemptionProposalGenerationFailedTotal,
+		MetricRedemptionProposalGenerationSuccessTotal,
+		MetricRedemptionProposalBroadcastTotal,
+		MetricRedemptionProposalBroadcastFailedTotal,
 		MetricCoordinationWindowsDetectedTotal,
 		MetricCoordinationProceduresExecutedTotal,
 		MetricCoordinationFailedTotal,
@@ -551,11 +551,12 @@ const (
 	MetricRedemptionActionDurationSeconds  = "redemption_action_duration_seconds"
 
 	// Redemption proposal counters distinguish task generation from P2P broadcast.
-	MetricRedemptionProposalGenerationAttemptsTotal = "redemption_proposal_generation_attempts_total"
-	MetricRedemptionProposalGenerationFailuresTotal = "redemption_proposal_generation_failures_total"
-	MetricRedemptionProposalsGeneratedTotal         = "redemption_proposals_generated_total"
-	MetricRedemptionProposalsBroadcastTotal         = "redemption_proposals_broadcast_total"
-	MetricRedemptionProposalBroadcastFailuresTotal  = "redemption_proposal_broadcast_failures_total"
+	// Recorded only when the node is acting as coordination leader for the wallet/window.
+	MetricRedemptionProposalGenerationTotal        = "redemption_proposal_generation_total"
+	MetricRedemptionProposalGenerationFailedTotal  = "redemption_proposal_generation_failed_total"
+	MetricRedemptionProposalGenerationSuccessTotal = "redemption_proposal_generation_success_total"
+	MetricRedemptionProposalBroadcastTotal         = "redemption_proposal_broadcast_total"
+	MetricRedemptionProposalBroadcastFailedTotal   = "redemption_proposal_broadcast_failed_total"
 
 	// Redemption Proof Submission Metrics (SPV maintainer)
 	MetricRedemptionProofSubmissionsTotal        = "redemption_proof_submissions_total"

--- a/pkg/clientinfo/proposal_metrics_test.go
+++ b/pkg/clientinfo/proposal_metrics_test.go
@@ -1,0 +1,26 @@
+package clientinfo
+
+import (
+	"context"
+	"testing"
+
+	keepclientinfo "github.com/keep-network/keep-common/pkg/clientinfo"
+)
+
+func TestRedemptionProposalCountersRegistered(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	metrics := NewPerformanceMetrics(ctx, &Registry{keepclientinfo.NewRegistry(), ctx})
+	defer metrics.Stop()
+	for _, name := range []string{
+		MetricRedemptionProposalGenerationAttemptsTotal,
+		MetricRedemptionProposalGenerationFailuresTotal,
+		MetricRedemptionProposalsGeneratedTotal,
+		MetricRedemptionProposalsBroadcastTotal,
+		MetricRedemptionProposalBroadcastFailuresTotal,
+	} {
+		if _, ok := metrics.counters[name]; !ok {
+			t.Errorf("counter %s is absent before the first proposal", name)
+		}
+	}
+}

--- a/pkg/clientinfo/proposal_metrics_test.go
+++ b/pkg/clientinfo/proposal_metrics_test.go
@@ -7,20 +7,43 @@ import (
 	keepclientinfo "github.com/keep-network/keep-common/pkg/clientinfo"
 )
 
+// TestRedemptionProposalCountersRegistered tests that the redemption
+// proposal counters are registered upfront so they appear in the metrics
+// endpoint before any increment.
 func TestRedemptionProposalCountersRegistered(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	metrics := NewPerformanceMetrics(ctx, &Registry{keepclientinfo.NewRegistry(), ctx})
-	defer metrics.Stop()
-	for _, name := range []string{
-		MetricRedemptionProposalGenerationAttemptsTotal,
-		MetricRedemptionProposalGenerationFailuresTotal,
-		MetricRedemptionProposalsGeneratedTotal,
-		MetricRedemptionProposalsBroadcastTotal,
-		MetricRedemptionProposalBroadcastFailuresTotal,
-	} {
-		if _, ok := metrics.counters[name]; !ok {
-			t.Errorf("counter %s is absent before the first proposal", name)
+
+	registry := &Registry{keepclientinfo.NewRegistry(), ctx}
+	pm := NewPerformanceMetrics(ctx, registry)
+	defer pm.Stop()
+
+	expectedCounters := []string{
+		MetricRedemptionProposalGenerationTotal,
+		MetricRedemptionProposalGenerationFailedTotal,
+		MetricRedemptionProposalGenerationSuccessTotal,
+		MetricRedemptionProposalBroadcastTotal,
+		MetricRedemptionProposalBroadcastFailedTotal,
+	}
+
+	for _, counterName := range expectedCounters {
+		pm.countersMutex.RLock()
+		_, exists := pm.counters[counterName]
+		pm.countersMutex.RUnlock()
+		if !exists {
+			t.Errorf("counter %s should be registered upfront", counterName)
+			continue
+		}
+
+		assertCounterExportedInRegistry(t, registry, counterName)
+
+		if value := pm.GetCounterValue(counterName); value != 0 {
+			t.Errorf("counter %s should start at 0, got %v", counterName, value)
+		}
+
+		pm.IncrementCounter(counterName, 1)
+		if value := pm.GetCounterValue(counterName); value != 1 {
+			t.Errorf("counter %s should increment to 1, got %v", counterName, value)
 		}
 	}
 }

--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -677,7 +677,20 @@ func (ce *coordinationExecutor) executeLeaderRoutine(
 		net.BackoffRetransmissionStrategy,
 	)
 	if err != nil {
+		if proposal.ActionType() == ActionRedemption && ce.metricsRecorder != nil {
+			ce.metricsRecorder.IncrementCounter(clientinfo.MetricRedemptionProposalBroadcastFailuresTotal, 1)
+		}
 		return nil, fmt.Errorf("failed to send coordination message: [%v]", err)
+	}
+	if proposal.ActionType() == ActionRedemption {
+		if ce.metricsRecorder != nil {
+			ce.metricsRecorder.IncrementCounter(clientinfo.MetricRedemptionProposalsBroadcastTotal, 1)
+		}
+		logger.With(
+			zap.String("event", "redemption_proposal_broadcast"),
+			zap.String("walletPKH", fmt.Sprintf("0x%x", walletPublicKeyHash)),
+			zap.Uint64("coordinationBlock", coordinationBlock),
+		).Info("redemption proposal broadcast to wallet coordination channel")
 	}
 
 	return proposal, nil

--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -677,14 +677,22 @@ func (ce *coordinationExecutor) executeLeaderRoutine(
 		net.BackoffRetransmissionStrategy,
 	)
 	if err != nil {
-		if proposal.ActionType() == ActionRedemption && ce.metricsRecorder != nil {
-			ce.metricsRecorder.IncrementCounter(clientinfo.MetricRedemptionProposalBroadcastFailuresTotal, 1)
+		if proposal.ActionType() == ActionRedemption {
+			if ce.metricsRecorder != nil {
+				ce.metricsRecorder.IncrementCounter(clientinfo.MetricRedemptionProposalBroadcastFailedTotal, 1)
+			}
+			logger.With(
+				zap.String("event", "redemption_proposal_broadcast_failed"),
+				zap.String("walletPKH", fmt.Sprintf("0x%x", walletPublicKeyHash)),
+				zap.Uint64("coordinationBlock", coordinationBlock),
+				zap.Error(err),
+			).Error("redemption proposal broadcast to wallet coordination channel failed")
 		}
 		return nil, fmt.Errorf("failed to send coordination message: [%v]", err)
 	}
 	if proposal.ActionType() == ActionRedemption {
 		if ce.metricsRecorder != nil {
-			ce.metricsRecorder.IncrementCounter(clientinfo.MetricRedemptionProposalsBroadcastTotal, 1)
+			ce.metricsRecorder.IncrementCounter(clientinfo.MetricRedemptionProposalBroadcastTotal, 1)
 		}
 		logger.With(
 			zap.String("event", "redemption_proposal_broadcast"),

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -228,6 +228,13 @@ func (n *node) setPerformanceMetrics(metrics interface {
 	}); ok {
 		pg.SetRedemptionMetricsRecorder(metrics)
 	}
+	if pg, ok := n.proposalGenerator.(interface {
+		SetProposalMetricsRecorder(recorder interface {
+			IncrementCounter(name string, value float64)
+		})
+	}); ok {
+		pg.SetProposalMetricsRecorder(metrics)
+	}
 
 	// Update metrics recorder for all cached coordination executors
 	// This is important because executors may be created before metrics are set

--- a/pkg/tbtc/proposal_metrics_test.go
+++ b/pkg/tbtc/proposal_metrics_test.go
@@ -1,0 +1,99 @@
+package tbtc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/net"
+	"github.com/keep-network/keep-core/pkg/protocol/group"
+)
+
+type proposalCounter map[string]float64
+
+func (m proposalCounter) IncrementCounter(name string, value float64) { m[name] += value }
+func (m proposalCounter) SetGauge(string, float64)                    {}
+func (m proposalCounter) RecordDuration(string, time.Duration)        {}
+
+type proposalBroadcast struct {
+	net.BroadcastChannel
+	err     error
+	message *coordinationMessage
+}
+
+func (b *proposalBroadcast) Send(_ context.Context, message net.TaggedMarshaler, _ ...net.RetransmissionStrategy) error {
+	b.message = message.(*coordinationMessage)
+	return b.err
+}
+
+func TestRedemptionProposalBroadcastMetrics(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		proposal CoordinationProposal
+		err      error
+		disabled bool
+		sent     float64
+		failed   float64
+	}{
+		{"redemption sent", &RedemptionProposal{}, nil, false, 1, 0},
+		{"redemption send fails", &RedemptionProposal{}, errors.New("broadcast unavailable"), false, 0, 1},
+		{"no-op is not a redemption", &NoopProposal{}, nil, false, 0, 0},
+		{"other action fails", &HeartbeatProposal{}, errors.New("broadcast unavailable"), false, 0, 0},
+		{"disabled metrics", &RedemptionProposal{}, nil, true, 0, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			channel := &proposalBroadcast{err: test.err}
+			executor := &coordinationExecutor{
+				coordinatedWallet: createMockSigner(t).wallet,
+				membersIndexes:    []group.MemberIndex{2, 1},
+				broadcastChannel:  channel,
+				proposalGenerator: newMockCoordinationProposalGenerator(func([20]byte, []WalletActionType, uint) (CoordinationProposal, error) {
+					return test.proposal, nil
+				}),
+			}
+			recorder := proposalCounter{}
+			if !test.disabled {
+				executor.setMetricsRecorder(recorder)
+			}
+			_, err := executor.executeLeaderRoutine(context.Background(), 900, []WalletActionType{ActionRedemption})
+			if (err != nil) != (test.err != nil) {
+				t.Fatalf("unexpected result: %v", err)
+			}
+			if channel.message == nil || channel.message.coordinationBlock != 900 || channel.message.proposal != test.proposal {
+				t.Fatal("expected the original proposal to be passed to broadcast")
+			}
+			if recorder[clientinfo.MetricRedemptionProposalsBroadcastTotal] != test.sent || recorder[clientinfo.MetricRedemptionProposalBroadcastFailuresTotal] != test.failed {
+				t.Fatalf("unexpected broadcast counters: %v", recorder)
+			}
+		})
+	}
+}
+
+type proposalMetricsSetter struct {
+	CoordinationProposalGenerator
+	recorder interface{ IncrementCounter(string, float64) }
+}
+
+func (p *proposalMetricsSetter) SetProposalMetricsRecorder(recorder interface{ IncrementCounter(string, float64) }) {
+	p.recorder = recorder
+}
+
+func TestNodeWiresProposalMetrics(t *testing.T) {
+	generator := &proposalMetricsSetter{}
+	n := &node{proposalGenerator: generator}
+	recorder := proposalCounter{}
+	n.setPerformanceMetrics(recorder)
+	if generator.recorder == nil {
+		t.Fatal("proposal generator did not receive the metrics recorder")
+	}
+	generator.recorder.IncrementCounter("wiring-test", 1)
+	if recorder["wiring-test"] != 1 {
+		t.Fatal("node passed the wrong recorder")
+	}
+	n.setPerformanceMetrics(nil)
+	if generator.recorder != nil {
+		t.Fatal("disabling node metrics must clear the generator recorder")
+	}
+}

--- a/pkg/tbtc/proposal_metrics_test.go
+++ b/pkg/tbtc/proposal_metrics_test.go
@@ -64,7 +64,7 @@ func TestRedemptionProposalBroadcastMetrics(t *testing.T) {
 			if channel.message == nil || channel.message.coordinationBlock != 900 || channel.message.proposal != test.proposal {
 				t.Fatal("expected the original proposal to be passed to broadcast")
 			}
-			if recorder[clientinfo.MetricRedemptionProposalsBroadcastTotal] != test.sent || recorder[clientinfo.MetricRedemptionProposalBroadcastFailuresTotal] != test.failed {
+			if recorder[clientinfo.MetricRedemptionProposalBroadcastTotal] != test.sent || recorder[clientinfo.MetricRedemptionProposalBroadcastFailedTotal] != test.failed {
 				t.Fatalf("unexpected broadcast counters: %v", recorder)
 			}
 		})

--- a/pkg/tbtcpg/proposal_metrics_test.go
+++ b/pkg/tbtcpg/proposal_metrics_test.go
@@ -1,0 +1,76 @@
+package tbtcpg
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+	"github.com/keep-network/keep-core/pkg/tbtc"
+)
+
+// The node cannot import tbtcpg. Pin its exact structural setter signature.
+var _ interface {
+	SetProposalMetricsRecorder(interface {
+		IncrementCounter(string, float64)
+	})
+} = (*ProposalGenerator)(nil)
+
+type proposalMetrics map[string]float64
+
+func (m proposalMetrics) IncrementCounter(name string, value float64) {
+	m[name] += value
+}
+
+func TestProposalGenerationMetrics(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		redemption mockProposalTaskResult
+		fallback   mockProposalTaskResult
+		attempts   float64
+		failures   float64
+		generated  float64
+		checklist  []tbtc.WalletActionType
+	}{
+		{"generated", resultProposal, resultEmpty, 1, 0, 1, nil},
+		{"no pending requests", resultEmpty, resultEmpty, 1, 0, 0, nil},
+		{"failure followed by successful fallback", resultError, resultProposal, 1, 1, 0, nil},
+		{"failure followed by no-op fallback", resultError, resultEmpty, 1, 1, 0, nil},
+		{"all tasks fail", resultError, resultError, 1, 1, 0, nil},
+		{"redemption not scheduled", resultError, resultProposal, 0, 0, 0, []tbtc.WalletActionType{tbtc.ActionDepositSweep}},
+		{"earlier task succeeds", resultError, resultProposal, 0, 0, 0, []tbtc.WalletActionType{tbtc.ActionDepositSweep, tbtc.ActionRedemption}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			walletPKH := [20]byte{1}
+			generator := &ProposalGenerator{tasks: []ProposalTask{
+				&mockProposalTask{action: tbtc.ActionRedemption, results: map[[20]byte]mockProposalTaskResult{walletPKH: test.redemption}},
+				&mockProposalTask{action: tbtc.ActionDepositSweep, results: map[[20]byte]mockProposalTaskResult{walletPKH: test.fallback}},
+			}}
+			recorder := proposalMetrics{}
+			generator.SetProposalMetricsRecorder(recorder)
+			checklist := test.checklist
+			if checklist == nil {
+				checklist = []tbtc.WalletActionType{tbtc.ActionRedemption, tbtc.ActionDepositSweep}
+			}
+			_, _ = generator.Generate(&tbtc.CoordinationProposalRequest{WalletPublicKeyHash: walletPKH, ActionsChecklist: checklist})
+			expected := map[string]float64{
+				clientinfo.MetricRedemptionProposalGenerationAttemptsTotal: test.attempts,
+				clientinfo.MetricRedemptionProposalGenerationFailuresTotal: test.failures,
+				clientinfo.MetricRedemptionProposalsGeneratedTotal:         test.generated,
+			}
+			for name, value := range expected {
+				if recorder[name] != value {
+					t.Errorf("%s: got %v, want %v", name, recorder[name], value)
+				}
+			}
+			before := make(proposalMetrics)
+			for name, value := range recorder {
+				before[name] = value
+			}
+			generator.SetProposalMetricsRecorder(nil)
+			_, _ = generator.Generate(&tbtc.CoordinationProposalRequest{WalletPublicKeyHash: walletPKH, ActionsChecklist: checklist})
+			if !reflect.DeepEqual(before, recorder) {
+				t.Fatal("disabled recorder was still updated")
+			}
+		})
+	}
+}

--- a/pkg/tbtcpg/proposal_metrics_test.go
+++ b/pkg/tbtcpg/proposal_metrics_test.go
@@ -53,9 +53,9 @@ func TestProposalGenerationMetrics(t *testing.T) {
 			}
 			_, _ = generator.Generate(&tbtc.CoordinationProposalRequest{WalletPublicKeyHash: walletPKH, ActionsChecklist: checklist})
 			expected := map[string]float64{
-				clientinfo.MetricRedemptionProposalGenerationAttemptsTotal: test.attempts,
-				clientinfo.MetricRedemptionProposalGenerationFailuresTotal: test.failures,
-				clientinfo.MetricRedemptionProposalsGeneratedTotal:         test.generated,
+				clientinfo.MetricRedemptionProposalGenerationTotal:        test.attempts,
+				clientinfo.MetricRedemptionProposalGenerationFailedTotal:  test.failures,
+				clientinfo.MetricRedemptionProposalGenerationSuccessTotal: test.generated,
 			}
 			for name, value := range expected {
 				if recorder[name] != value {

--- a/pkg/tbtcpg/tbtcpg.go
+++ b/pkg/tbtcpg/tbtcpg.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/clientinfo"
 	"github.com/keep-network/keep-core/pkg/tbtc"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
@@ -42,7 +43,19 @@ type ProposalTask interface {
 // ProposalGenerator is a component responsible for generating coordination
 // proposals for tbtc wallets.
 type ProposalGenerator struct {
-	tasks []ProposalTask
+	tasks           []ProposalTask
+	proposalMetrics interface {
+		IncrementCounter(name string, value float64)
+	}
+}
+
+// SetProposalMetricsRecorder records redemption task outcomes, including errors
+// followed by a successful fallback task. Keep the anonymous parameter in sync
+// with the node's structural interface assertion to avoid an import cycle.
+func (pg *ProposalGenerator) SetProposalMetricsRecorder(recorder interface {
+	IncrementCounter(name string, value float64)
+}) {
+	pg.proposalMetrics = recorder
 }
 
 // SetRedemptionMetricsRecorder sets the metrics recorder for the redemption task.
@@ -112,8 +125,14 @@ func (pg *ProposalGenerator) Generate(
 			continue
 		}
 
+		if action == tbtc.ActionRedemption && pg.proposalMetrics != nil {
+			pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalGenerationAttemptsTotal, 1)
+		}
 		proposal, ok, err := pg.tasks[taskIndex].Run(request)
 		if err != nil {
+			if action == tbtc.ActionRedemption && pg.proposalMetrics != nil {
+				pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalGenerationFailuresTotal, 1)
+			}
 			walletLogger.With(
 				zap.String("action", action.String()),
 				zap.Error(err),
@@ -128,6 +147,9 @@ func (pg *ProposalGenerator) Generate(
 				action,
 			)
 			continue
+		}
+		if action == tbtc.ActionRedemption && pg.proposalMetrics != nil {
+			pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalsGeneratedTotal, 1)
 		}
 
 		walletLogger.Infof(

--- a/pkg/tbtcpg/tbtcpg.go
+++ b/pkg/tbtcpg/tbtcpg.go
@@ -126,17 +126,23 @@ func (pg *ProposalGenerator) Generate(
 		}
 
 		if action == tbtc.ActionRedemption && pg.proposalMetrics != nil {
-			pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalGenerationAttemptsTotal, 1)
+			pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalGenerationTotal, 1)
 		}
 		proposal, ok, err := pg.tasks[taskIndex].Run(request)
 		if err != nil {
 			if action == tbtc.ActionRedemption && pg.proposalMetrics != nil {
-				pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalGenerationFailuresTotal, 1)
+				pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalGenerationFailedTotal, 1)
 			}
-			walletLogger.With(
+			taskFailedLogger := walletLogger.With(
 				zap.String("action", action.String()),
 				zap.Error(err),
-			).Error("proposal task failed; continuing with next task")
+			)
+			if action == tbtc.ActionRedemption {
+				taskFailedLogger = taskFailedLogger.With(
+					zap.String("event", "redemption_proposal_generation_failed"),
+				)
+			}
+			taskFailedLogger.Error("proposal task failed; continuing with next task")
 			taskErrors = append(taskErrors, fmt.Errorf("task [%s]: [%w]", action, err))
 			continue
 		}
@@ -148,8 +154,9 @@ func (pg *ProposalGenerator) Generate(
 			)
 			continue
 		}
+
 		if action == tbtc.ActionRedemption && pg.proposalMetrics != nil {
-			pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalsGeneratedTotal, 1)
+			pg.proposalMetrics.IncrementCounter(clientinfo.MetricRedemptionProposalGenerationSuccessTotal, 1)
 		}
 
 		walletLogger.Infof(


### PR DESCRIPTION
Redemption proposals are generated and broadcast off-chain, so Ethereum event monitoring cannot report this stage. This change adds bounded counters for redemption task attempts, generation failures/results, and local broadcast success/failure, plus a structured `redemption_proposal_broadcast` log event with wallet PKH and coordination block for per-proposal notifications.

Generation failures remain visible when the generator falls back to a different wallet action or a no-op. An empty pending-request set is not counted as a failure, and broadcast success is recorded only after the channel accepts the message. The existing pending-request gauge wiring and proposal behavior are preserved.

Targets `dev` independently of #4190 because wallet coordination does not depend on the SPV metrics stack. Refs #3664. The runbook describes metrics, notification deduplication, receiver integration, and staging checks; production receiver setup remains a rollout step.

Validation:
- Full tests pass for `pkg/tbtc`, `pkg/tbtcpg`, and `pkg/clientinfo`.
- New telemetry, fallback, broadcast, registration, and node-wiring tests pass under the race detector.
- Vet passes for the affected packages; `git diff --check` passes.
- No deployment or live notification delivery was performed.
