### PR TITLE
feat(tbtc): make transaction monitor settings configurable

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -503,6 +503,7 @@ jobs:
       # They remain required for Bitcoin client/config/dependency changes and
       # for every push, scheduled run, and manual run.
       - name: Run public Electrum integration tests
+        if: ${{ !cancelled() }}
         continue-on-error: ${{ github.event_name == 'pull_request' && needs.electrum-integration-detect-changes.outputs.path-filter == 'false' }}
         run: |
           docker run \

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -61,7 +61,12 @@ jobs:
           filters: |
             path-filter:
               - './config/_electrum_urls/**'
-              - './pkg/bitcoin/electrum/**'
+              - './config/electrum*.go'
+              - './pkg/bitcoin/**'
+              - './internal/testdata/bitcoin/**'
+              - './go.mod'
+              - './go.sum'
+              - './third_party/**'
   btcec-vendor-byte-identity:
     # Enforces the VENDOR.md byte-identity recipe and runs the
     # vendored upstream test suite. The root module's `go test ./...`
@@ -489,4 +494,18 @@ jobs:
             -e ETHEREUM_MAINNET_RPC_URL \
             --workdir /go/src/github.com/keep-network/keep-core \
             go-build-env \
-            gotestsum -- -timeout 20m -tags=integration ./...
+            sh -ec 'packages=$(go list ./...);
+              packages=$(printf "%s\n" "$packages" | grep -v "/pkg/bitcoin/electrum$");
+              gotestsum -- -timeout 20m -tags=integration $packages'
+
+      # Public Electrum servers can time out independently of this PR. Run
+      # their tests separately so they cannot mask other integration failures.
+      # They remain required for Bitcoin client/config/dependency changes and
+      # for every push, scheduled run, and manual run.
+      - name: Run public Electrum integration tests
+        continue-on-error: ${{ github.event_name == 'pull_request' && needs.electrum-integration-detect-changes.outputs.path-filter == 'false' }}
+        run: |
+          docker run \
+            --workdir /go/src/github.com/keep-network/keep-core \
+            go-build-env \
+            gotestsum -- -timeout 20m -tags=integration ./pkg/bitcoin/electrum

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -483,6 +483,7 @@ jobs:
           path: /tmp
 
       - name: Load Docker Build Image
+        id: load-image
         run: |
           docker load --input /tmp/go-build-env-image.tar
 
@@ -503,7 +504,7 @@ jobs:
       # They remain required for Bitcoin client/config/dependency changes and
       # for every push, scheduled run, and manual run.
       - name: Run public Electrum integration tests
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.load-image.outcome == 'success' }}
         continue-on-error: ${{ github.event_name == 'pull_request' && needs.electrum-integration-detect-changes.outputs.path-filter == 'false' }}
         run: |
           docker run \

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -329,6 +329,37 @@ func initTbtcFlags(cmd *cobra.Command, cfg *config.Config) {
 			"(bufferedRate = ceil(rawRate * (100+Percent) / 100)); "+
 			"0 means use the default.",
 	)
+
+	cmd.Flags().DurationVar(
+		&cfg.Tbtc.TransactionMonitor.StuckThreshold,
+		"tbtc.transactionMonitor.stuckThreshold",
+		tbtc.DefaultTransactionMonitorStuckThreshold,
+		"Unconfirmed transaction age before a stuck-transaction alert; 0 uses the default.",
+	)
+	cmd.Flags().DurationVar(
+		&cfg.Tbtc.TransactionMonitor.CheckInterval,
+		"tbtc.transactionMonitor.checkInterval",
+		tbtc.DefaultTransactionMonitorCheckInterval,
+		"Polling interval for wallet transaction confirmations; 0 uses the default.",
+	)
+	cmd.Flags().IntVar(
+		&cfg.Tbtc.TransactionMonitor.MaxTracked,
+		"tbtc.transactionMonitor.maxTracked",
+		tbtc.DefaultTransactionMonitorMaxTracked,
+		"Maximum number of wallet transactions tracked in memory; 0 uses the default.",
+	)
+	cmd.Flags().DurationVar(
+		&cfg.Tbtc.TransactionMonitor.MaxTrackingAge,
+		"tbtc.transactionMonitor.maxTrackingAge",
+		tbtc.DefaultTransactionMonitorMaxTrackingAge,
+		"Maximum age of a tracked transaction; must be at least stuckThreshold; 0 uses the default.",
+	)
+	cmd.Flags().DurationVar(
+		&cfg.Tbtc.TransactionMonitor.CheckBudget,
+		"tbtc.transactionMonitor.checkBudget",
+		tbtc.DefaultTransactionMonitorCheckBudget,
+		"Time budget for one transaction confirmation-check pass; 0 uses the default.",
+	)
 }
 
 // Initialize flags for Maintainer configuration.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -346,7 +346,7 @@ func initTbtcFlags(cmd *cobra.Command, cfg *config.Config) {
 		&cfg.Tbtc.TransactionMonitor.MaxTracked,
 		"tbtc.transactionMonitor.maxTracked",
 		tbtc.DefaultTransactionMonitorMaxTracked,
