### PR TITLE
build(ecdsa): upgrade TypeChain to 8 for ethers v5

### DIFF
--- a/solidity/ecdsa/hardhat.config.ts
+++ b/solidity/ecdsa/hardhat.config.ts
@@ -273,6 +273,7 @@ const config: HardhatUserConfig = {
     timeout: 60000,
   },
   typechain: {
+    target: "ethers-v5",
     outDir: "typechain",
   },
   docgen: {

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -45,8 +45,8 @@
     "@openzeppelin/hardhat-upgrades": "^1.20.4",
     "@tenderly/hardhat-tenderly": ">=1.0.13 <1.2.0",
     "@thesis-co/eslint-config": "https://codeload.github.com/thesis/eslint-config/tar.gz/778365bbebb6b056bf973d25c57b8b466d21cbcf",
-    "@typechain/ethers-v5": "^8.0.5",
-    "@typechain/hardhat": "^4.0.0",
+    "@typechain/ethers-v5": "^11.1.2",
+    "@typechain/hardhat": "^7.0.0",
     "@types/chai": "^4.3.0",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^9.1.0",
@@ -68,7 +68,7 @@
     "solhint-config-keep": "https://codeload.github.com/keep-network/solhint-config-keep/tar.gz/5e1751e58c0f1c507305ffc8c7f6c58047657ada",
     "solidity-docgen": "^0.6.0-beta.35",
     "ts-node": "^10.4.0",
-    "typechain": "^6.1.0",
+    "typechain": "^8.3.2",
     "typescript": "^6.0.3"
   },
   "dependencies": {

--- a/solidity/ecdsa/test/DKGValidator.test.ts
+++ b/solidity/ecdsa/test/DKGValidator.test.ts
@@ -13,15 +13,15 @@ import {
 } from "./utils/dkg"
 import ecdsaData from "./data/ecdsa"
 
-import type { IWalletOwner } from "../typechain/IWalletOwner"
-import type { Mock } from "./helpers/mock"
-import type { DkgResult } from "./utils/dkg"
-import type { Operator } from "./utils/operators"
 import type {
+  IWalletOwner,
   SortitionPool,
   EcdsaDkgValidator,
   WalletRegistry,
 } from "../typechain"
+import type { Mock } from "./helpers/mock"
+import type { DkgResult } from "./utils/dkg"
+import type { Operator } from "./utils/operators"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 

--- a/solidity/ecdsa/test/WalletRegistry.Authorization.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Authorization.test.ts
@@ -11,11 +11,8 @@ import {
 } from "./fixtures"
 import { legacyTokenStakingAt } from "./utils/operators"
 
-import type { IWalletOwner } from "../typechain/IWalletOwner"
-import type { Mock } from "./helpers/mock"
-import type { ContractTransaction } from "ethers"
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type {
+  IWalletOwner,
   WalletRegistry,
   SortitionPool,
   TokenStaking,
@@ -24,6 +21,9 @@ import type {
   WalletRegistryGovernance,
   IStaking,
 } from "../typechain"
+import type { Mock } from "./helpers/mock"
+import type { ContractTransaction } from "ethers"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 
 const { mineBlocks } = helpers.time
 const { to1e18 } = helpers.number

--- a/solidity/ecdsa/test/WalletRegistry.CustomErrors.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.CustomErrors.test.ts
@@ -12,17 +12,17 @@ import {
   setupAllowlist,
 } from "./fixtures"
 
-import type { IWalletOwner } from "../typechain/IWalletOwner"
-import type { IRandomBeacon } from "../typechain/IRandomBeacon"
-import type { Mock } from "./helpers/mock"
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type {
+  IWalletOwner,
+  IRandomBeacon,
   WalletRegistry,
   SortitionPool,
   TokenStaking,
   T,
   WalletRegistryGovernance,
 } from "../typechain"
+import type { Mock } from "./helpers/mock"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 
 const { to1e18 } = helpers.number
 const { createSnapshot, restoreSnapshot } = helpers.snapshot

--- a/solidity/ecdsa/test/WalletRegistry.Deployment.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Deployment.test.ts
@@ -5,8 +5,11 @@ import chaiAsPromised from "chai-as-promised"
 
 import type { Contract } from "ethers"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import type { WalletRegistry, WalletRegistryGovernance } from "../typechain"
-import type { TransparentUpgradeableProxy } from "../typechain/TransparentUpgradeableProxy"
+import type {
+  WalletRegistry,
+  WalletRegistryGovernance,
+  TransparentUpgradeableProxy,
+} from "../typechain"
 
 chai.use(chaiAsPromised)
 

--- a/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.Parameters.test.ts
@@ -3,15 +3,15 @@ import { expect } from "chai"
 
 import { walletRegistryFixture } from "./fixtures"
 
-import type { IWalletOwner } from "../typechain/IWalletOwner"
-import type { Mock } from "./helpers/mock"
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type {
+  IWalletOwner,
   WalletRegistry,
   WalletRegistryStub,
   IRandomBeacon,
   WalletRegistryGovernance,
 } from "../typechain"
+import type { Mock } from "./helpers/mock"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 

--- a/solidity/ecdsa/test/WalletRegistry.RandomBeacon.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.RandomBeacon.test.ts
@@ -6,16 +6,16 @@ import { expectCalledWith } from "./helpers/mock"
 import { dkgState, walletRegistryFixture } from "./fixtures"
 import { upgradeRandomBeacon } from "./utils/governance"
 
-import type { IWalletOwner } from "../typechain/IWalletOwner"
-import type { Mock } from "./helpers/mock"
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type {
+  IWalletOwner,
   IRandomBeacon,
   RandomBeaconStub,
   RandomBeaconStub__factory,
   WalletRegistry,
   WalletRegistryStub,
 } from "../typechain"
+import type { Mock } from "./helpers/mock"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { ContractTransaction } from "ethers"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot

--- a/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
+++ b/solidity/ecdsa/test/WalletRegistry.WalletCreation.test.ts
@@ -20,9 +20,8 @@ import { legacyTokenStakingAt } from "./utils/operators"
 
 import type { Operator } from "./utils/operators"
 import type { BigNumber, ContractTransaction, Signer } from "ethers"
-import type { IWalletOwner } from "../typechain/IWalletOwner"
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type {
+  IWalletOwner,
   SortitionPool,
   WalletRegistry,
   WalletRegistryStub,
@@ -30,6 +29,7 @@ import type {
   IRandomBeacon,
   DkgChallenger,
 } from "../typechain"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import type { DkgResult, DkgResultSubmittedEventArgs } from "./utils/dkg"
 import type { Mock } from "./helpers/mock"
 

--- a/solidity/ecdsa/test/fixtures/index.ts
+++ b/solidity/ecdsa/test/fixtures/index.ts
@@ -50,10 +50,8 @@ import { createMock } from "../helpers/mock"
 import { registerOperators } from "../utils/operators"
 import { fakeRandomBeacon } from "../utils/randomBeacon"
 
-import type { IWalletOwner } from "../../typechain/IWalletOwner"
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-import type { Operator } from "../utils/operators"
 import type {
+  IWalletOwner,
   SortitionPool,
   ReimbursementPool,
   WalletRegistry,
@@ -64,6 +62,8 @@ import type {
   IRandomBeacon,
   Allowlist,
 } from "../../typechain"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import type { Operator } from "../utils/operators"
 import type { Mock } from "../helpers/mock"
 
 const { to1e18 } = helpers.number

--- a/solidity/ecdsa/test/utils/dkg.ts
+++ b/solidity/ecdsa/test/utils/dkg.ts
@@ -12,8 +12,8 @@ import type { SortitionPool, WalletRegistry } from "../../typechain"
 import type { Operator } from "./operators"
 import type {
   DkgResultSubmittedEvent,
-  ResultStruct,
-} from "../../typechain/EcdsaDkg"
+  EcdsaDkg,
+} from "../../typechain/contracts/WalletRegistry"
 
 const { provider } = ethers
 
@@ -284,7 +284,7 @@ export function hashDKGMembers(
 export interface DkgResultSubmittedEventArgs {
   resultHash: string
   seed: BigNumber
-  result: ResultStruct
+  result: EcdsaDkg.ResultStruct
 }
 
 // Decode this event explicitly. The assertion was introduced as a workaround

--- a/solidity/ecdsa/yarn.lock
+++ b/solidity/ecdsa/yarn.lock
@@ -1273,8 +1273,8 @@ __metadata:
     "@tenderly/hardhat-tenderly": "npm:>=1.0.13 <1.2.0"
     "@thesis-co/eslint-config": "https://codeload.github.com/thesis/eslint-config/tar.gz/778365bbebb6b056bf973d25c57b8b466d21cbcf"
     "@threshold-network/solidity-contracts": "npm:1.3.0-dev.14"
-    "@typechain/ethers-v5": "npm:^8.0.5"
-    "@typechain/hardhat": "npm:^4.0.0"
+    "@typechain/ethers-v5": "npm:^11.1.2"
+    "@typechain/hardhat": "npm:^7.0.0"
     "@types/chai": "npm:^4.3.0"
     "@types/chai-as-promised": "npm:^7.1.5"
     "@types/mocha": "npm:^9.1.0"
@@ -1296,7 +1296,7 @@ __metadata:
     solhint-config-keep: "https://codeload.github.com/keep-network/solhint-config-keep/tar.gz/5e1751e58c0f1c507305ffc8c7f6c58047657ada"
     solidity-docgen: "npm:^0.6.0-beta.35"
     ts-node: "npm:^10.4.0"
-    typechain: "npm:^6.1.0"
+    typechain: "npm:^8.3.2"
     typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
@@ -2210,33 +2210,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typechain/ethers-v5@npm:^8.0.5":
-  version: 8.0.5
-  resolution: "@typechain/ethers-v5@npm:8.0.5"
+"@typechain/ethers-v5@npm:^11.1.2":
+  version: 11.1.2
+  resolution: "@typechain/ethers-v5@npm:11.1.2"
   dependencies:
     lodash: "npm:^4.17.15"
     ts-essentials: "npm:^7.0.1"
   peerDependencies:
     "@ethersproject/abi": ^5.0.0
-    "@ethersproject/bytes": ^5.0.0
     "@ethersproject/providers": ^5.0.0
     ethers: ^5.1.3
-    typechain: ^6.0.4
-    typescript: ">=4.0.0"
-  checksum: 10c0/2febc9ff0356628b7e1c5e744e44077b3f077e6bab453f315679ae182c71f42fb94fc6c088f2cc8438530efab0e234d7554a78590426ed0ddf51e74d3e6be1fb
+    typechain: ^8.3.2
+    typescript: ">=4.3.0"
+  checksum: 10c0/5da6109ded6e02701e5ad718479b8a316011c5366adcbfbd8b7ee1c149c02960714c6906d823d76ab1839046aad127f9c8793f4b36a65f4299d7ce4314265ae1
   languageName: node
   linkType: hard
 
-"@typechain/hardhat@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@typechain/hardhat@npm:4.0.0"
+"@typechain/hardhat@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@typechain/hardhat@npm:7.0.0"
   dependencies:
     fs-extra: "npm:^9.1.0"
   peerDependencies:
-    hardhat: ^2.0.10
-    lodash: ^4.17.15
-    typechain: ^7.0.0
-  checksum: 10c0/f1004bfb11e08ea786a930401be0d22bab58eb1ee3c8901baa8cd467e45fe8a451d6f1e6b86d53ac84338c9fd3b7f422184d68274cbf7877196e695e2e301238
+    "@ethersproject/abi": ^5.4.7
+    "@ethersproject/providers": ^5.4.7
+    "@typechain/ethers-v5": ^11.0.0
+    ethers: ^5.4.7
+    hardhat: ^2.9.9
+    typechain: ^8.2.0
+  checksum: 10c0/80732203ec94fd6933eedbef24d2b74ce167e0bdaf697ca1a98edbcb88775814a02e1e0fabdb2fd1e53d53730204fcad392580b42c0b47beeb30c403535dd652
   languageName: node
   linkType: hard
 
@@ -6323,6 +6325,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:7.1.7":
+  version: 7.1.7
+  resolution: "glob@npm:7.1.7"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.0.4"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10c0/173245e6f9ccf904309eb7ef4a44a11f3bf68e9e341dff5a28b5db0dd7123b7506daf41497f3437a0710f57198187b758c2351eeaabce4d16935e956920da6a4
+  languageName: node
+  linkType: hard
+
 "glob@npm:^10.3.10, glob@npm:^10.4.5":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
@@ -6350,7 +6366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.6":
+"glob@npm:^7.1.2, glob@npm:^7.1.3":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -9188,7 +9204,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.1.2, prettier@npm:^2.5.1":
+"prettier@npm:^2.3.1":
+  version: 2.8.8
+  resolution: "prettier@npm:2.8.8"
+  bin:
+    prettier: bin-prettier.js
+  checksum: 10c0/463ea8f9a0946cd5b828d8cf27bd8b567345cf02f56562d5ecde198b91f47a76b7ac9eae0facd247ace70e927143af6135e8cf411986b8cb8478784a4d6d724a
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.5.1":
   version: 2.5.1
   resolution: "prettier@npm:2.5.1"
   bin:
@@ -11052,25 +11077,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typechain@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "typechain@npm:6.1.0"
+"typechain@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "typechain@npm:8.3.2"
   dependencies:
     "@types/prettier": "npm:^2.1.1"
-    debug: "npm:^4.1.1"
+    debug: "npm:^4.3.1"
     fs-extra: "npm:^7.0.0"
-    glob: "npm:^7.1.6"
+    glob: "npm:7.1.7"
     js-sha3: "npm:^0.8.0"
     lodash: "npm:^4.17.15"
     mkdirp: "npm:^1.0.4"
-    prettier: "npm:^2.1.2"
+    prettier: "npm:^2.3.1"
     ts-command-line-args: "npm:^2.2.0"
     ts-essentials: "npm:^7.0.1"
   peerDependencies:
-    typescript: ">=4.1.0"
+    typescript: ">=4.3.0"
   bin:
     typechain: dist/cli/cli.js
-  checksum: 10c0/85e6e00e169c95245d9acfc46143677ddac562c4ec853fa4c06b519f0509ec9e9dfc810c8537afb144366206909f9ed5e49e4292a7d34df949705f956c7abb9f
+  checksum: 10c0/1ea660cc7c699c6ac68da67b76454eb4e9395c54666d924ca67f983ae8eb5b5e7dab0a576beb55dbfad75ea784a3f68cb1ca019d332293b7291731c156ead5b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
ECDSA's TypeChain 6 factories produce implicit-any diagnostics that block strict TypeScript. Upgrade to TypeChain 8.3.2, the ethers-v5 target 11.1.2, and the compatible Hardhat plugin 7.0.0. Pin the code-generation target to ethers-v5 and move imports to the new barrel/source layout, including the EcdsaDkg namespace exported through WalletRegistry.

Stacked on #4208. Closes #4212.

Validation on Node 24.11.1 with Yarn 4.8.1: clean contract compilation and binding generation, `tsc --noEmit`, export compilation, and full lint pass. The full ECDSA suite passes: 673 passing, 44 existing pending, 0 failing.
