### PR TITLE
build: use Go 1.26.8 and preserve glibc 2.31 compatibility

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -81,9 +81,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.24.1'
+          go-version-file: "go.mod"
 
       - name: Verify vendored btcec byte identity vs upstream v0.22.3
         run: |
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - name: gofmt
@@ -357,7 +357,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - run: go vet
@@ -370,13 +370,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - name: Staticcheck
         uses: dominikh/staticcheck-action@v1.4.0
         with:
-          version: "2025.1.1"
+          version: "2026.1"
           install-go: false
           checks: "-SA1019"
 

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -268,6 +268,17 @@ jobs:
           push: false
           context: .
 
+      - name: Verify Linux release compatibility
+        run: |
+          release_dir=$(mktemp -d)
+          trap 'rm -rf "$release_dir"' EXIT
+          tar -xzf out/bin/*-linux-amd64.tar.gz -C "$release_dir"
+          for image in debian:bullseye-slim ubuntu:20.04; do
+            docker run --rm --platform linux/amd64 \
+              --mount "type=bind,src=$release_dir,dst=/release,readonly" \
+              "$image" sh -ec 'getconf GNU_LIBC_VERSION; /release/keep-client --version'
+          done
+
       - name: Archive Client Binaries
         uses: actions/upload-artifact@v4
         with:
@@ -386,14 +397,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+      contents: read
     steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version-file: "go.mod"
           cache: false
 
       - name: Download Docker Build Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,17 @@ jobs:
           push: false
           context: .
 
+      - name: Verify Linux release compatibility
+        run: |
+          release_dir=$(mktemp -d)
+          trap 'rm -rf "$release_dir"' EXIT
+          tar -xzf out/bin/*-linux-amd64.tar.gz -C "$release_dir"
+          for image in debian:bullseye-slim ubuntu:20.04; do
+            docker run --rm --platform linux/amd64 \
+              --mount "type=bind,src=$release_dir,dst=/release,readonly" \
+              "$image" sh -ec 'getconf GNU_LIBC_VERSION; /release/keep-client --version'
+          done
+
       - name: Generate release notes
         id: release_notes
         run: |
@@ -172,4 +183,4 @@ jobs:
       - name: Move Docker cache
         run: |
           rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-docker-new /tmp/.buildx-cache          
+          mv /tmp/.buildx-cache-docker-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.24-alpine3.21 AS build-sources
+# Keep both builders aligned with the toolchain directive in go.mod.
+FROM golang:1.26.8-alpine3.23 AS build-sources
 
 ENV GOPATH=/go \
 	GOBIN=/go/bin \
@@ -91,7 +92,7 @@ RUN GOOS=linux make build \
 	version=$VERSION \
 	revision=$REVISION
 
-FROM alpine:3.21 as runtime-docker
+FROM alpine:3.23 as runtime-docker
 
 ENV APP_NAME=keep-client \
 	APP_DIR=/go/src/github.com/keep-network/keep-core \
@@ -111,7 +112,7 @@ CMD []
 #
 # Build Binaries
 #
-FROM golang:1.24-bullseye AS build-bins
+FROM golang:1.26.8-bookworm AS build-bins
 
 ENV APP_DIR=/go/src/github.com/keep-network/keep-core
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,9 +112,15 @@ CMD []
 #
 # Build Binaries
 #
-FROM golang:1.26.8-bookworm AS build-bins
+# Keep cgo release binaries compatible with glibc 2.31 (Debian 11/Ubuntu 20.04).
+# Copy only Go so the C compiler and libc still come from Bullseye.
+FROM buildpack-deps:bullseye AS build-bins
 
-ENV APP_DIR=/go/src/github.com/keep-network/keep-core
+COPY --from=golang:1.26.8-bookworm /usr/local/go /usr/local/go
+
+ENV PATH=/usr/local/go/bin:$PATH \
+	GOTOOLCHAIN=local \
+	APP_DIR=/go/src/github.com/keep-network/keep-core
 
 WORKDIR $APP_DIR
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/keep-network/keep-core
 
-go 1.24.0
+go 1.25.7
 
-toolchain go1.24.1
+toolchain go1.26.8
 
 replace (
 	github.com/bnb-chain/tss-lib => github.com/threshold-network/tss-lib v0.0.0-20230901144531-2e712689cfbe


### PR DESCRIPTION
The Go 1.24 Docker builders reject dependency updates that require Go 1.25.7, including the IPLD update discussed in #3991. Raise the module minimum to 1.25.7 and use Go 1.26.8 for the suggested toolchain, both Docker builders, and CI. Go 1.26 is the older supported release line; Go 1.25 left support when Go 1.27 shipped.

The source builder and runtime move to Alpine 3.23. The release builder retains Bullseye's C compiler and glibc 2.31, copying only Go from the official 1.26.8 image. This preserves cgo for native Linux/amd64 releases and compatibility with Debian 11 and Ubuntu 20.04. Both the client and tag-based release workflows now extract the actual Linux release archive and run the binary in both baseline containers before archiving or publishing it.

All `setup-go` jobs use v6 and read `go.mod`, including the vendored btcec and manual benchmark jobs; v6 honors the `toolchain` directive. The benchmark job now checks out the repository to read that file. Staticcheck moves to 2026.1 for Go 1.26 support.

This targets `dev` and implements the standalone toolchain step of #3991. All module dependency versions and `go.sum` remain unchanged; the issue's separate x/crypto, telemetry, and IPLD/libp2p reviews remain follow-ups.

Validation:

- The original PR's CI Linux release artifact fails at startup on both Debian 11 and Ubuntu 20.04 with missing `GLIBC_2.32` and `GLIBC_2.34` symbols, confirming that the added check detects the regression.
- The updated Linux/amd64 builder reports Go 1.26.8, glibc 2.31, and `CGO_ENABLED=1`.
- [CI on the final commit](https://github.com/threshold-network/keep-core/actions/runs/34245079426/job/102124924005) passes the full Go unit suite, coverage gate, Docker runtime build, Linux/macOS release packaging, and startup of the rebuilt Linux archive on both Debian 11 and Ubuntu 20.04. Formatting, vet, Staticcheck, gosec, and vendored btcec verification/tests also pass.
- Workflow YAML, the compatibility step's Bash syntax, Go 1.26.8 formatting, and `git diff --check` pass.
- The separate client integration job also passes. All applicable CI checks are green on `97b4e1ce5a26a6db467f322e619de059d844b61d`.

References: [Go release policy and versions](https://go.dev/doc/devel/release), [Staticcheck 2026.1](https://staticcheck.dev/changes/2026.1/).