-		"Maximum number of wallet transactions tracked in memory; 0 uses the default.",
+		"Maximum number of wallet transactions tracked in memory; must not exceed 100000; 0 uses the default.",
 	)
 	cmd.Flags().DurationVar(
 		&cfg.Tbtc.TransactionMonitor.MaxTrackingAge,

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -240,6 +240,41 @@ var cmdFlagsTests = map[string]struct {
 		expectedValueFromFlag: 30,
 		defaultValue:          tbtc.DefaultWalletTxFeeBufferPercent,
 	},
+	"tbtc.transactionMonitor.stuckThreshold": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.TransactionMonitor.StuckThreshold },
+		flagName:              "--tbtc.transactionMonitor.stuckThreshold",
+		flagValue:             "1h",
+		expectedValueFromFlag: time.Hour,
+		defaultValue:          tbtc.DefaultTransactionMonitorStuckThreshold,
+	},
+	"tbtc.transactionMonitor.checkInterval": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.TransactionMonitor.CheckInterval },
+		flagName:              "--tbtc.transactionMonitor.checkInterval",
+		flagValue:             "1m",
+		expectedValueFromFlag: time.Minute,
+		defaultValue:          tbtc.DefaultTransactionMonitorCheckInterval,
+	},
+	"tbtc.transactionMonitor.maxTracked": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.TransactionMonitor.MaxTracked },
+		flagName:              "--tbtc.transactionMonitor.maxTracked",
+		flagValue:             "25",
+		expectedValueFromFlag: 25,
+		defaultValue:          tbtc.DefaultTransactionMonitorMaxTracked,
+	},
+	"tbtc.transactionMonitor.maxTrackingAge": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.TransactionMonitor.MaxTrackingAge },
+		flagName:              "--tbtc.transactionMonitor.maxTrackingAge",
+		flagValue:             "12h",
+		expectedValueFromFlag: 12 * time.Hour,
+		defaultValue:          tbtc.DefaultTransactionMonitorMaxTrackingAge,
+	},
+	"tbtc.transactionMonitor.checkBudget": {
+		readValueFunc:         func(c *config.Config) interface{} { return c.Tbtc.TransactionMonitor.CheckBudget },
+		flagName:              "--tbtc.transactionMonitor.checkBudget",
+		flagValue:             "30s",
+		expectedValueFromFlag: 30 * time.Second,
+		defaultValue:          tbtc.DefaultTransactionMonitorCheckBudget,
+	},
 	"maintainer.bitcoinDifficulty": {
 		readValueFunc:         func(c *config.Config) interface{} { return c.Maintainer.BitcoinDifficulty.Enabled },
 		flagName:              "--bitcoinDifficulty",
@@ -447,6 +482,7 @@ func TestFlags_Mixed(t *testing.T) {
 		"--bitcoin.electrum.url", "ssl://url.to.electrum:18332",
 		"--network.port", "7469",
 		"--bitcoinDifficulty",
+		"--tbtc.transactionMonitor.stuckThreshold", "30m",
 	}
 	testCommand.SetArgs(args)
 
@@ -479,6 +515,16 @@ func TestFlags_Mixed(t *testing.T) {
 		"clientInfo.port": {
 			readValueFunc: func(c *config.Config) interface{} { return c.ClientInfo.Port },
 			expectedValue: 3097,
+		},
+		"tbtc.transactionMonitor": {
+			readValueFunc: func(c *config.Config) interface{} { return c.Tbtc.TransactionMonitor },
+			expectedValue: tbtc.TransactionMonitorConfig{
+				StuckThreshold: 30 * time.Minute,
+				CheckInterval:  45 * time.Second,
+				MaxTracked:     50,
+				MaxTrackingAge: 12 * time.Hour,
+				CheckBudget:    tbtc.DefaultTransactionMonitorCheckBudget,
+			},
 		},
 		"storage.dir": {
 			readValueFunc: func(c *config.Config) interface{} { return c.Storage.Dir },

--- a/config/config.go
+++ b/config/config.go
@@ -227,6 +227,10 @@ func validateConfig(config *Config, categories ...Category) error {
 					"missing value for storage.dir; see storage section in configuration",
 				))
 			}
+		case Tbtc:
+			if err := config.Tbtc.TransactionMonitor.Validate(); err != nil {
+				result = multierror.Append(result, err)
+			}
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,7 +18,21 @@ import (
 	ethereumEcdsa "github.com/keep-network/keep-core/pkg/chain/ethereum/ecdsa/gen"
 	ethereumTbtc "github.com/keep-network/keep-core/pkg/chain/ethereum/tbtc/gen"
 	ethereumThreshold "github.com/keep-network/keep-core/pkg/chain/ethereum/threshold/gen"
+	"github.com/keep-network/keep-core/pkg/tbtc"
 )
+
+func TestValidateConfig_TransactionMonitor(t *testing.T) {
+	cfg := &Config{Tbtc: tbtc.Config{TransactionMonitor: tbtc.TransactionMonitorConfig{
+		StuckThreshold: time.Hour,
+		MaxTrackingAge: 30 * time.Minute,
+	}}}
+	if err := validateConfig(cfg, Tbtc); err == nil || !strings.Contains(err.Error(), "maxTrackingAge") {
+		t.Fatalf("expected invalid monitoring settings to fail configuration validation, got %v", err)
+	}
+	if err := validateConfig(cfg, Maintainer); err != nil {
+		t.Fatalf("a command that does not start tBTC should ignore its monitor settings: %v", err)
+	}
+}
 
 func TestReadConfigFromFile(t *testing.T) {
 	filePaths := []string{

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -118,6 +118,19 @@ Port = 9601
 # PreParamsGenerationConcurrency = 1
 # KeyGenerationConcurrency = 1
 
+# Stuck wallet transaction monitoring. Values shown are the defaults.
+# Zero selects the default; negative values are rejected. MaxTrackingAge must
+# be at least StuckThreshold. These settings apply when the node starts.
+# Command-line overrides use --tbtc.transactionMonitor.<setting>, for example
+# --tbtc.transactionMonitor.stuckThreshold=30m.
+#
+# [tbtc.transactionMonitor]
+# StuckThreshold = "6h"
+# CheckInterval = "5m"
+# MaxTracked = 1000
+# MaxTrackingAge = "24h"
+# CheckBudget = "2m"
+
 # Developer options to work with locally deployed contracts
 #
 # [developer]

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -119,8 +119,9 @@ Port = 9601
 # KeyGenerationConcurrency = 1
 
 # Stuck wallet transaction monitoring. Values shown are the defaults.
-# Zero selects the default; negative values are rejected. MaxTrackingAge must
-# be at least StuckThreshold. These settings apply when the node starts.
+# Zero selects the default; negative values are rejected. MaxTracked must
+# not exceed 100000. MaxTrackingAge must be at least StuckThreshold. These
+# settings apply when the node starts.
 # Command-line overrides use --tbtc.transactionMonitor.<setting>, for example
 # --tbtc.transactionMonitor.stuckThreshold=30m.
 #

--- a/pkg/tbtc/node.go
+++ b/pkg/tbtc/node.go
@@ -130,6 +130,11 @@ func newNode(
 	proposalGenerator CoordinationProposalGenerator,
 	config Config,
 ) (*node, error) {
+	transactionMonitor, err := newTransactionMonitor(btcChain, config.TransactionMonitor)
+	if err != nil {
+		return nil, err
+	}
+
 	walletRegistry, err := newWalletRegistry(
 		keyStorePersistance,
 		chain.CalculateWalletID,
@@ -154,7 +159,7 @@ func newNode(
 		inactivityClaimExecutors: make(map[string]*inactivityClaimExecutor),
 		coordinationExecutors:    make(map[string]*coordinationExecutor),
 		proposalGenerator:        proposalGenerator,
-		transactionMonitor:       newTransactionMonitor(btcChain),
+		transactionMonitor:       transactionMonitor,
 	}
 
 	// Archive any wallets that might have been closed or terminated while the

--- a/pkg/tbtc/node_test.go
+++ b/pkg/tbtc/node_test.go
@@ -50,6 +50,11 @@ func TestNode_GetSigningExecutor(t *testing.T) {
 	// Populate the mock keystore with the mock signer's data. This is
 	// required to make the node controlling the signer's wallet.
 	keyStorePersistence := createMockKeyStorePersistence(t, signer)
+	nodeConfig := Config{
+		PreParamsPoolSize:          1,
+		PreParamsGenerationTimeout: time.Hour,
+		TransactionMonitor:         TransactionMonitorConfig{StuckThreshold: 45 * time.Minute},
+	}
 
 	node, err := newNode(
 		groupParameters,
@@ -60,10 +65,13 @@ func TestNode_GetSigningExecutor(t *testing.T) {
 		&mockPersistenceHandle{},
 		newTestScheduler(t),
 		&mockCoordinationProposalGenerator{},
-		Config{PreParamsPoolSize: 1, PreParamsGenerationTimeout: time.Hour},
+		nodeConfig,
 	)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if node.transactionMonitor.config.StuckThreshold != nodeConfig.TransactionMonitor.StuckThreshold {
+		t.Fatal("node did not pass its transaction monitor configuration to the monitor")
 	}
 
 	walletPublicKey := signer.wallet.publicKey

--- a/pkg/tbtc/tbtc.go
+++ b/pkg/tbtc/tbtc.go
@@ -153,6 +153,9 @@ type Config struct {
 	// DefaultWalletTxFeeBufferPercent. Maps to the
 	// tbtc.walletTxFeeBufferPercent flag / viper key.
 	WalletTxFeeBufferPercent int
+	// TransactionMonitor controls confirmation polling and stuck-transaction
+	// alerts. Omitted settings retain the default monitoring policy.
+	TransactionMonitor TransactionMonitorConfig
 }
 
 // applyWalletTxFeePolicy applies the operator-tunable wallet-tx fee-floor

--- a/pkg/tbtc/transaction_monitor.go
+++ b/pkg/tbtc/transaction_monitor.go
@@ -2,6 +2,7 @@ package tbtc
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -10,37 +11,9 @@ import (
 	"github.com/keep-network/keep-core/pkg/clientinfo"
 )
 
-const (
-	// defaultStuckTransactionThreshold is how long a broadcast wallet
-	// transaction may remain unconfirmed before it is considered stuck and an
-	// alert is raised (~6 hours).
-	defaultStuckTransactionThreshold = 6 * time.Hour
-
-	// transactionMonitorCheckInterval is how often the monitor polls the
-	// confirmation status of the tracked transactions.
-	transactionMonitorCheckInterval = 5 * time.Minute
-
-	// transactionMonitorMinConfirmations is the number of confirmations at
-	// which a tracked transaction is considered mined and stops being tracked.
-	transactionMonitorMinConfirmations = uint(1)
-
-	// transactionMonitorMaxTracked bounds the number of tracked transactions to
-	// prevent unbounded memory growth.
-	transactionMonitorMaxTracked = 1000
-
-	// transactionMonitorMaxTrackingAge is how long a still-unconfirmed
-	// transaction is tracked before the monitor gives up on it - e.g. it was
-	// dropped from the mempool and will never confirm. Bounding the tracking
-	// duration prevents never-confirming transactions from filling up the
-	// tracking table and starving monitoring of new transactions (~24 hours).
-	transactionMonitorMaxTrackingAge = 24 * time.Hour
-
-	// transactionMonitorCheckBudget bounds the wall-clock time of a single check
-	// pass so that a slow chain call cannot stall monitoring of every remaining
-	// transaction; transactions not reached within the budget are handled on the
-	// next pass.
-	transactionMonitorCheckBudget = 2 * time.Minute
-)
+// transactionMonitorMinConfirmations is the number of confirmations at which
+// a tracked transaction is considered mined and stops being tracked.
+const transactionMonitorMinConfirmations = uint(1)
 
 // trackedTransaction holds the monitoring state of a single broadcast wallet
 // transaction.
@@ -103,17 +76,23 @@ type transactionMonitor struct {
 	mu      sync.Mutex
 	tracked map[bitcoin.Hash]*trackedTransaction
 
-	threshold time.Duration
+	config TransactionMonitorConfig
 
 	metricsRecorder clientinfo.PerformanceMetricsRecorder
 }
 
-func newTransactionMonitor(btcChain bitcoin.Chain) *transactionMonitor {
-	return &transactionMonitor{
-		btcChain:  btcChain,
-		tracked:   make(map[bitcoin.Hash]*trackedTransaction),
-		threshold: defaultStuckTransactionThreshold,
+func newTransactionMonitor(
+	btcChain bitcoin.Chain,
+	config TransactionMonitorConfig,
+) (*transactionMonitor, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid transaction monitor configuration: %w", err)
 	}
+	return &transactionMonitor{
+		btcChain: btcChain,
+		tracked:  make(map[bitcoin.Hash]*trackedTransaction),
+		config:   config.withDefaults(),
+	}, nil
 }
 
 // setMetricsRecorder wires the performance metrics recorder used to expose the
@@ -141,7 +120,7 @@ func (tm *transactionMonitor) track(
 		return
 	}
 
-	if len(tm.tracked) >= transactionMonitorMaxTracked {
+	if len(tm.tracked) >= tm.config.MaxTracked {
 		// A full table means a real broadcast transaction goes unmonitored;
 		// surface it as a metric (emitted outside the lock) as well as a log.
 		recorder := tm.metricsRecorder
@@ -150,7 +129,7 @@ func (tm *transactionMonitor) track(
 		logger.Warnf(
 			"transaction monitor tracking table is full ([%d]); transaction "+
 				"[%s] will not be monitored",
-			transactionMonitorMaxTracked,
+			tm.config.MaxTracked,
 			txHash.Hex(bitcoin.ReversedByteOrder),
 		)
 		if recorder != nil {
@@ -170,7 +149,7 @@ func (tm *transactionMonitor) track(
 
 // run starts the monitor's polling loop. It blocks until the context is done.
 func (tm *transactionMonitor) run(ctx context.Context) {
-	ticker := time.NewTicker(transactionMonitorCheckInterval)
+	ticker := time.NewTicker(tm.config.CheckInterval)
 	defer ticker.Stop()
 
 	for {
@@ -192,7 +171,7 @@ func (tm *transactionMonitor) run(ctx context.Context) {
 // concurrently but only inserts new entries, so the per-entry alerted flag is
 // only ever mutated here, under the mutex.
 func (tm *transactionMonitor) check(ctx context.Context) {
-	tm.checkWithBudget(ctx, transactionMonitorCheckBudget)
+	tm.checkWithBudget(ctx, tm.config.CheckBudget)
 }
 
 func (tm *transactionMonitor) checkWithBudget(
@@ -251,7 +230,7 @@ func (tm *transactionMonitor) checkWithBudget(
 		// threshold. This runs before the give-up eviction below so that a
 		// transaction first observed after the maximum tracking age still fires
 		// exactly one alert instead of being silently evicted.
-		if outstanding > tm.threshold && !t.alerted {
+		if outstanding > tm.config.StuckThreshold && !t.alerted {
 			logger.Warnf(
 				"wallet transaction [%s] for wallet [0x%x] has been unconfirmed "+
 					"for [%s] (threshold [%s]); it may be stuck in the mempool "+
@@ -260,7 +239,7 @@ func (tm *transactionMonitor) checkWithBudget(
 				txHash.Hex(bitcoin.ReversedByteOrder),
 				t.walletPublicKeyHash,
 				outstanding.Round(time.Minute),
-				tm.threshold,
+				tm.config.StuckThreshold,
 			)
 
 			// Mark as alerted under the lock, but emit the metric outside the
@@ -281,7 +260,7 @@ func (tm *transactionMonitor) checkWithBudget(
 
 		// Give up on transactions that have been unconfirmed for too long (e.g.
 		// dropped from the mempool) so they cannot fill the tracking table.
-		if outstanding > transactionMonitorMaxTrackingAge {
+		if outstanding > tm.config.MaxTrackingAge {
 			logger.Warnf(
 				"giving up monitoring wallet transaction [%s] for wallet "+
 					"[0x%x]; it has been unconfirmed for [%s]",

--- a/pkg/tbtc/transaction_monitor_config.go
+++ b/pkg/tbtc/transaction_monitor_config.go
@@ -1,0 +1,76 @@
+package tbtc
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// DefaultTransactionMonitorStuckThreshold is the age at which an
+	// unconfirmed wallet transaction starts generating alerts.
+	DefaultTransactionMonitorStuckThreshold = 6 * time.Hour
+	// DefaultTransactionMonitorCheckInterval is the confirmation polling cadence.
+	DefaultTransactionMonitorCheckInterval = 5 * time.Minute
+	// DefaultTransactionMonitorMaxTracked bounds the in-memory tracking table.
+	DefaultTransactionMonitorMaxTracked = 1000
+	// DefaultTransactionMonitorMaxTrackingAge bounds how long an unconfirmed
+	// transaction occupies the tracking table.
+	DefaultTransactionMonitorMaxTrackingAge = 24 * time.Hour
+	// DefaultTransactionMonitorCheckBudget bounds one confirmation-check pass.
+	DefaultTransactionMonitorCheckBudget = 2 * time.Minute
+)
+
+// TransactionMonitorConfig configures monitoring of broadcast wallet
+// transactions. Zero values select the defaults; negative values are invalid.
+type TransactionMonitorConfig struct {
+	StuckThreshold time.Duration
+	CheckInterval  time.Duration
+	MaxTracked     int
+	MaxTrackingAge time.Duration
+	CheckBudget    time.Duration
+}
+
+func (c TransactionMonitorConfig) withDefaults() TransactionMonitorConfig {
+	if c.StuckThreshold == 0 {
+		c.StuckThreshold = DefaultTransactionMonitorStuckThreshold
+	}
+	if c.CheckInterval == 0 {
+		c.CheckInterval = DefaultTransactionMonitorCheckInterval
+	}
+	if c.MaxTracked == 0 {
+		c.MaxTracked = DefaultTransactionMonitorMaxTracked
+	}
+	if c.MaxTrackingAge == 0 {
+		c.MaxTrackingAge = DefaultTransactionMonitorMaxTrackingAge
+	}
+	if c.CheckBudget == 0 {
+		c.CheckBudget = DefaultTransactionMonitorCheckBudget
+	}
+	return c
+}
+
+// Validate checks the effective configuration, including defaults for omitted
+// fields. Transactions must remain tracked long enough to generate an alert.
+func (c TransactionMonitorConfig) Validate() error {
+	c = c.withDefaults()
+	for _, setting := range []struct {
+		name  string
+		value time.Duration
+	}{
+		{"stuckThreshold", c.StuckThreshold},
+		{"checkInterval", c.CheckInterval},
+		{"maxTrackingAge", c.MaxTrackingAge},
+		{"checkBudget", c.CheckBudget},
+	} {
+		if setting.value < 0 {
+			return fmt.Errorf("tbtc.transactionMonitor.%s must not be negative", setting.name)
+		}
+	}
+	if c.MaxTracked < 0 {
+		return fmt.Errorf("tbtc.transactionMonitor.maxTracked must not be negative")
+	}
+	if c.MaxTrackingAge < c.StuckThreshold {
+		return fmt.Errorf("tbtc.transactionMonitor.maxTrackingAge must be at least stuckThreshold")
+	}
+	return nil
+}

--- a/pkg/tbtc/transaction_monitor_config.go
+++ b/pkg/tbtc/transaction_monitor_config.go
@@ -18,10 +18,17 @@ const (
 	DefaultTransactionMonitorMaxTrackingAge = 24 * time.Hour
 	// DefaultTransactionMonitorCheckBudget bounds one confirmation-check pass.
 	DefaultTransactionMonitorCheckBudget = 2 * time.Minute
+
+	// maxTransactionMonitorMaxTracked is the highest allowed in-memory
+	// tracking table size; guards against unbounded memory growth from a
+	// misconfigured deployment.
+	maxTransactionMonitorMaxTracked = 100_000
 )
 
 // TransactionMonitorConfig configures monitoring of broadcast wallet
-// transactions. Zero values select the defaults; negative values are invalid.
+// transactions. Zero values select the defaults; negative values are
+// invalid. MaxTrackingAge must be at least the effective StuckThreshold
+// after defaults are applied.
 type TransactionMonitorConfig struct {
 	StuckThreshold time.Duration
 	CheckInterval  time.Duration
@@ -69,8 +76,17 @@ func (c TransactionMonitorConfig) Validate() error {
 	if c.MaxTracked < 0 {
 		return fmt.Errorf("tbtc.transactionMonitor.maxTracked must not be negative")
 	}
+	if c.MaxTracked > maxTransactionMonitorMaxTracked {
+		return fmt.Errorf(
+			"tbtc.transactionMonitor.maxTracked must not exceed %d",
+			maxTransactionMonitorMaxTracked,
+		)
+	}
 	if c.MaxTrackingAge < c.StuckThreshold {
-		return fmt.Errorf("tbtc.transactionMonitor.maxTrackingAge must be at least stuckThreshold")
+		return fmt.Errorf(
+			"tbtc.transactionMonitor.maxTrackingAge (%s) must be at least stuckThreshold (%s)",
+			c.MaxTrackingAge, c.StuckThreshold,
+		)
 	}
 	return nil
 }

--- a/pkg/tbtc/transaction_monitor_config_test.go
+++ b/pkg/tbtc/transaction_monitor_config_test.go
@@ -1,0 +1,153 @@
+package tbtc
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+	"github.com/keep-network/keep-core/pkg/clientinfo"
+)
+
+func TestTransactionMonitorConfig_Defaults(t *testing.T) {
+	monitor, err := newTransactionMonitor(newLocalBitcoinChain(), TransactionMonitorConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := TransactionMonitorConfig{
+		StuckThreshold: 6 * time.Hour,
+		CheckInterval:  5 * time.Minute,
+		MaxTracked:     1000,
+		MaxTrackingAge: 24 * time.Hour,
+		CheckBudget:    2 * time.Minute,
+	}
+	if monitor.config != expected {
+		t.Fatalf("default configuration changed: got %+v, want %+v", monitor.config, expected)
+	}
+}
+
+func TestTransactionMonitorConfig_Validation(t *testing.T) {
+	tests := map[string]struct {
+		config     TransactionMonitorConfig
+		errorField string
+	}{
+		"negative threshold":          {TransactionMonitorConfig{StuckThreshold: -time.Second}, "stuckThreshold"},
+		"negative interval":           {TransactionMonitorConfig{CheckInterval: -time.Second}, "checkInterval"},
+		"negative capacity":           {TransactionMonitorConfig{MaxTracked: -1}, "maxTracked"},
+		"negative age":                {TransactionMonitorConfig{MaxTrackingAge: -time.Second}, "maxTrackingAge"},
+		"negative budget":             {TransactionMonitorConfig{CheckBudget: -time.Second}, "checkBudget"},
+		"age below default threshold": {TransactionMonitorConfig{MaxTrackingAge: time.Hour}, "maxTrackingAge"},
+		"threshold above default age": {TransactionMonitorConfig{StuckThreshold: 25 * time.Hour}, "maxTrackingAge"},
+		"equal threshold and age":     {TransactionMonitorConfig{StuckThreshold: time.Hour, MaxTrackingAge: time.Hour}, ""},
+		"partial override":            {TransactionMonitorConfig{CheckInterval: time.Minute}, ""},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := newTransactionMonitor(newLocalBitcoinChain(), test.config)
+			if test.errorField == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), test.errorField) {
+				t.Fatalf("expected error naming %s, got %v", test.errorField, err)
+			}
+		})
+	}
+}
+
+func TestTransactionMonitor_CustomThresholdCapacityAndAge(t *testing.T) {
+	monitor, err := newTransactionMonitor(newLocalBitcoinChain(), TransactionMonitorConfig{
+		StuckThreshold: time.Hour,
+		MaxTracked:     2,
+		MaxTrackingAge: 2 * time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := newCountingMetricsRecorder()
+	monitor.setMetricsRecorder(recorder)
+	first, second, overflow := bitcoin.Hash{1}, bitcoin.Hash{2}, bitcoin.Hash{3}
+	monitor.track(first, [20]byte{1})
+	monitor.track(second, [20]byte{1})
+	monitor.track(overflow, [20]byte{1})
+	if isTracked(monitor, overflow) || recorder.GetCounterValue(clientinfo.MetricUnmonitoredWalletTransactionsTotal) != 1 {
+		t.Fatal("custom tracking capacity was not enforced")
+	}
+	ageTransaction(monitor, first, 45*time.Minute)
+	ageTransaction(monitor, second, 90*time.Minute)
+	monitor.check(context.Background())
+	if got := recorder.GetCounterValue(clientinfo.MetricStuckWalletTransactionsTotal); got != 1 {
+		t.Fatalf("expected one alert with the custom threshold, got %v", got)
+	}
+	if !isTracked(monitor, second) {
+		t.Fatal("transaction evicted before custom maximum age")
+	}
+	ageTransaction(monitor, second, time.Hour)
+	monitor.check(context.Background())
+	if isTracked(monitor, second) {
+		t.Fatal("transaction retained past custom maximum age")
+	}
+	if got := recorder.GetCounterValue(clientinfo.MetricStuckWalletTransactionsTotal); got != 1 {
+		t.Fatalf("expected no duplicate alert before eviction, got %v", got)
+	}
+	monitor.track(overflow, [20]byte{1})
+	if !isTracked(monitor, overflow) {
+		t.Fatal("evicted transaction did not free tracking capacity")
+	}
+}
+
+func TestTransactionMonitor_CustomCheckBudget(t *testing.T) {
+	hash := bitcoin.Hash{1}
+	chain := newBlockingTransactionConfirmationsChain(hash)
+	monitor, err := newTransactionMonitor(chain, TransactionMonitorConfig{CheckBudget: 20 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	monitor.track(hash, [20]byte{1})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	monitor.check(ctx)
+	if ctx.Err() != nil {
+		t.Fatal("custom check budget did not cancel the blocked lookup before the parent deadline")
+	}
+	if chain.getLookupCount() != 1 {
+		t.Fatal("expected one confirmation lookup")
+	}
+}
+
+func TestTransactionMonitor_CustomCheckInterval(t *testing.T) {
+	hash := bitcoin.Hash{1}
+	chain := newBlockingTransactionConfirmationsChain(hash)
+	monitor, err := newTransactionMonitor(chain, TransactionMonitorConfig{CheckInterval: 5 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	monitor.track(hash, [20]byte{1})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); monitor.run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("monitor did not stop after cancellation")
+		}
+	})
+	select {
+	case <-chain.lookupStarted:
+	case <-time.After(time.Second):
+		t.Fatal("custom polling interval did not trigger a confirmation check")
+	}
+}
+
+func TestNewNode_RejectsInvalidTransactionMonitorConfig(t *testing.T) {
+	// Validation must precede persistence, chain access, and scheduler setup.
+	_, err := newNode(nil, nil, nil, nil, nil, nil, nil, nil, Config{
+		TransactionMonitor: TransactionMonitorConfig{CheckInterval: -time.Second},
+	})
+	if err == nil || !strings.Contains(err.Error(), "checkInterval") {
+		t.Fatalf("expected monitor configuration rejection before node setup, got %v", err)
+	}
+}

--- a/pkg/tbtc/transaction_monitor_config_test.go
+++ b/pkg/tbtc/transaction_monitor_config_test.go
@@ -41,6 +41,7 @@ func TestTransactionMonitorConfig_Validation(t *testing.T) {
 		"threshold above default age": {TransactionMonitorConfig{StuckThreshold: 25 * time.Hour}, "maxTrackingAge"},
 		"equal threshold and age":     {TransactionMonitorConfig{StuckThreshold: time.Hour, MaxTrackingAge: time.Hour}, ""},
 		"partial override":            {TransactionMonitorConfig{CheckInterval: time.Minute}, ""},
+		"capacity above ceiling":      {TransactionMonitorConfig{MaxTracked: maxTransactionMonitorMaxTracked + 1}, "maxTracked"},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/tbtc/transaction_monitor_test.go
+++ b/pkg/tbtc/transaction_monitor_test.go
@@ -115,7 +115,10 @@ func TestTransactionMonitor(t *testing.T) {
 	chain := newLocalBitcoinChain()
 	recorder := newCountingMetricsRecorder()
 
-	monitor := newTransactionMonitor(chain)
+	monitor, err := newTransactionMonitor(chain, TransactionMonitorConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	monitor.setMetricsRecorder(recorder)
 
 	tx := &bitcoin.Transaction{}
@@ -137,7 +140,7 @@ func TestTransactionMonitor(t *testing.T) {
 	// deliberately: with a real clock the check-time drift always nudges the
 	// elapsed time a hair past any exact backdated value, so it cannot be pinned
 	// deterministically without an injectable clock.
-	ageTransaction(monitor, txHash, defaultStuckTransactionThreshold-time.Minute)
+	ageTransaction(monitor, txHash, DefaultTransactionMonitorStuckThreshold-time.Minute)
 	monitor.check(context.Background())
 	if got := stuckCount(); got != 0 {
 		t.Fatalf("expected no alert at the threshold boundary; got counter [%v]", got)
@@ -166,7 +169,10 @@ func TestTransactionMonitor(t *testing.T) {
 // table.
 func TestTransactionMonitor_GivesUpOnNeverConfirming(t *testing.T) {
 	recorder := newCountingMetricsRecorder()
-	monitor := newTransactionMonitor(newLocalBitcoinChain())
+	monitor, err := newTransactionMonitor(newLocalBitcoinChain(), TransactionMonitorConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	monitor.setMetricsRecorder(recorder)
 
 	tx := &bitcoin.Transaction{}
@@ -177,7 +183,7 @@ func TestTransactionMonitor_GivesUpOnNeverConfirming(t *testing.T) {
 	// the stuck threshold and the give-up age. It must still fire exactly one
 	// stuck alert (the alert runs before eviction) and then be evicted rather
 	// than tracked forever.
-	ageTransaction(monitor, txHash, transactionMonitorMaxTrackingAge+time.Minute)
+	ageTransaction(monitor, txHash, DefaultTransactionMonitorMaxTrackingAge+time.Minute)
 	monitor.check(context.Background())
 
 	if got := recorder.GetCounterValue(
@@ -196,7 +202,10 @@ func TestTransactionMonitor_GivesUpOnNeverConfirming(t *testing.T) {
 func TestTransactionMonitor_CheckBudgetBoundsLookup(t *testing.T) {
 	blockedTxHash := bitcoin.Hash{1}
 	chain := newBlockingTransactionConfirmationsChain(blockedTxHash)
-	monitor := newTransactionMonitor(chain)
+	monitor, err := newTransactionMonitor(chain, TransactionMonitorConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	monitor.track(blockedTxHash, [20]byte{})
 
@@ -255,7 +264,10 @@ func TestTransactionMonitor_BudgetExpiryStillAlertsOldest(t *testing.T) {
 	blockedTxHash := bitcoin.Hash{1} // oldest; its lookup hangs until the budget expires
 	chain := newBlockingTransactionConfirmationsChain(blockedTxHash)
 	recorder := newCountingMetricsRecorder()
-	monitor := newTransactionMonitor(chain)
+	monitor, err := newTransactionMonitor(chain, TransactionMonitorConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	monitor.setMetricsRecorder(recorder)
 
 	newerTxHash := bitcoin.Hash{2}
@@ -264,8 +276,8 @@ func TestTransactionMonitor_BudgetExpiryStillAlertsOldest(t *testing.T) {
 
 	// Both transactions are past the stuck threshold; the blocked one is older so
 	// oldest-first ordering checks it first and its lookup consumes the budget.
-	ageTransaction(monitor, blockedTxHash, defaultStuckTransactionThreshold+2*time.Hour)
-	ageTransaction(monitor, newerTxHash, defaultStuckTransactionThreshold+time.Hour)
+	ageTransaction(monitor, blockedTxHash, DefaultTransactionMonitorStuckThreshold+2*time.Hour)
+	ageTransaction(monitor, newerTxHash, DefaultTransactionMonitorStuckThreshold+time.Hour)
 
 	// Release the intentionally blocked backend on exit so its lookup goroutine
 	// is never left parked.
@@ -319,21 +331,24 @@ func TestTransactionMonitor_BudgetExpiryStillAlertsOldest(t *testing.T) {
 // past its bound.
 func TestTransactionMonitor_CapacityBound(t *testing.T) {
 	recorder := newCountingMetricsRecorder()
-	monitor := newTransactionMonitor(newLocalBitcoinChain())
+	monitor, err := newTransactionMonitor(newLocalBitcoinChain(), TransactionMonitorConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	monitor.setMetricsRecorder(recorder)
 
 	const excess = 10
-	for i := 0; i < transactionMonitorMaxTracked+excess; i++ {
+	for i := 0; i < DefaultTransactionMonitorMaxTracked+excess; i++ {
 		var h bitcoin.Hash
 		h[0] = byte(i)
 		h[1] = byte(i >> 8)
 		monitor.track(h, [20]byte{})
 	}
 
-	if got := trackedCount(monitor); got != transactionMonitorMaxTracked {
+	if got := trackedCount(monitor); got != DefaultTransactionMonitorMaxTracked {
 		t.Fatalf(
 			"expected tracking table bounded to [%d]; got [%d]",
-			transactionMonitorMaxTracked,
+			DefaultTransactionMonitorMaxTracked,
 			got,
 		)
 	}
@@ -355,7 +370,10 @@ func TestTransactionMonitor_CapacityBound(t *testing.T) {
 // transactions oldest-first, so an old transaction near the stuck threshold is
 // never starved when a pass hits its time budget (Go map order is randomized).
 func TestTransactionMonitor_SnapshotByAge(t *testing.T) {
-	monitor := newTransactionMonitor(newLocalBitcoinChain())
+	monitor, err := newTransactionMonitor(newLocalBitcoinChain(), TransactionMonitorConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var h1, h2, h3 bitcoin.Hash
 	h1[0], h2[0], h3[0] = 1, 2, 3

--- a/test/config_flags.toml
+++ b/test/config_flags.toml
@@ -20,3 +20,10 @@ Dir = "/my/secure/location"
 [clientinfo]
 # Port is expected to be read from the file, not passed as a flag.
 Port = 3097
+
+[tbtc.transactionMonitor]
+# StuckThreshold is overridden by a flag; the other values come from this file.
+StuckThreshold = "1h"
+CheckInterval = "45s"
+MaxTracked = 50
+MaxTrackingAge = "12h"


### PR DESCRIPTION
Operators currently need to rebuild the client to tune stuck-transaction monitoring. Add `tbtc.transactionMonitor` settings and matching CLI flags for the stuck threshold, polling interval, tracking capacity, maximum tracking age, and per-pass time budget.

Omitted or zero values retain the existing defaults (6h, 5m, 1,000 transactions, 24h, and 2m). Negative values and a tracking age shorter than the effective stuck threshold fail startup validation. Document the settings in the sample configuration.

CI runs public Electrum checks separately from the other Go integration tests. Endpoint timeouts are advisory for unrelated PRs; Bitcoin client, Electrum configuration, test-vector, and dependency changes still require them, as do push, scheduled, and manual runs. An unavailable path-filter result also keeps the checks required.

Validation:
- Full `./cmd`, `./config`, and `./pkg/tbtc` test suites pass with Go 1.24.1.
- Focused monitor and invalid-startup tests pass with the race detector.
- Regression coverage exercises custom thresholds, capacity, expiry, polling cadence, and check budgets, plus config-file/CLI precedence and node wiring.
- `go vet ./cmd ./config ./pkg/tbtc`, `go build ./...`, gofmt, and `git diff --check` pass.

Fixes #4176.
