### PR TITLE
build(solidity): update Yarn for Git 2.52 compatibility

### DIFF
--- a/solidity/ecdsa/Dockerfile
+++ b/solidity/ecdsa/Dockerfile
@@ -17,7 +17,7 @@ RUN git config --global url."https://".insteadOf git://
 
 COPY package*.json yarn.lock .yarnrc.yml ./
 ENV COREPACK_DEFAULT_TO_LATEST=0
-RUN corepack enable && corepack prepare yarn@4.8.1 --activate && yarn install --immutable
+RUN corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install --immutable
 
 COPY . ./
 

--- a/solidity/ecdsa/package.json
+++ b/solidity/ecdsa/package.json
@@ -15,7 +15,7 @@
     "export.json"
   ],
   "scripts": {
-    "install:deps": "corepack enable && corepack prepare yarn@4.8.1 --activate && yarn install",
+    "install:deps": "corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install",
     "prepare": "npx tsc -p tsconfig.export.json",
     "format": "npm run lint",
     "format:fix": "npm run lint:fix",
@@ -84,5 +84,5 @@
     "ethereumjs-abi": "npm:0.6.8",
     "get-func-name": "^2.0.2"
   },
-  "packageManager": "yarn@4.8.1+sha512.bc946f2a022d7a1a38adfc15b36a66a3807a67629789496c3714dd1703d2e6c6b1c69ff9ec3b43141ac7a1dd853b7685638eb0074300386a59c18df351ef8ff6"
+  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8"
 }

--- a/solidity/random-beacon/Dockerfile
+++ b/solidity/random-beacon/Dockerfile
@@ -17,7 +17,7 @@ RUN git config --global url."https://".insteadOf git://
 
 COPY package*.json yarn.lock .yarnrc.yml ./
 ENV COREPACK_DEFAULT_TO_LATEST=0
-RUN corepack enable && corepack prepare yarn@4.8.1 --activate && yarn install --immutable
+RUN corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install --immutable
 
 COPY . ./
 

--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -14,7 +14,7 @@
     "export.json"
   ],
   "scripts": {
-    "install:deps": "corepack enable && corepack prepare yarn@4.8.1 --activate && yarn install",
+    "install:deps": "corepack enable && corepack prepare yarn@4.12.0 --activate && yarn install",
     "clean": "hardhat clean && rm -rf cache/ export/ external/npm typechain/ export.json",
     "build": "hardhat compile",
     "test": "hardhat typechain && hardhat check-accounts-count && USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_BEACON=true hardhat test",
@@ -78,5 +78,5 @@
   "resolutions": {
     "ethereumjs-abi": "npm:0.6.8"
   },
-  "packageManager": "yarn@4.8.1+sha512.bc946f2a022d7a1a38adfc15b36a66a3807a67629789496c3714dd1703d2e6c6b1c69ff9ec3b43141ac7a1dd853b7685638eb0074300386a59c18df351ef8ff6"
+  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8"
 }


### PR DESCRIPTION
Fresh contract image builds fail when Alpine installs Git 2.52: Yarn 4.8.1 passes `-c core.autocrlf=false` as one argument to `git clone`, which Git now rejects with `invalid key:  core.autocrlf`.

Pin both Solidity packages to Yarn 4.12.0, the first release containing [the upstream clone-argument fix](https://github.com/yarnpkg/berry/pull/6983). Update the Corepack integrity pins, install scripts, and Docker preparation commands together. Both Yarn dependency lockfiles are unchanged.

This is the prerequisite for the non-root Docker change in #4311 (issue #4307). The unchanged root-based `dev` Dockerfile reproduced the same Git failure locally. Validation: Corepack verified the new CLI integrity pin. Both packages passed `yarn install --immutable --mode=skip-build` with unchanged lockfiles. GitHub CI passed for both packages, including contract tests, lint, export byte-identity checks, deployment dry runs, and image builds. The non-root stack is validated separately in #4311.
