### PR TITLE
build(solidity): run contract images as node user

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: True if the image should be published
     required: true
     default: "false"
+  load:
+    description: True to load the built image into the local Docker daemon (for post-build verification steps); ignored when push is true
+    required: false
+    default: "false"
   gcrJsonKey:
     description: JSON key for Google Container Registry service account (required if push is true)
     required: false
@@ -69,6 +73,7 @@ runs:
         labels: |
           revision=${{ github.sha }}
         push: ${{ inputs.push == 'true' }}
+        load: ${{ inputs.push != 'true' && inputs.load == 'true' }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -187,7 +187,14 @@ jobs:
         with:
           imageName: keep-ecdsa-hardhat
           push: false
+          load: true
           context: ./solidity/ecdsa
+
+      - name: Verify non-root runtime user
+        run: |
+          docker run --rm --entrypoint sh "$IMAGE_NAME" -c 'test "$(id -u)" = 1000 && test "$(id -g)" = 1000'
+          docker run --rm --entrypoint sh "$IMAGE_NAME" -c 'test -w "$WORK_DIR"'
+          docker run --rm "$IMAGE_NAME" --help >/dev/null
 
   # Verifies that hardhat-deploy's `export`/`export.json` output - the
   # artifact shape consumed downstream by @keep-network/tbtc-v2 - stays

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -175,6 +175,13 @@ jobs:
           imageName: keep-random-beacon-hardhat
           context: ./solidity/random-beacon
           push: false
+          load: true
+
+      - name: Verify non-root runtime user
+        run: |
+          docker run --rm --entrypoint sh "$IMAGE_NAME" -c 'test "$(id -u)" = 1000 && test "$(id -g)" = 1000'
+          docker run --rm --entrypoint sh "$IMAGE_NAME" -c 'test -w "$WORK_DIR"'
+          docker run --rm "$IMAGE_NAME" --help >/dev/null
 
   # Enforces the core safety constraint stated in issue #4216 for the
   # hardhat-deploy v1 upgrade: `export/` and `export.json` (the deploy

--- a/solidity/ecdsa/Dockerfile
+++ b/solidity/ecdsa/Dockerfile
@@ -8,17 +8,19 @@ RUN apk add --update --no-cache \
     rm -rf /usr/share/man
 
 ENV WORK_DIR=/ecdsa
+ENV HOME=/home/node
+ENV COREPACK_DEFAULT_TO_LATEST=0
 
-RUN mkdir -p $WORK_DIR
+RUN corepack enable && mkdir -p $WORK_DIR && chown node:node $WORK_DIR
 WORKDIR $WORK_DIR
+USER node
 
 # Use `https://` instead of unauthenticated `git://` protocol.
 RUN git config --global url."https://".insteadOf git://
 
-COPY package*.json yarn.lock .yarnrc.yml ./
-ENV COREPACK_DEFAULT_TO_LATEST=0
-RUN corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install --immutable
+COPY --chown=node:node package*.json yarn.lock .yarnrc.yml ./
+RUN corepack prepare yarn@4.12.0 --activate && yarn install --immutable
 
-COPY . ./
+COPY --chown=node:node . ./
 
 ENTRYPOINT ["npx", "hardhat"]

--- a/solidity/ecdsa/Dockerfile
+++ b/solidity/ecdsa/Dockerfile
@@ -11,6 +11,11 @@ ENV WORK_DIR=/ecdsa
 ENV HOME=/home/node
 ENV COREPACK_DEFAULT_TO_LATEST=0
 
+# `corepack enable` must run as root: it writes shims into root-owned
+# /usr/local/bin. `corepack prepare` (below, after `USER node`) must run as
+# node: it writes Corepack's per-user cache under $HOME. `chown` targets only
+# $WORK_DIR here because `yarn install` creates node_modules inside it;
+# dependency/source ownership is set later via `COPY --chown`.
 RUN corepack enable && mkdir -p $WORK_DIR && chown node:node $WORK_DIR
 WORKDIR $WORK_DIR
 USER node

--- a/solidity/random-beacon/Dockerfile
+++ b/solidity/random-beacon/Dockerfile
@@ -11,6 +11,11 @@ ENV WORK_DIR=/random-beacon
 ENV HOME=/home/node
 ENV COREPACK_DEFAULT_TO_LATEST=0
 
+# `corepack enable` must run as root: it writes shims into root-owned
+# /usr/local/bin. `corepack prepare` (below, after `USER node`) must run as
+# node: it writes Corepack's per-user cache under $HOME. `chown` targets only
+# $WORK_DIR here because `yarn install` creates node_modules inside it;
+# dependency/source ownership is set later via `COPY --chown`.
 RUN corepack enable && mkdir -p $WORK_DIR && chown node:node $WORK_DIR
 WORKDIR $WORK_DIR
 USER node

--- a/solidity/random-beacon/Dockerfile
+++ b/solidity/random-beacon/Dockerfile
@@ -8,17 +8,19 @@ RUN apk add --update --no-cache \
     rm -rf /usr/share/man
 
 ENV WORK_DIR=/random-beacon
+ENV HOME=/home/node
+ENV COREPACK_DEFAULT_TO_LATEST=0
 
-RUN mkdir -p $WORK_DIR
+RUN corepack enable && mkdir -p $WORK_DIR && chown node:node $WORK_DIR
 WORKDIR $WORK_DIR
+USER node
 
 # Use `https://` instead of unauthenticated `git://` protocol.
 RUN git config --global url."https://".insteadOf git://
 
-COPY package*.json yarn.lock .yarnrc.yml ./
-ENV COREPACK_DEFAULT_TO_LATEST=0
-RUN corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install --immutable
+COPY --chown=node:node package*.json yarn.lock .yarnrc.yml ./
+RUN corepack prepare yarn@4.12.0 --activate && yarn install --immutable
 
-COPY . ./
+COPY --chown=node:node . ./
 
 ENTRYPOINT ["npx", "hardhat"]


### PR DESCRIPTION
Stacked on #4313, which fixes the pre-existing Yarn/Git 2.52 clone failure.

Both contract CLI images currently install and run as root. Switch ECDSA and Random Beacon to the existing `node` user with `/home/node` as its home.

Create the work directory and Corepack shims as root, then configure Git and install dependencies as `node`. Copy manifests and sources with `--chown=node:node` so the work directory, dependencies, and user caches remain writable without recursively rewriting the node_modules layer. The HTTPS Git rewrite remains in the runtime user's global config.

Validation:

- GitHub CI passed for both packages, including contract tests, lint, export byte-identity checks, deployment dry runs, and builds of the unmodified Dockerfiles.
- Local Linux ARM runtime probes passed for both images: UID/GID 1000, source/dependency ownership, writable work and cache directories, HTTPS Git rewrite, pinned Yarn startup, `hardhat --help`, and complete Solidity compilation with the compiler cache owned by `node`.
- Local runtime images used Git dependency archives whose complete checksums match the committed lockfiles. Cold local ARM builds got past the fixed clone invocation but failed while packing the historical thesis dependency. The cache was supplied only through temporary validation Dockerfiles; the PR does not add it to the images.
- `git diff --check` passed.

Closes #4307.
