### PR TITLE
Check integer conversion boundaries and enable G115

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -324,7 +324,7 @@ jobs:
       - uses: securego/gosec@master
         with:
           args: |
-            -exclude=G115,G118
+            -exclude=G118
             -exclude-dir=pkg/chain/ethereum/beacon/gen
             -exclude-dir=pkg/chain/ethereum/ecdsa/gen
             -exclude-dir=pkg/chain/ethereum/threshold/gen

--- a/docs/development/go-guidelines.adoc
+++ b/docs/development/go-guidelines.adoc
@@ -72,13 +72,11 @@ There are a few common patterns for testing in the Keep codebase:
 
 Keep numeric validation and narrowing in the same function. A checked conversion
 should return the converted value and an error, so callers cannot accidentally
-validate one value and cast another. Use `group.MemberIndexFromUint32` for member
-indices decoded from protocol messages or persisted signers. It checks the type
-range; the protocol still checks actual group membership.
+validate one value and cast another. Use `group.MemberIndexFromUint32` for member indices decoded from protocol messages or persisted signers. It checks the type range; wire/protocol messages get their membership re-checked downstream, but persisted signer records do not, so persisted-signer callers must reject zero at decode time instead. Note: `MemberIndex` is currently a type alias, not a defined type, so this helper is a convention, not a compiler-enforced guarantee; a future refactor to a defined type would close this gap.
 
 Use `new(big.Int).SetUint64(value)` to construct a nonnegative `big.Int` from an
 unsigned block number or transaction index. When serializing a `big.Int` into a
-fixed-width unsigned field, check `IsUint64` first. For signed Bitcoin amounts,
+fixed-width unsigned field, check `IsUint64` first. For narrower unsigned destinations, also check the destination type's upper bound before converting. For signed Bitcoin amounts,
 reject negative inputs before converting to unsigned ABI fields and check the
 upper bound before converting unsigned responses to `int64`. Check arithmetic
 before it can overflow; a check on an already-wrapped fee cannot recover the
@@ -89,8 +87,9 @@ value. Existing deterministic retry and coordination seeds use all 64 bits,
 including the sign bit, and Bitcoin version fields preserve their signed 32-bit
 wire encoding. Do not reject, mask, or clamp these values: doing so would change
 protocol behavior. Such conversions use a local `#nosec G115` comment explaining
-the representation contract. Other local exceptions identify the upstream
-library or internal test-only range guarantee. Do not exclude G115 globally or
+the representation contract. Other local exceptions identify the concrete
+upstream-library, domain, or test-only range guarantee that makes the
+conversion safe. Do not exclude G115 globally or
 annotate a conversion without checking its callers and bounds.
 
 Run the G115 check with the same generated-code exclusions used by CI:

--- a/docs/development/go-guidelines.adoc
+++ b/docs/development/go-guidelines.adoc
@@ -67,3 +67,39 @@ There are a few common patterns for testing in the Keep codebase:
   information is deemed useful, it can be included before the initial newline.
   See `pkg/internal/testutils` for an example of an assert helper that uses this
   style.
+
+=== Integer conversions
+
+Keep numeric validation and narrowing in the same function. A checked conversion
+should return the converted value and an error, so callers cannot accidentally
+validate one value and cast another. Use `group.MemberIndexFromUint32` for member
+indices decoded from protocol messages or persisted signers. It checks the type
+range; the protocol still checks actual group membership.
+
+Use `new(big.Int).SetUint64(value)` to construct a nonnegative `big.Int` from an
+unsigned block number or transaction index. When serializing a `big.Int` into a
+fixed-width unsigned field, check `IsUint64` first. For signed Bitcoin amounts,
+reject negative inputs before converting to unsigned ABI fields and check the
+upper bound before converting unsigned responses to `int64`. Check arithmetic
+before it can overflow; a check on an already-wrapped fee cannot recover the
+original value.
+
+Some conversions intentionally preserve a bit pattern rather than a numeric
+value. Existing deterministic retry and coordination seeds use all 64 bits,
+including the sign bit, and Bitcoin version fields preserve their signed 32-bit
+wire encoding. Do not reject, mask, or clamp these values: doing so would change
+protocol behavior. Such conversions use a local `#nosec G115` comment explaining
+the representation contract. Other local exceptions identify the upstream
+library or internal test-only range guarantee. Do not exclude G115 globally or
+annotate a conversion without checking its callers and bounds.
+
+Run the G115 check with the same generated-code exclusions used by CI:
+
+[source,shell]
+----
+gosec -include=G115 \
+  -exclude-dir=pkg/chain/ethereum/beacon/gen \
+  -exclude-dir=pkg/chain/ethereum/ecdsa/gen \
+  -exclude-dir=pkg/chain/ethereum/threshold/gen \
+  -exclude-dir=pkg/chain/ethereum/tbtc/gen ./...
+----

--- a/docs/development/go-guidelines.adoc
+++ b/docs/development/go-guidelines.adoc
@@ -72,15 +72,23 @@ There are a few common patterns for testing in the Keep codebase:
 
 Keep numeric validation and narrowing in the same function. A checked conversion
 should return the converted value and an error, so callers cannot accidentally
-validate one value and cast another. Use `group.MemberIndexFromUint32` for member indices decoded from protocol messages or persisted signers. It checks the type range; wire/protocol messages get their membership re-checked downstream, but persisted signer records do not, so persisted-signer callers must reject zero at decode time instead. Note: `MemberIndex` is currently a type alias, not a defined type, so this helper is a convention, not a compiler-enforced guarantee; a future refactor to a defined type would close this gap.
+validate one value and cast another. Use `group.MemberIndexFromUint32` for
+member indices decoded from protocol messages or persisted signers. It checks
+the type range; wire/protocol messages get their membership re-checked
+downstream, but persisted signer records do not, so persisted-signer callers
+must reject zero at decode time instead. Note: `MemberIndex` is currently a
+type alias, not a defined type, so this helper is a convention, not a
+compiler-enforced guarantee; a future refactor to a defined type would close
+this gap.
 
 Use `new(big.Int).SetUint64(value)` to construct a nonnegative `big.Int` from an
 unsigned block number or transaction index. When serializing a `big.Int` into a
-fixed-width unsigned field, check `IsUint64` first. For narrower unsigned destinations, also check the destination type's upper bound before converting. For signed Bitcoin amounts,
-reject negative inputs before converting to unsigned ABI fields and check the
-upper bound before converting unsigned responses to `int64`. Check arithmetic
-before it can overflow; a check on an already-wrapped fee cannot recover the
-original value.
+fixed-width unsigned field, check `IsUint64` first. For narrower unsigned
+destinations, also check the destination type's upper bound before converting.
+For signed Bitcoin amounts, reject negative inputs before converting to
+unsigned ABI fields and check the upper bound before converting unsigned
+responses to `int64`. Check arithmetic before it can overflow; a check on an
+already-wrapped fee cannot recover the original value.
 
 Some conversions intentionally preserve a bit pattern rather than a numeric
 value. Existing deterministic retry and coordination seeds use all 64 bits,

--- a/pkg/beacon/dkg/dkg.go
+++ b/pkg/beacon/dkg/dkg.go
@@ -197,6 +197,9 @@ func waitForDkgResultEvent(
 	blockCounter chain.BlockCounter,
 ) (*event.DKGResultSubmission, error) {
 	config := beaconChain.GetConfig()
+	if config.GroupSize <= 0 {
+		return nil, fmt.Errorf("invalid group size: [%v]", config.GroupSize)
+	}
 
 	timeoutBlock := startPublicationBlockHeight +
 		dkgResult.PrePublicationBlocks() +

--- a/pkg/beacon/dkg/dkg_test.go
+++ b/pkg/beacon/dkg/dkg_test.go
@@ -160,6 +160,28 @@ func TestDecideMemberFate_Timeout(t *testing.T) {
 	}
 }
 
+func TestWaitForDkgResultEvent_InvalidGroupSize(t *testing.T) {
+	setup()
+
+	localChain := local_v1.Connect(0, 3)
+
+	_, err := waitForDkgResultEvent(
+		dkgResultChannel,
+		startPublicationBlockHeight,
+		localChain,
+		blockCounter,
+	)
+
+	expectedError := fmt.Errorf("invalid group size: [%v]", 0)
+	if !reflect.DeepEqual(expectedError, err) {
+		t.Errorf(
+			"unexpected error\nexpected: %v\nactual:   %v\n",
+			expectedError,
+			err,
+		)
+	}
+}
+
 func TestResolveGroupOperators(t *testing.T) {
 	beaconConfig := &beaconchain.Config{
 		GroupSize:       5,

--- a/pkg/beacon/dkg/integer_conversion_test.go
+++ b/pkg/beacon/dkg/integer_conversion_test.go
@@ -26,9 +26,10 @@ func TestThresholdSignerMemberIndexBounds(t *testing.T) {
 			}
 			decoded := new(ThresholdSigner)
 			err = decoded.Unmarshal(data)
-			if index > 255 {
+			rejected := index > 255 || (!inMap && index == 0)
+			if rejected {
 				if err == nil {
-					t.Fatalf("accepted index %d (map: %v)", index, inMap)
+					t.Fatalf("accepted invalid index %d (map: %v)", index, inMap)
 				}
 			} else if err != nil {
 				t.Fatalf("rejected valid index %d (map: %v): %v", index, inMap, err)

--- a/pkg/beacon/dkg/integer_conversion_test.go
+++ b/pkg/beacon/dkg/integer_conversion_test.go
@@ -1,0 +1,38 @@
+package dkg
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/keep-network/keep-core/pkg/beacon/registry/gen/pb"
+)
+
+func TestThresholdSignerMemberIndexBounds(t *testing.T) {
+	publicKey := new(bn256.G2).ScalarBaseMult(big.NewInt(10)).Marshal()
+	for _, index := range []uint32{0, 1, 255, 256, math.MaxUint32} {
+		for _, inMap := range []bool{false, true} {
+			message := &pb.ThresholdSigner{MemberIndex: index, GroupPublicKey: publicKey, GroupPrivateKeyShare: "1"}
+			if inMap {
+				message.MemberIndex = 1
+				message.GroupPublicKeyShares = map[uint32][]byte{index: publicKey}
+			}
+			data, err := proto.Marshal(message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded := new(ThresholdSigner)
+			err = decoded.Unmarshal(data)
+			if index > 255 {
+				if err == nil {
+					t.Fatalf("accepted index %d (map: %v)", index, inMap)
+				}
+			} else if err != nil {
+				t.Fatalf("rejected valid index %d (map: %v): %v", index, inMap, err)
+			}
+		}
+	}
+}

--- a/pkg/beacon/dkg/marshaling.go
+++ b/pkg/beacon/dkg/marshaling.go
@@ -55,7 +55,7 @@ func (ts *ThresholdSigner) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	memberIndex, err := group.MemberIndexFromUint32(pbThresholdSigner.MemberIndex)
+	memberIndex, err := group.MemberIndexFromUint32NonZero(pbThresholdSigner.MemberIndex)
 	if err != nil {
 		return err
 	}

--- a/pkg/beacon/dkg/marshaling.go
+++ b/pkg/beacon/dkg/marshaling.go
@@ -55,8 +55,13 @@ func (ts *ThresholdSigner) Unmarshal(bytes []byte) error {
 		return err
 	}
 
+	memberIndex, err := group.MemberIndexFromUint32(pbThresholdSigner.MemberIndex)
+	if err != nil {
+		return err
+	}
+
 	groupPublicKey := new(bn256.G2)
-	_, err := groupPublicKey.Unmarshal(pbThresholdSigner.GroupPublicKey)
+	_, err = groupPublicKey.Unmarshal(pbThresholdSigner.GroupPublicKey)
 	if err != nil {
 		return err
 	}
@@ -74,7 +79,7 @@ func (ts *ThresholdSigner) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	ts.memberIndex = group.MemberIndex(pbThresholdSigner.MemberIndex)
+	ts.memberIndex = memberIndex
 	ts.groupPublicKey = groupPublicKey
 	ts.groupPrivateKeyShare = privateKeyShare
 	ts.groupPublicKeyShares = groupPublicKeyShares
@@ -89,13 +94,17 @@ func unmarshalGroupPublicKeyShares(
 	var unmarshalled = make(map[group.MemberIndex]*bn256.G2, len(shares))
 
 	for memberID, shareBytes := range shares {
+		memberIndex, err := group.MemberIndexFromUint32(memberID)
+		if err != nil {
+			return nil, err
+		}
 		share := new(bn256.G2)
-		_, err := share.Unmarshal(shareBytes)
+		_, err = share.Unmarshal(shareBytes)
 		if err != nil {
 			return nil, fmt.Errorf("could not unmarshal share [%v]", err)
 		}
 
-		unmarshalled[group.MemberIndex(memberID)] = share
+		unmarshalled[memberIndex] = share
 	}
 
 	return unmarshalled, nil

--- a/pkg/beacon/dkg/result/marshaling.go
+++ b/pkg/beacon/dkg/result/marshaling.go
@@ -2,8 +2,6 @@
 package result
 
 import (
-	"fmt"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/keep-network/keep-core/pkg/beacon/chain"
@@ -14,15 +12,6 @@ import (
 // MemberIndex is represented as uint8 in gjkr. Protobuf does not have uint8
 // type so we are using uint32. When unmarshalling message, we need to make
 // sure we do not overflow.
-const maxMemberIndex = 255
-
-func validateMemberIndex(protoIndex uint32) error {
-	if protoIndex > maxMemberIndex {
-		return fmt.Errorf("invalid member index value: [%v]", protoIndex)
-	}
-	return nil
-}
-
 // Type returns a string describing a DKGResultHashSignatureMessage type for
 // marshalling purposes.
 func (d *DKGResultHashSignatureMessage) Type() string {
@@ -49,10 +38,11 @@ func (d *DKGResultHashSignatureMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderIndex); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderIndex)
+	if err != nil {
 		return err
 	}
-	d.senderIndex = group.MemberIndex(pbMsg.SenderIndex)
+	d.senderIndex = senderID
 
 	resultHash, err := chain.DKGResultHashFromBytes(pbMsg.ResultHash)
 	if err != nil {

--- a/pkg/beacon/dkg/result/marshaling.go
+++ b/pkg/beacon/dkg/result/marshaling.go
@@ -9,9 +9,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
-// MemberIndex is represented as uint8 in gjkr. Protobuf does not have uint8
-// type so we are using uint32. When unmarshalling message, we need to make
-// sure we do not overflow.
 // Type returns a string describing a DKGResultHashSignatureMessage type for
 // marshalling purposes.
 func (d *DKGResultHashSignatureMessage) Type() string {

--- a/pkg/beacon/entry/marshaling.go
+++ b/pkg/beacon/entry/marshaling.go
@@ -7,9 +7,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
-// MemberIndex is represented as uint8 in gjkr. Protobuf does not have uint8
-// type so we are using uint32. When unmarshalling message, we need to make
-// sure we do not overflow.
 // Type returns a string describing a SignatureShareMessage's type.
 func (*SignatureShareMessage) Type() string {
 	return "relay/signature/share"

--- a/pkg/beacon/entry/marshaling.go
+++ b/pkg/beacon/entry/marshaling.go
@@ -1,8 +1,6 @@
 package entry
 
 import (
-	"fmt"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/keep-network/keep-core/pkg/beacon/entry/gen/pb"
@@ -12,15 +10,6 @@ import (
 // MemberIndex is represented as uint8 in gjkr. Protobuf does not have uint8
 // type so we are using uint32. When unmarshalling message, we need to make
 // sure we do not overflow.
-const maxMemberIndex = 255
-
-func validateMemberIndex(protoIndex uint32) error {
-	if protoIndex > maxMemberIndex {
-		return fmt.Errorf("invalid member index value: [%v]", protoIndex)
-	}
-	return nil
-}
-
 // Type returns a string describing a SignatureShareMessage's type.
 func (*SignatureShareMessage) Type() string {
 	return "relay/signature/share"
@@ -47,10 +36,11 @@ func (ssm *SignatureShareMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbSignatureShare.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbSignatureShare.SenderID)
+	if err != nil {
 		return err
 	}
-	ssm.senderID = group.MemberIndex(pbSignatureShare.SenderID)
+	ssm.senderID = senderID
 	ssm.shareBytes = pbSignatureShare.Share
 	ssm.sessionID = pbSignatureShare.SessionID
 

--- a/pkg/beacon/entry/submission.go
+++ b/pkg/beacon/entry/submission.go
@@ -2,8 +2,9 @@ package entry
 
 import (
 	"fmt"
-	"github.com/ipfs/go-log/v2"
 	"math/big"
+
+	"github.com/ipfs/go-log/v2"
 
 	beaconchain "github.com/keep-network/keep-core/pkg/beacon/chain"
 	"github.com/keep-network/keep-core/pkg/chain"
@@ -129,6 +130,10 @@ func (res *relayEntrySubmitter) waitForSubmissionEligibility(
 	groupSize int,
 	blockStep uint64,
 ) (<-chan uint64, error) {
+	if groupSize <= 0 {
+		return nil, fmt.Errorf("invalid group size: [%v]", groupSize)
+	}
+
 	// First submitter index is calculated as entry % groupSize and gives
 	// an index from range [0, groupSize-1].
 	firstSubmitterMemberIndex := new(big.Int).Mod(

--- a/pkg/beacon/entry/submission_test.go
+++ b/pkg/beacon/entry/submission_test.go
@@ -1,6 +1,10 @@
 package entry
 
-import "testing"
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
 
 func TestCalculateSubmissionQueueIndex(t *testing.T) {
 	groupSize := uint64(64)
@@ -43,5 +47,25 @@ func TestCalculateSubmissionQueueIndex(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestWaitForSubmissionEligibility_InvalidGroupSize(t *testing.T) {
+	res := &relayEntrySubmitter{}
+
+	_, err := res.waitForSubmissionEligibility(
+		[]byte{1, 2, 3},
+		0,
+		0,
+		1,
+	)
+
+	expectedError := fmt.Errorf("invalid group size: [%v]", 0)
+	if !reflect.DeepEqual(expectedError, err) {
+		t.Errorf(
+			"unexpected error\nexpected: %v\nactual:   %v\n",
+			expectedError,
+			err,
+		)
 	}
 }

--- a/pkg/beacon/gjkr/integer_conversion_test.go
+++ b/pkg/beacon/gjkr/integer_conversion_test.go
@@ -1,0 +1,36 @@
+package gjkr
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/keep-network/keep-core/pkg/beacon/gjkr/gen/pb"
+)
+
+func TestAccusationsUnmarshalValidationErrors(t *testing.T) {
+	for _, keys := range []map[uint32][]byte{{256: {1}}, {1: nil}} {
+		cases := []struct {
+			message   proto.Message
+			unmarshal func([]byte) error
+		}{
+			{
+				message:   &pb.SecretSharesAccusations{SenderID: 1, AccusedMembersKeys: keys, SessionID: "session"},
+				unmarshal: new(SecretSharesAccusationsMessage).Unmarshal,
+			},
+			{
+				message:   &pb.PointsAccusations{SenderID: 1, AccusedMembersKeys: keys, SessionID: "session"},
+				unmarshal: new(PointsAccusationsMessage).Unmarshal,
+			},
+		}
+		for _, tc := range cases {
+			data, err := proto.Marshal(tc.message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := tc.unmarshal(data); err == nil {
+				t.Fatalf("%T accepted invalid accusation keys", tc.message)
+			}
+		}
+	}
+}

--- a/pkg/beacon/gjkr/marshaling.go
+++ b/pkg/beacon/gjkr/marshaling.go
@@ -11,15 +11,6 @@ import (
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 )
 
-func validateMemberIndex(protoIndex uint32) error {
-	// Protobuf does not have uint8 type so we are using uint32. When
-	// unmarshalling message, we need to make sure we do not overflow.
-	if protoIndex > group.MaxMemberIndex {
-		return fmt.Errorf("invalid member index value: [%v]", protoIndex)
-	}
-	return nil
-}
-
 // Type returns a string describing an EphemeralPublicKeyMessage type for
 // marshaling purposes.
 func (epkm *EphemeralPublicKeyMessage) Type() string {
@@ -49,10 +40,11 @@ func (epkm *EphemeralPublicKeyMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	epkm.senderID = group.MemberIndex(pbMsg.SenderID)
+	epkm.senderID = senderID
 
 	ephemeralPublicKeys, err := unmarshalPublicKeyMap(pbMsg.EphemeralPublicKeys)
 	if err != nil {
@@ -94,10 +86,11 @@ func (mcm *MemberCommitmentsMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	mcm.senderID = group.MemberIndex(pbMsg.SenderID)
+	mcm.senderID = senderID
 
 	var commitments []*bn256.G1
 	for _, commitmentBytes := range pbMsg.Commitments {
@@ -152,14 +145,16 @@ func (psm *PeerSharesMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	psm.senderID = group.MemberIndex(pbMsg.SenderID)
+	psm.senderID = senderID
 
 	shares := make(map[group.MemberIndex]*peerShares)
 	for memberID, pbShares := range pbMsg.Shares {
-		if err := validateMemberIndex(memberID); err != nil {
+		memberIndex, err := group.MemberIndexFromUint32(memberID)
+		if err != nil {
 			return err
 		}
 
@@ -167,7 +162,7 @@ func (psm *PeerSharesMessage) Unmarshal(bytes []byte) error {
 			return fmt.Errorf("nil shares from member [%v]", memberID)
 		}
 
-		shares[group.MemberIndex(memberID)] = &peerShares{
+		shares[memberIndex] = &peerShares{
 			encryptedShareS: pbShares.EncryptedShareS,
 			encryptedShareT: pbShares.EncryptedShareT,
 		}
@@ -208,14 +203,15 @@ func (ssam *SecretSharesAccusationsMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	ssam.senderID = group.MemberIndex(pbMsg.SenderID)
+	ssam.senderID = senderID
 
 	accusedMembersKeys, err := unmarshalPrivateKeyMap(pbMsg.AccusedMembersKeys)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	ssam.accusedMembersKeys = accusedMembersKeys
@@ -257,10 +253,11 @@ func (mpspm *MemberPublicKeySharePointsMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	mpspm.senderID = group.MemberIndex(pbMsg.SenderID)
+	mpspm.senderID = senderID
 
 	var keySharePoints []*bn256.G2
 	for _, keySharePointBytes := range pbMsg.PublicKeySharePoints {
@@ -309,14 +306,15 @@ func (pam *PointsAccusationsMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	pam.senderID = group.MemberIndex(pbMsg.SenderID)
+	pam.senderID = senderID
 
 	accusedMembersKeys, err := unmarshalPrivateKeyMap(pbMsg.AccusedMembersKeys)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	pam.accusedMembersKeys = accusedMembersKeys
@@ -354,10 +352,11 @@ func (mekm *MisbehavedEphemeralKeysMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	mekm.senderID = group.MemberIndex(pbMsg.SenderID)
+	mekm.senderID = senderID
 
 	privateKeys, err := unmarshalPrivateKeyMap(pbMsg.PrivateKeys)
 	if err != nil {
@@ -389,7 +388,8 @@ func unmarshalPublicKeyMap(
 ) (map[group.MemberIndex]*ephemeral.PublicKey, error) {
 	var unmarshalled = make(map[group.MemberIndex]*ephemeral.PublicKey, len(publicKeys))
 	for memberID, publicKeyBytes := range publicKeys {
-		if err := validateMemberIndex(memberID); err != nil {
+		memberIndex, err := group.MemberIndexFromUint32(memberID)
+		if err != nil {
 			return nil, err
 		}
 
@@ -398,7 +398,7 @@ func unmarshalPublicKeyMap(
 			return nil, fmt.Errorf("could not unmarshal public key [%v]", err)
 		}
 
-		unmarshalled[group.MemberIndex(memberID)] = publicKey
+		unmarshalled[memberIndex] = publicKey
 
 	}
 
@@ -424,7 +424,8 @@ func unmarshalPrivateKeyMap(
 ) (map[group.MemberIndex]*ephemeral.PrivateKey, error) {
 	var unmarshalled = make(map[group.MemberIndex]*ephemeral.PrivateKey, len(privateKeys))
 	for memberID, privateKeyBytes := range privateKeys {
-		if err := validateMemberIndex(memberID); err != nil {
+		memberIndex, err := group.MemberIndexFromUint32(memberID)
+		if err != nil {
 			return nil, err
 		}
 
@@ -434,7 +435,7 @@ func unmarshalPrivateKeyMap(
 			)
 		}
 
-		unmarshalled[group.MemberIndex(memberID)] = ephemeral.UnmarshalPrivateKey(privateKeyBytes)
+		unmarshalled[memberIndex] = ephemeral.UnmarshalPrivateKey(privateKeyBytes)
 	}
 
 	return unmarshalled, nil

--- a/pkg/bitcoin/block.go
+++ b/pkg/bitcoin/block.go
@@ -39,6 +39,7 @@ func (bh *BlockHeader) Serialize() [BlockHeaderByteLength]byte {
 	offset := 0
 
 	// Version
+	// #nosec G115 -- Bitcoin version fields encode the exact signed 32-bit bit pattern.
 	binary.LittleEndian.PutUint32(result[offset:], uint32(bh.Version))
 	offset += 4
 
@@ -71,6 +72,7 @@ func (bh *BlockHeader) Deserialize(rawBlockHeader [BlockHeaderByteLength]byte) {
 	offset := 0
 
 	// Version
+	// #nosec G115 -- Decode the exact signed 32-bit Bitcoin version bit pattern.
 	bh.Version = int32(binary.LittleEndian.Uint32(rawBlockHeader[offset:]))
 	offset += 4
 

--- a/pkg/bitcoin/electrum/block.go
+++ b/pkg/bitcoin/electrum/block.go
@@ -29,9 +29,10 @@ func convertBlockHeader(electrumResult *electrum.GetBlockHeaderResult) (*bitcoin
 		Version:                 b.Version,
 		PreviousBlockHeaderHash: bitcoin.Hash(b.PrevBlock),
 		MerkleRootHash:          bitcoin.Hash(b.MerkleRoot),
-		Time:                    uint32(b.Timestamp.Unix()),
-		Bits:                    b.Bits,
-		Nonce:                   b.Nonce,
+		// #nosec G115 -- wire.BlockHeader.Deserialize reads the timestamp from a uint32 field.
+		Time:  uint32(b.Timestamp.Unix()),
+		Bits:  b.Bits,
+		Nonce: b.Nonce,
 	}
 
 	return result, nil

--- a/pkg/bitcoin/electrum/electrum.go
+++ b/pkg/bitcoin/electrum/electrum.go
@@ -357,6 +357,11 @@ func (c *Connection) GetLatestBlockHeight() (uint, error) {
 func (c *Connection) GetBlockHeader(
 	blockHeight uint,
 ) (*bitcoin.BlockHeader, error) {
+	if blockHeight > math.MaxUint32 {
+		return nil, fmt.Errorf("block height exceeds Electrum range: [%v]", blockHeight)
+	}
+	height := uint32(blockHeight)
+
 	getBlockHeaderResult, err := requestWithRetry(
 		c.parentCtx,
 		c,
@@ -364,7 +369,7 @@ func (c *Connection) GetBlockHeader(
 			ctx context.Context,
 			client *electrum.Client,
 		) (*electrum.GetBlockHeaderResult, error) {
-			return client.GetBlockHeader(ctx, uint32(blockHeight), 0)
+			return client.GetBlockHeader(ctx, height, 0)
 		},
 		"GetBlockHeader",
 	)
@@ -387,6 +392,11 @@ func (c *Connection) GetTransactionMerkleProof(
 	transactionHash bitcoin.Hash,
 	blockHeight uint,
 ) (*bitcoin.TransactionMerkleProof, error) {
+	if blockHeight > math.MaxUint32 {
+		return nil, fmt.Errorf("block height exceeds Electrum range: [%v]", blockHeight)
+	}
+	height := uint32(blockHeight)
+
 	txID := transactionHash.Hex(bitcoin.ReversedByteOrder)
 
 	getMerkleProofResult, err := requestWithRetry(
@@ -399,7 +409,7 @@ func (c *Connection) GetTransactionMerkleProof(
 			return client.GetMerkleProof(
 				ctx,
 				txID,
-				uint32(blockHeight),
+				height,
 			)
 		},
 		"GetMerkleProof",
@@ -593,6 +603,11 @@ func (c *Connection) getConfirmedScriptHistory(
 // GetCoinbaseTxHash gets the hash of the coinbase transaction for the given
 // block height.
 func (c *Connection) GetCoinbaseTxHash(blockHeight uint) (bitcoin.Hash, error) {
+	if blockHeight > math.MaxUint32 {
+		return bitcoin.Hash{}, fmt.Errorf("block height exceeds Electrum range: [%v]", blockHeight)
+	}
+	height := uint32(blockHeight)
+
 	txHashString, err := requestWithRetry(
 		c.parentCtx,
 		c,
@@ -600,7 +615,7 @@ func (c *Connection) GetCoinbaseTxHash(blockHeight uint) (bitcoin.Hash, error) {
 			ctx context.Context,
 			client *electrum.Client,
 		) (string, error) {
-			return client.GetHashFromPosition(ctx, uint32(blockHeight), 0)
+			return client.GetHashFromPosition(ctx, height, 0)
 		},
 		"GetHashFromPosition",
 	)
@@ -798,18 +813,7 @@ func (c *Connection) GetUtxosForPublicKeyHash(
 		},
 	)
 
-	utxos := make([]*bitcoin.UnspentTransactionOutput, len(items))
-	for i, item := range items {
-		utxos[i] = &bitcoin.UnspentTransactionOutput{
-			Outpoint: &bitcoin.TransactionOutpoint{
-				TransactionHash: item.txHash,
-				OutputIndex:     item.outputIndex,
-			},
-			Value: int64(item.value),
-		}
-	}
-
-	return utxos, nil
+	return convertUtxoItems(items)
 }
 
 // GetMempoolUtxosForPublicKeyHash gets unspent outputs of unconfirmed transactions
@@ -859,8 +863,15 @@ func (c *Connection) GetMempoolUtxosForPublicKeyHash(
 
 	items := append(p2pkhItems, p2wpkhItems...)
 
+	return convertUtxoItems(items)
+}
+
+func convertUtxoItems(items []*scriptUtxoItem) ([]*bitcoin.UnspentTransactionOutput, error) {
 	utxos := make([]*bitcoin.UnspentTransactionOutput, len(items))
 	for i, item := range items {
+		if item.value > math.MaxInt64 {
+			return nil, fmt.Errorf("UTXO value exceeds int64 range: [%v]", item.value)
+		}
 		utxos[i] = &bitcoin.UnspentTransactionOutput{
 			Outpoint: &bitcoin.TransactionOutpoint{
 				TransactionHash: item.txHash,

--- a/pkg/bitcoin/electrum/integer_conversion_test.go
+++ b/pkg/bitcoin/electrum/integer_conversion_test.go
@@ -1,0 +1,41 @@
+package electrum
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+)
+
+func TestElectrumBlockHeightBounds(t *testing.T) {
+	if strconv.IntSize < 64 {
+		t.Skip("uint cannot exceed the Electrum height range")
+	}
+	height64 := uint64(math.MaxUint32) + 1
+	height := uint(height64)
+	connection := new(Connection)
+	if _, err := connection.GetBlockHeader(height); err == nil {
+		t.Fatal("accepted out-of-range block header height")
+	}
+	if _, err := connection.GetTransactionMerkleProof(bitcoin.Hash{}, height); err == nil {
+		t.Fatal("accepted out-of-range merkle proof height")
+	}
+	if _, err := connection.GetCoinbaseTxHash(height); err == nil {
+		t.Fatal("accepted out-of-range coinbase height")
+	}
+}
+
+func TestConvertUtxoItemsAmountBounds(t *testing.T) {
+	for _, value := range []uint64{0, 1, math.MaxInt64, math.MaxInt64 + 1, math.MaxUint64} {
+		utxos, err := convertUtxoItems([]*scriptUtxoItem{{value: value, outputIndex: 3}})
+		if value > math.MaxInt64 {
+			if err == nil {
+				t.Fatalf("accepted amount %d", value)
+			}
+		} else if err != nil || len(utxos) != 1 ||
+			uint64(utxos[0].Value) != value || utxos[0].Outpoint.OutputIndex != 3 {
+			t.Fatalf("amount %d: got %v, %v", value, utxos, err)
+		}
+	}
+}

--- a/pkg/bitcoin/estimator.go
+++ b/pkg/bitcoin/estimator.go
@@ -249,8 +249,14 @@ func (tfe *TransactionFeeEstimator) EstimateFee(
 		return 0, fmt.Errorf("cannot get estimated sat/vbyte fee: [%v]", err)
 	}
 
-	if satPerVByteFee <= 0 || transactionVirtualSize <= 0 {
-		return 0, fmt.Errorf("estimated fee is less than or equal zero")
+	if transactionVirtualSize <= 0 {
+		return 0, fmt.Errorf(
+			"invalid transaction virtual size: [%v]",
+			transactionVirtualSize,
+		)
+	}
+	if satPerVByteFee <= 0 {
+		return 0, fmt.Errorf("estimated sat/vbyte fee is less than or equal zero")
 	}
 	if satPerVByteFee > math.MaxInt64/transactionVirtualSize {
 		return 0, fmt.Errorf("estimated fee exceeds int64 range")

--- a/pkg/bitcoin/estimator.go
+++ b/pkg/bitcoin/estimator.go
@@ -2,6 +2,8 @@ package bitcoin
 
 import (
 	"fmt"
+	"math"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/mempool"
@@ -247,6 +249,12 @@ func (tfe *TransactionFeeEstimator) EstimateFee(
 		return 0, fmt.Errorf("cannot get estimated sat/vbyte fee: [%v]", err)
 	}
 
+	if satPerVByteFee <= 0 || transactionVirtualSize <= 0 {
+		return 0, fmt.Errorf("estimated fee is less than or equal zero")
+	}
+	if satPerVByteFee > math.MaxInt64/transactionVirtualSize {
+		return 0, fmt.Errorf("estimated fee exceeds int64 range")
+	}
 	fee := satPerVByteFee * transactionVirtualSize
 
 	// Just in case check.

--- a/pkg/bitcoin/integer_conversion_test.go
+++ b/pkg/bitcoin/integer_conversion_test.go
@@ -1,0 +1,46 @@
+package bitcoin
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestSignedVersionWireCompatibility(t *testing.T) {
+	for _, tc := range []struct {
+		version int32
+		bytes   []byte
+	}{
+		{0, []byte{0, 0, 0, 0}},
+		{-1, []byte{255, 255, 255, 255}},
+		{math.MinInt32, []byte{0, 0, 0, 128}},
+		{math.MaxInt32, []byte{255, 255, 255, 127}},
+	} {
+		header := (&BlockHeader{Version: tc.version}).Serialize()
+		version := (&Transaction{Version: tc.version}).SerializeVersion()
+		if !bytes.Equal(header[:4], tc.bytes) || !bytes.Equal(version[:], tc.bytes) {
+			t.Fatalf("version %d changed wire encoding", tc.version)
+		}
+		decoded := new(BlockHeader)
+		decoded.Deserialize(header)
+		if decoded.Version != tc.version {
+			t.Fatalf("version %d decoded as %d", tc.version, decoded.Version)
+		}
+	}
+}
+
+func TestTransactionFeeEstimatorOverflow(t *testing.T) {
+	chain := newLocalChain()
+	for _, tc := range []struct{ rate, size int64 }{
+		{math.MaxInt64, 2}, {1<<62 + 1, 4}, {-1, 1}, {1, -1},
+	} {
+		chain.setSatPerVByteFee(tc.rate)
+		if fee, err := NewTransactionFeeEstimator(chain).EstimateFee(tc.size); err == nil {
+			t.Fatalf("accepted rate %d, size %d: %d", tc.rate, tc.size, fee)
+		}
+	}
+	chain.setSatPerVByteFee(math.MaxInt64)
+	if fee, err := NewTransactionFeeEstimator(chain).EstimateFee(1); err != nil || fee != math.MaxInt64 {
+		t.Fatalf("valid boundary: %d, %v", fee, err)
+	}
+}

--- a/pkg/bitcoin/script.go
+++ b/pkg/bitcoin/script.go
@@ -53,7 +53,10 @@ func NewScriptFromVarLenData(varLenData []byte) (Script, error) {
 	// Make sure the combined byte length of the script and the byte length
 	// of the CompactSizeUint matches the total byte length of the variable
 	// length data. Otherwise, the input data slice is malformed.
-	if uint64(scriptByteLength)+uint64(compactByteLength) != uint64(len(varLenData)) {
+	if compactByteLength < 0 || compactByteLength > len(varLenData) {
+		return nil, fmt.Errorf("malformed var len data")
+	}
+	if uint64(scriptByteLength) != uint64(len(varLenData))-uint64(compactByteLength) {
 		return nil, fmt.Errorf("malformed var len data")
 	}
 

--- a/pkg/bitcoin/transaction.go
+++ b/pkg/bitcoin/transaction.go
@@ -122,6 +122,7 @@ func (t *Transaction) Serialize(
 // 4-byte array.
 func (t *Transaction) SerializeVersion() [4]byte {
 	result := [4]byte{}
+	// #nosec G115 -- Bitcoin version fields encode the exact signed 32-bit bit pattern.
 	binary.LittleEndian.PutUint32(result[:], uint32(t.Version))
 	return result
 }

--- a/pkg/bitcoin/transaction_builder.go
+++ b/pkg/bitcoin/transaction_builder.go
@@ -164,7 +164,7 @@ func (tb *TransactionBuilder) getScript(
 	}
 
 	outputIndex := utxo.Outpoint.OutputIndex
-	if outputIndex >= uint32(len(transaction.Outputs)) {
+	if uint64(outputIndex) >= uint64(len(transaction.Outputs)) {
 		return nil, fmt.Errorf(
 			"output index [%d] out of range for transaction [%s] "+
 				"with [%d] outputs",

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -448,7 +448,7 @@ func (bc *baseChain) blockByNumber(number uint64) (*types.Header, error) {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelCtx()
 
-	return bc.client.HeaderByNumber(ctx, big.NewInt(int64(number)))
+	return bc.client.HeaderByNumber(ctx, new(big.Int).SetUint64(number))
 }
 
 // headerByNumber returns the header for the given block number. Times out
@@ -457,22 +457,22 @@ func (bc *baseChain) headerByNumber(number uint64) (*types.Header, error) {
 	ctx, cancelCtx := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelCtx()
 
-	return bc.client.HeaderByNumber(ctx, big.NewInt(int64(number)))
+	return bc.client.HeaderByNumber(ctx, new(big.Int).SetUint64(number))
 }
 
 // closerBlock check timestamps of block headers b1 and b2 and returns the one
 // whose timestamp lies closer to the requested timestamp. If the distance is
 // the same for both headers, the one with greater block number is returned.
 func closerBlock(timestamp uint64, b1, b2 *types.Header) *types.Header {
-	abs := func(x int64) int64 {
-		if x < 0 {
-			return -x
+	distance := func(blockTime uint64) uint64 {
+		if blockTime > timestamp {
+			return blockTime - timestamp
 		}
-		return x
+		return timestamp - blockTime
 	}
 
-	b1Diff := abs(int64(b1.Time - timestamp))
-	b2Diff := abs(int64(b2.Time - timestamp))
+	b1Diff := distance(b1.Time)
+	b2Diff := distance(b2.Time)
 
 	// If the differences are same, return the block with greater number.
 	if b1Diff == b2Diff {

--- a/pkg/chain/ethereum/integer_conversion_test.go
+++ b/pkg/chain/ethereum/integer_conversion_test.go
@@ -1,0 +1,60 @@
+package ethereum
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/keep-network/keep-core/pkg/bitcoin"
+)
+
+func TestCloserBlockUnsignedDistances(t *testing.T) {
+	for _, tc := range []struct {
+		timestamp, first, second uint64
+		wantSecond               bool
+	}{
+		{0, math.MaxUint64, 1, true},
+		{math.MaxUint64, 0, math.MaxUint64 - 1, true},
+		{10, 9, 11, true},
+		{math.MaxInt64, math.MaxInt64 - 1, math.MaxUint64, false},
+	} {
+		first := &types.Header{Number: big.NewInt(1), Time: tc.first}
+		second := &types.Header{Number: big.NewInt(2), Time: tc.second}
+		actual := closerBlock(tc.timestamp, first, second)
+		if (actual == second) != tc.wantSecond {
+			t.Fatalf("wrong block for timestamp %d, block times %d/%d", tc.timestamp, tc.first, tc.second)
+		}
+	}
+}
+
+func TestChainMemberIndexBounds(t *testing.T) {
+	for _, value := range []*big.Int{nil, big.NewInt(-1), big.NewInt(0), big.NewInt(256), new(big.Int).Lsh(big.NewInt(1), 64)} {
+		if _, err := memberIndexFromChain(value); err == nil {
+			t.Fatalf("accepted index %v", value)
+		}
+	}
+	for _, value := range []int64{1, 255} {
+		index, err := memberIndexFromChain(big.NewInt(value))
+		if err != nil || int64(index) != value {
+			t.Fatalf("index %d: %d, %v", value, index, err)
+		}
+	}
+}
+
+func TestProofSubmissionsRejectNegativeUtxo(t *testing.T) {
+	chain := new(TbtcChain)
+	utxo := bitcoin.UnspentTransactionOutput{Value: -1}
+	calls := []func() error{
+		func() error { return chain.SubmitRedemptionProofWithReimbursement(nil, nil, utxo, [20]byte{}) },
+		func() error { return chain.SubmitDepositSweepProofWithReimbursement(nil, nil, utxo, [20]byte{}) },
+		func() error { return chain.SubmitMovingFundsProofWithReimbursement(nil, nil, utxo, [20]byte{}) },
+		func() error { return chain.SubmitMovedFundsSweepProofWithReimbursement(nil, nil, utxo) },
+		func() error { return chain.ValidateMovingFundsProposal([20]byte{}, &utxo, nil) },
+	}
+	for i, call := range calls {
+		if err := call(); err == nil {
+			t.Fatalf("submission %d accepted negative UTXO", i)
+		}
+	}
+}

--- a/pkg/chain/ethereum/tbtc_deposit.go
+++ b/pkg/chain/ethereum/tbtc_deposit.go
@@ -167,6 +167,10 @@ func (tc *TbtcChain) SubmitDepositSweepProofWithReimbursement(
 	mainUTXO bitcoin.UnspentTransactionOutput,
 	vault common.Address,
 ) error {
+	if mainUTXO.Value < 0 {
+		return fmt.Errorf("invalid main UTXO value: [%v]", mainUTXO.Value)
+	}
+
 	bitcoinTxInfo := tbtcabi.BitcoinTxInfo3{
 		Version:      transaction.SerializeVersion(),
 		InputVector:  transaction.SerializeInputs(),
@@ -175,7 +179,7 @@ func (tc *TbtcChain) SubmitDepositSweepProofWithReimbursement(
 	}
 	sweepProof := tbtcabi.BitcoinTxProof2{
 		MerkleProof:      proof.MerkleProof,
-		TxIndexInBlock:   big.NewInt(int64(proof.TxIndexInBlock)),
+		TxIndexInBlock:   new(big.Int).SetUint64(uint64(proof.TxIndexInBlock)),
 		BitcoinHeaders:   proof.BitcoinHeaders,
 		CoinbasePreimage: proof.CoinbasePreimage,
 		CoinbaseProof:    proof.CoinbaseProof,

--- a/pkg/chain/ethereum/tbtc_dkg.go
+++ b/pkg/chain/ethereum/tbtc_dkg.go
@@ -122,7 +122,8 @@ func (tc *TbtcChain) OnDKGResultSubmitted(
 func convertDkgResultFromAbiType(
 	result ecdsaabi.EcdsaDkgResult,
 ) (*tbtc.DKGChainResult, error) {
-	if err := validateMemberIndex(result.SubmitterMemberIndex); err != nil {
+	submitterIndex, err := memberIndexFromChain(result.SubmitterMemberIndex)
+	if err != nil {
 		return nil, fmt.Errorf(
 			"unexpected submitter member index: [%v]",
 			err,
@@ -134,18 +135,19 @@ func convertDkgResultFromAbiType(
 		len(result.SigningMembersIndices),
 	)
 	for i, memberIndex := range result.SigningMembersIndices {
-		if err := validateMemberIndex(memberIndex); err != nil {
+		index, err := memberIndexFromChain(memberIndex)
+		if err != nil {
 			return nil, fmt.Errorf(
 				"unexpected signing member index: [%v]",
 				err,
 			)
 		}
 
-		signingMembersIndexes[i] = group.MemberIndex(memberIndex.Uint64())
+		signingMembersIndexes[i] = index
 	}
 
 	return &tbtc.DKGChainResult{
-		SubmitterMemberIndex:     group.MemberIndex(result.SubmitterMemberIndex.Uint64()),
+		SubmitterMemberIndex:     submitterIndex,
 		GroupPublicKey:           result.GroupPubKey,
 		MisbehavedMembersIndexes: result.MisbehavedMembersIndices,
 		Signatures:               result.Signatures,
@@ -176,20 +178,17 @@ func convertDkgResultToAbiType(
 	}
 }
 
-// validateMemberIndex guards a *big.Int member index against both an
-// upper bound and a non-positive value. The non-positive check
-// (`chainMemberIndex.Sign() <= 0`) is a behavior change introduced
-// during the #4191 file split (the upper-bound check predated the
-// split). On-chain indices are 1-based and uint64, so the new check
-// is unreachable for valid events; it exists to surface a malformed
-// event as an error instead of producing a zero `group.MemberIndex`.
-func validateMemberIndex(chainMemberIndex *big.Int) error {
-	maxMemberIndex := big.NewInt(group.MaxMemberIndex)
-	if chainMemberIndex.Sign() <= 0 || chainMemberIndex.Cmp(maxMemberIndex) > 0 {
-		return fmt.Errorf("invalid member index value: [%v]", chainMemberIndex)
+// memberIndexFromChain checks that a chain member index fits the 1-based
+// group index range before converting it.
+func memberIndexFromChain(value *big.Int) (group.MemberIndex, error) {
+	if value == nil || !value.IsUint64() {
+		return 0, fmt.Errorf("invalid member index value: [%v]", value)
 	}
-
-	return nil
+	index := value.Uint64()
+	if index == 0 || index > group.MaxMemberIndex {
+		return 0, fmt.Errorf("invalid member index value: [%v]", value)
+	}
+	return group.MemberIndex(index), nil
 }
 
 func (tc *TbtcChain) OnDKGResultChallenged(
@@ -415,7 +414,7 @@ func (tc *TbtcChain) CalculateDKGResultSignatureHash(
 		tc.chainID,
 		unprefixedGroupPublicKeyBytes,
 		misbehavedMembersIndexes,
-		big.NewInt(int64(startBlock)),
+		new(big.Int).SetUint64(startBlock),
 	)
 }
 

--- a/pkg/chain/ethereum/tbtc_dkg_test.go
+++ b/pkg/chain/ethereum/tbtc_dkg_test.go
@@ -125,7 +125,7 @@ func TestConvertSignaturesToChainFormat(t *testing.T) {
 	}
 }
 
-func TestValidateMemberIndex(t *testing.T) {
+func TestMemberIndexFromChain(t *testing.T) {
 	one := big.NewInt(1)
 	maxMemberIndex := big.NewInt(255)
 
@@ -149,7 +149,7 @@ func TestValidateMemberIndex(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			err := validateMemberIndex(test.chainMemberIndex)
+			_, err := memberIndexFromChain(test.chainMemberIndex)
 
 			if !reflect.DeepEqual(err, test.expectedError) {
 				t.Errorf(

--- a/pkg/chain/ethereum/tbtc_moving_funds.go
+++ b/pkg/chain/ethereum/tbtc_moving_funds.go
@@ -128,6 +128,10 @@ func (tc *TbtcChain) SubmitMovingFundsCommitment(
 	walletMemberIndex uint32,
 	targetWallets [][20]byte,
 ) error {
+	if walletMainUTXO.Value < 0 {
+		return fmt.Errorf("invalid main UTXO value: [%v]", walletMainUTXO.Value)
+	}
+
 	mainUtxo := tbtcabi.BitcoinTxUTXO{
 		TxHash:        walletMainUTXO.Outpoint.TransactionHash,
 		TxOutputIndex: walletMainUTXO.Outpoint.OutputIndex,
@@ -149,6 +153,10 @@ func (tc *TbtcChain) SubmitMovingFundsProofWithReimbursement(
 	mainUTXO bitcoin.UnspentTransactionOutput,
 	walletPublicKeyHash [20]byte,
 ) error {
+	if mainUTXO.Value < 0 {
+		return fmt.Errorf("invalid main UTXO value: [%v]", mainUTXO.Value)
+	}
+
 	bitcoinTxInfo := tbtcabi.BitcoinTxInfo3{
 		Version:      transaction.SerializeVersion(),
 		InputVector:  transaction.SerializeInputs(),
@@ -157,7 +165,7 @@ func (tc *TbtcChain) SubmitMovingFundsProofWithReimbursement(
 	}
 	movingFundsProof := tbtcabi.BitcoinTxProof2{
 		MerkleProof:      proof.MerkleProof,
-		TxIndexInBlock:   big.NewInt(int64(proof.TxIndexInBlock)),
+		TxIndexInBlock:   new(big.Int).SetUint64(uint64(proof.TxIndexInBlock)),
 		BitcoinHeaders:   proof.BitcoinHeaders,
 		CoinbasePreimage: proof.CoinbasePreimage,
 		CoinbaseProof:    proof.CoinbaseProof,
@@ -201,6 +209,10 @@ func (tc *TbtcChain) SubmitMovedFundsSweepProofWithReimbursement(
 	proof *bitcoin.SpvProof,
 	mainUTXO bitcoin.UnspentTransactionOutput,
 ) error {
+	if mainUTXO.Value < 0 {
+		return fmt.Errorf("invalid main UTXO value: [%v]", mainUTXO.Value)
+	}
+
 	bitcoinTxInfo := tbtcabi.BitcoinTxInfo3{
 		Version:      transaction.SerializeVersion(),
 		InputVector:  transaction.SerializeInputs(),
@@ -209,7 +221,7 @@ func (tc *TbtcChain) SubmitMovedFundsSweepProofWithReimbursement(
 	}
 	movedFundsSweepProof := tbtcabi.BitcoinTxProof2{
 		MerkleProof:      proof.MerkleProof,
-		TxIndexInBlock:   big.NewInt(int64(proof.TxIndexInBlock)),
+		TxIndexInBlock:   new(big.Int).SetUint64(uint64(proof.TxIndexInBlock)),
 		BitcoinHeaders:   proof.BitcoinHeaders,
 		CoinbasePreimage: proof.CoinbasePreimage,
 		CoinbaseProof:    proof.CoinbaseProof,
@@ -369,6 +381,10 @@ func (tc *TbtcChain) ValidateMovingFundsProposal(
 	mainUTXO *bitcoin.UnspentTransactionOutput,
 	proposal *tbtc.MovingFundsProposal,
 ) error {
+	if mainUTXO.Value < 0 {
+		return fmt.Errorf("invalid main UTXO value: [%v]", mainUTXO.Value)
+	}
+
 	abiProposal := tbtcabi.WalletProposalValidatorMovingFundsProposal{
 		WalletPubKeyHash: walletPublicKeyHash,
 		TargetWallets:    proposal.TargetWallets,

--- a/pkg/chain/ethereum/tbtc_redemption.go
+++ b/pkg/chain/ethereum/tbtc_redemption.go
@@ -124,6 +124,10 @@ func (tc *TbtcChain) SubmitRedemptionProofWithReimbursement(
 	mainUTXO bitcoin.UnspentTransactionOutput,
 	walletPublicKeyHash [20]byte,
 ) error {
+	if mainUTXO.Value < 0 {
+		return fmt.Errorf("invalid main UTXO value: [%v]", mainUTXO.Value)
+	}
+
 	bitcoinTxInfo := tbtcabi.BitcoinTxInfo3{
 		Version:      transaction.SerializeVersion(),
 		InputVector:  transaction.SerializeInputs(),
@@ -132,7 +136,7 @@ func (tc *TbtcChain) SubmitRedemptionProofWithReimbursement(
 	}
 	redemptionProof := tbtcabi.BitcoinTxProof2{
 		MerkleProof:      proof.MerkleProof,
-		TxIndexInBlock:   big.NewInt(int64(proof.TxIndexInBlock)),
+		TxIndexInBlock:   new(big.Int).SetUint64(uint64(proof.TxIndexInBlock)),
 		BitcoinHeaders:   proof.BitcoinHeaders,
 		CoinbasePreimage: proof.CoinbasePreimage,
 		CoinbaseProof:    proof.CoinbaseProof,

--- a/pkg/chain/ethereum/tbtc_wallet.go
+++ b/pkg/chain/ethereum/tbtc_wallet.go
@@ -159,6 +159,7 @@ func computeMainUtxoHash(mainUtxo *bitcoin.UnspentTransactionOutput) [32]byte {
 	binary.BigEndian.PutUint32(outputIndexBytes, mainUtxo.Outpoint.OutputIndex)
 
 	valueBytes := make([]byte, 8)
+	// #nosec G115 -- Hash the exact 64-bit Bitcoin amount encoding; valid UTXOs are nonnegative.
 	binary.BigEndian.PutUint64(valueBytes, uint64(mainUtxo.Value))
 
 	mainUtxoHash := crypto.Keccak256Hash(

--- a/pkg/chain/ethereum/tbtc_wallet.go
+++ b/pkg/chain/ethereum/tbtc_wallet.go
@@ -159,7 +159,12 @@ func computeMainUtxoHash(mainUtxo *bitcoin.UnspentTransactionOutput) [32]byte {
 	binary.BigEndian.PutUint32(outputIndexBytes, mainUtxo.Outpoint.OutputIndex)
 
 	valueBytes := make([]byte, 8)
-	// #nosec G115 -- Hash the exact 64-bit Bitcoin amount encoding; valid UTXOs are nonnegative.
+	// #nosec G115 -- Hash the exact 64-bit Bitcoin amount encoding. This
+	// value is set by ComputeMainUtxoHash's real callers - the wallet main
+	// UTXO lookup in pkg/tbtc/wallet.go and isInputCurrentWalletsMainUTXO in
+	// pkg/maintainer/spv/spv.go - directly from a parsed Bitcoin transaction
+	// output; neither caller currently guards against a negative Value
+	// before invoking this function.
 	binary.BigEndian.PutUint64(valueBytes, uint64(mainUtxo.Value))
 
 	mainUtxoHash := crypto.Keccak256Hash(

--- a/pkg/chain/local_v1/local.go
+++ b/pkg/chain/local_v1/local.go
@@ -188,7 +188,8 @@ func ConnectWithKey(
 			GroupSize:                  groupSize,
 			HonestThreshold:            honestThreshold,
 			ResultPublicationBlockStep: resultPublicationBlockStep,
-			RelayEntryTimeout:          resultPublicationBlockStep * uint64(groupSize),
+			// #nosec G115 -- Local test-chain callers supply a nonnegative protocol group size.
+			RelayEntryTimeout: resultPublicationBlockStep * uint64(groupSize),
 		},
 		relayEntryHandlers:       make(map[int]func(request *event.RelayEntrySubmitted)),
 		relayRequestHandlers:     make(map[int]func(request *event.RelayEntryRequested)),

--- a/pkg/maintainer/spv/spv.go
+++ b/pkg/maintainer/spv/spv.go
@@ -346,7 +346,7 @@ func isInputCurrentWalletsMainUTXO(
 	if err != nil {
 		return false, fmt.Errorf("failed to get previous transaction: [%v]", err)
 	}
-	if fundingOutputIndex >= uint32(len(previousTransaction.Outputs)) {
+	if uint64(fundingOutputIndex) >= uint64(len(previousTransaction.Outputs)) {
 		return false, fmt.Errorf(
 			"funding output index [%d] out of range for transaction [%s] "+
 				"with [%d] outputs",

--- a/pkg/net/retransmission/ticker.go
+++ b/pkg/net/retransmission/ticker.go
@@ -45,8 +45,8 @@ func NewTimeTicker(ctx context.Context, duration time.Duration) *Ticker {
 	go func() {
 		for {
 			select {
-			case tick := <-timeTicker.C:
-				ticks <- uint64(tick.Unix())
+			case <-timeTicker.C:
+				ticks <- 0
 
 			case <-ctx.Done():
 				timeTicker.Stop()

--- a/pkg/operator/key.go
+++ b/pkg/operator/key.go
@@ -134,7 +134,7 @@ func MarshalCompressed(publicKey *PublicKey) []byte {
 
 	byteLength := (curveBitSize + 7) / 8
 	compressed := make([]byte, 1+byteLength)
-	compressed[0] = byte(publicKey.Y.Bit(0)) | 2
+	compressed[0] = byte(publicKey.Y.Bit(0)&1) | 2
 	publicKey.X.FillBytes(compressed[1:])
 
 	return compressed

--- a/pkg/protocol/announcer/announcer.go
+++ b/pkg/protocol/announcer/announcer.go
@@ -47,11 +47,11 @@ func (am *announcementMessage) Unmarshal(bytes []byte) error {
 		)
 	}
 
-	if senderID := pbMessage.SenderID; senderID > group.MaxMemberIndex {
-		return fmt.Errorf("invalid member index value: [%v]", senderID)
-	} else {
-		am.senderID = group.MemberIndex(senderID)
+	senderID, err := group.MemberIndexFromUint32(pbMessage.SenderID)
+	if err != nil {
+		return err
 	}
+	am.senderID = senderID
 
 	am.protocolID = pbMessage.ProtocolID
 	am.sessionID = pbMessage.SessionID

--- a/pkg/protocol/group/member_index.go
+++ b/pkg/protocol/group/member_index.go
@@ -3,11 +3,32 @@ package group
 import "fmt"
 
 // MemberIndexFromUint32 converts a wire or persisted member index without
-// truncating it. Zero retains its existing meaning at each protocol boundary;
-// validation of group membership belongs to the protocol using the index.
+// truncating it, accepting any value in the range [0, MaxMemberIndex]. Zero
+// retains its existing meaning at each protocol boundary; validation of
+// group membership belongs to the protocol using the index. Persisted-signer
+// callers must use MemberIndexFromUint32NonZero instead, since a persisted
+// signer's own index is never re-checked against group membership after
+// being loaded.
 func MemberIndexFromUint32(value uint32) (MemberIndex, error) {
 	if value > MaxMemberIndex {
 		return 0, fmt.Errorf("invalid member index value: [%v]", value)
 	}
 	return MemberIndex(value), nil
+}
+
+// MemberIndexFromUint32NonZero converts a persisted member index, rejecting
+// both out-of-range values and zero. Persisted-signer decode paths never
+// re-check group membership after loading their own index, so a zero index
+// must be rejected here: MembershipValidator.IsValidMembership computes
+// int(memberID-1), which silently wraps a MemberIndex(0) to 255 and matches
+// no real group position.
+func MemberIndexFromUint32NonZero(value uint32) (MemberIndex, error) {
+	memberIndex, err := MemberIndexFromUint32(value)
+	if err != nil {
+		return 0, err
+	}
+	if memberIndex == 0 {
+		return 0, fmt.Errorf("invalid member index value: [%v]", value)
+	}
+	return memberIndex, nil
 }

--- a/pkg/protocol/group/member_index.go
+++ b/pkg/protocol/group/member_index.go
@@ -1,0 +1,13 @@
+package group
+
+import "fmt"
+
+// MemberIndexFromUint32 converts a wire or persisted member index without
+// truncating it. Zero retains its existing meaning at each protocol boundary;
+// validation of group membership belongs to the protocol using the index.
+func MemberIndexFromUint32(value uint32) (MemberIndex, error) {
+	if value > MaxMemberIndex {
+		return 0, fmt.Errorf("invalid member index value: [%v]", value)
+	}
+	return MemberIndex(value), nil
+}

--- a/pkg/protocol/group/member_index_test.go
+++ b/pkg/protocol/group/member_index_test.go
@@ -1,0 +1,24 @@
+package group
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestMemberIndexFromUint32(t *testing.T) {
+	for _, value := range []uint32{0, 1, 255, 256, math.MaxUint32} {
+		t.Run(fmt.Sprint(value), func(t *testing.T) {
+			index, err := MemberIndexFromUint32(value)
+			if value > MaxMemberIndex {
+				if err == nil {
+					t.Fatal("expected out-of-range index to be rejected")
+				}
+				return
+			}
+			if err != nil || uint32(index) != value {
+				t.Fatalf("index %d: got %d, %v", value, index, err)
+			}
+		})
+	}
+}

--- a/pkg/protocol/inactivity/marshaling.go
+++ b/pkg/protocol/inactivity/marshaling.go
@@ -2,22 +2,11 @@
 package inactivity
 
 import (
-	"fmt"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/keep-network/keep-core/pkg/protocol/group"
 	"github.com/keep-network/keep-core/pkg/protocol/inactivity/gen/pb"
 )
-
-func validateMemberIndex(protoIndex uint32) error {
-	// Protobuf does not have uint8 type, so we are using uint32. When
-	// unmarshalling message, we need to make sure we do not overflow.
-	if protoIndex > group.MaxMemberIndex {
-		return fmt.Errorf("invalid member index value: [%v]", protoIndex)
-	}
-	return nil
-}
 
 // Marshal converts this claimSignatureMessage to a byte array suitable
 // for network communication.
@@ -39,10 +28,11 @@ func (csm *claimSignatureMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	csm.senderID = group.MemberIndex(pbMsg.SenderID)
+	csm.senderID = senderID
 
 	claimHash, err := ClaimHashFromBytes(pbMsg.ClaimHash)
 	if err != nil {

--- a/pkg/tbtc/chain.go
+++ b/pkg/tbtc/chain.go
@@ -2,6 +2,8 @@ package tbtc
 
 import (
 	"crypto/ecdsa"
+	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -352,7 +354,10 @@ type DepositRevealedEvent struct {
 	BlockNumber         uint64
 }
 
-func (dre *DepositRevealedEvent) unpack(extraData *[32]byte) *Deposit {
+func (dre *DepositRevealedEvent) unpack(extraData *[32]byte) (*Deposit, error) {
+	if dre.Amount > math.MaxInt64 {
+		return nil, fmt.Errorf("deposit amount exceeds int64 range: [%v]", dre.Amount)
+	}
 	return &Deposit{
 		Utxo: &bitcoin.UnspentTransactionOutput{
 			Outpoint: &bitcoin.TransactionOutpoint{
@@ -368,7 +373,7 @@ func (dre *DepositRevealedEvent) unpack(extraData *[32]byte) *Deposit {
 		RefundLocktime:      dre.RefundLocktime,
 		Vault:               dre.Vault,
 		ExtraData:           extraData,
-	}
+	}, nil
 }
 
 func (dre *DepositRevealedEvent) GetWalletPublicKeyHash() [20]byte {

--- a/pkg/tbtc/coordination.go
+++ b/pkg/tbtc/coordination.go
@@ -556,6 +556,7 @@ func (ce *coordinationExecutor) getLeader(seed [32]byte) chain.Address {
 	// #nosec G404 (insecure random number source (rand))
 	// Shuffling operators does not require secure randomness.
 	// Use first 8 bytes of the seed to initialize the RNG.
+	// #nosec G115 -- Preserve all 64 seed bits so existing operators select the same leader/actions.
 	rng := rand.New(rand.NewSource(int64(binary.BigEndian.Uint64(seed[:8]))))
 
 	// Shuffle the list of unique operators.
@@ -626,6 +627,7 @@ func (ce *coordinationExecutor) getActionsChecklist(
 	// #nosec G404 (insecure random number source (rand))
 	// Drawing a decision about heartbeat does not require secure randomness.
 	// Use first 8 bytes of the seed to initialize the RNG.
+	// #nosec G115 -- Preserve all 64 seed bits so existing operators select the same leader/actions.
 	rng := rand.New(rand.NewSource(int64(binary.BigEndian.Uint64(seed[:8]))))
 	if rng.Float64() < coordinationHeartbeatProbability {
 		actions = append(actions, ActionHeartbeat)

--- a/pkg/tbtc/coordination_window_metrics.go
+++ b/pkg/tbtc/coordination_window_metrics.go
@@ -320,8 +320,8 @@ func (cwm *coordinationWindowMetrics) cleanupOldWindows() {
 	})
 
 	// Remove oldest windows
-	windowsToRemove := len(cwm.windows) - int(cwm.maxWindowsToTrack)
-	for i := 0; i < windowsToRemove; i++ {
+	windowsToRemove := uint64(len(cwm.windows)) - cwm.maxWindowsToTrack
+	for i := uint64(0); i < windowsToRemove; i++ {
 		delete(cwm.windows, indices[i])
 	}
 }

--- a/pkg/tbtc/deduplicator.go
+++ b/pkg/tbtc/deduplicator.go
@@ -83,7 +83,7 @@ func (d *deduplicator) notifyDKGResultSubmitted(
 
 	cacheKey := newDKGResultSeed.Text(16) +
 		hex.EncodeToString(newDKGResultHash[:]) +
-		strconv.Itoa(int(newDKGResultBlock))
+		strconv.FormatUint(newDKGResultBlock, 10)
 
 	// If the key is not in the cache, that means the result was not handled
 	// yet and the client should proceed with the execution.

--- a/pkg/tbtc/deposit_sweep.go
+++ b/pkg/tbtc/deposit_sweep.go
@@ -488,11 +488,16 @@ func ValidateDepositSweepProposal(
 			)
 		}
 
+		deposit, err := matchingEvent.unpack(depositRequest.ExtraData)
+		if err != nil {
+			return nil, err
+		}
+
 		depositExtraInfo[i] = struct {
 			*Deposit
 			FundingTx *bitcoin.Transaction
 		}{
-			Deposit:   matchingEvent.unpack(depositRequest.ExtraData),
+			Deposit:   deposit,
 			FundingTx: fundingTx,
 		}
 	}

--- a/pkg/tbtc/dkg_loop.go
+++ b/pkg/tbtc/dkg_loop.go
@@ -5,8 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"github.com/keep-network/keep-core/pkg/protocol/announcer"
 	"math/big"
+
+	"github.com/keep-network/keep-core/pkg/protocol/announcer"
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/keep-network/keep-core/pkg/chain"
@@ -92,6 +93,7 @@ func newDkgRetryLoop(
 	// care in this piece of the code about the length of the seed and how this
 	// seed is proposed.
 	seedSha256 := sha256.Sum256(seed.Bytes())
+	// #nosec G115 -- Preserve all 64 seed bits, including the sign bit, for deterministic retries.
 	attemptSeed := int64(binary.BigEndian.Uint64(seedSha256[:8]))
 
 	return &dkgRetryLoop{

--- a/pkg/tbtc/integer_conversion_test.go
+++ b/pkg/tbtc/integer_conversion_test.go
@@ -27,9 +27,9 @@ func TestSignerUnmarshalMemberIndexBounds(t *testing.T) {
 		}
 		decoded := new(signer)
 		err = decoded.Unmarshal(data)
-		if index > 255 {
+		if index == 0 || index > 255 {
 			if err == nil {
-				t.Fatalf("accepted out-of-range index %d", index)
+				t.Fatalf("accepted invalid index %d", index)
 			}
 		} else if err != nil || uint32(decoded.signingGroupMemberIndex) != index {
 			t.Fatalf("index %d: got %d, %v", index, decoded.signingGroupMemberIndex, err)

--- a/pkg/tbtc/integer_conversion_test.go
+++ b/pkg/tbtc/integer_conversion_test.go
@@ -1,0 +1,81 @@
+package tbtc
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/keep-network/keep-core/pkg/tbtc/gen/pb"
+)
+
+func TestSignerUnmarshalMemberIndexBounds(t *testing.T) {
+	original, err := createMockSigner(t).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := new(pb.Signer)
+	if err := proto.Unmarshal(original, message); err != nil {
+		t.Fatal(err)
+	}
+	for _, index := range []uint32{0, 1, 255, 256, math.MaxUint32} {
+		message.SigningGroupMemberIndex = index
+		data, err := proto.Marshal(message)
+		if err != nil {
+			t.Fatal(err)
+		}
+		decoded := new(signer)
+		err = decoded.Unmarshal(data)
+		if index > 255 {
+			if err == nil {
+				t.Fatalf("accepted out-of-range index %d", index)
+			}
+		} else if err != nil || uint32(decoded.signingGroupMemberIndex) != index {
+			t.Fatalf("index %d: got %d, %v", index, decoded.signingGroupMemberIndex, err)
+		}
+	}
+}
+
+func TestDepositRevealBlockUnsignedRoundtrip(t *testing.T) {
+	blocks := []uint64{0, math.MaxInt64, math.MaxInt64 + 1, math.MaxUint64}
+	original := &DepositSweepProposal{SweepTxFee: big.NewInt(1)}
+	for _, block := range blocks {
+		original.DepositsRevealBlocks = append(original.DepositsRevealBlocks, new(big.Int).SetUint64(block))
+	}
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded := new(DepositSweepProposal)
+	if err := decoded.Unmarshal(data); err != nil {
+		t.Fatal(err)
+	}
+	for i, want := range original.DepositsRevealBlocks {
+		if decoded.DepositsRevealBlocks[i].Cmp(want) != 0 {
+			t.Fatalf("block %d: got %v, want %v", i, decoded.DepositsRevealBlocks[i], want)
+		}
+	}
+}
+
+func TestDepositRevealBlockMarshalBounds(t *testing.T) {
+	for _, block := range []*big.Int{nil, big.NewInt(-1), new(big.Int).Lsh(big.NewInt(1), 64)} {
+		proposal := &DepositSweepProposal{SweepTxFee: big.NewInt(1), DepositsRevealBlocks: []*big.Int{block}}
+		if _, err := proposal.Marshal(); err == nil {
+			t.Fatalf("accepted block %v", block)
+		}
+	}
+}
+
+func TestDepositRevealedEventAmountBounds(t *testing.T) {
+	for _, value := range []uint64{0, 1, math.MaxInt64, math.MaxInt64 + 1, math.MaxUint64} {
+		deposit, err := (&DepositRevealedEvent{Amount: value}).unpack(nil)
+		if value > math.MaxInt64 {
+			if err == nil {
+				t.Fatalf("accepted amount %d", value)
+			}
+		} else if err != nil || uint64(deposit.Utxo.Value) != value {
+			t.Fatalf("amount %d: got %v, %v", value, deposit, err)
+		}
+	}
+}

--- a/pkg/tbtc/marshaling.go
+++ b/pkg/tbtc/marshaling.go
@@ -61,7 +61,7 @@ func (s *signer) Unmarshal(bytes []byte) error {
 		return fmt.Errorf("cannot unmarshal signer: [%w]", err)
 	}
 
-	memberIndex, err := group.MemberIndexFromUint32(pbSigner.SigningGroupMemberIndex)
+	memberIndex, err := group.MemberIndexFromUint32NonZero(pbSigner.SigningGroupMemberIndex)
 	if err != nil {
 		return err
 	}

--- a/pkg/tbtc/marshaling.go
+++ b/pkg/tbtc/marshaling.go
@@ -61,6 +61,11 @@ func (s *signer) Unmarshal(bytes []byte) error {
 		return fmt.Errorf("cannot unmarshal signer: [%w]", err)
 	}
 
+	memberIndex, err := group.MemberIndexFromUint32(pbSigner.SigningGroupMemberIndex)
+	if err != nil {
+		return err
+	}
+
 	walletPublicKey, err := unmarshalPublicKey(pbSigner.Wallet.PublicKey)
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal wallet public key: [%w]", err)
@@ -84,7 +89,7 @@ func (s *signer) Unmarshal(bytes []byte) error {
 		publicKey:             walletPublicKey,
 		signingGroupOperators: walletSigningGroupOperators,
 	}
-	s.signingGroupMemberIndex = group.MemberIndex(pbSigner.SigningGroupMemberIndex)
+	s.signingGroupMemberIndex = memberIndex
 	s.privateKeyShare = privateKeyShare
 
 	return nil
@@ -113,7 +118,8 @@ func (sdm *signingDoneMessage) Unmarshal(bytes []byte) error {
 		return fmt.Errorf("failed to unmarshal SigningDoneMessage: [%v]", err)
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
@@ -122,7 +128,7 @@ func (sdm *signingDoneMessage) Unmarshal(bytes []byte) error {
 		return fmt.Errorf("cannot unmarshal signature: [%v]", err)
 	}
 
-	sdm.senderID = group.MemberIndex(pbMsg.SenderID)
+	sdm.senderID = senderID
 	sdm.message = new(big.Int).SetBytes(pbMsg.Message)
 	sdm.attemptNumber = pbMsg.AttemptNumber
 	sdm.signature = signature
@@ -160,7 +166,8 @@ func (cm *coordinationMessage) Unmarshal(bytes []byte) error {
 		return fmt.Errorf("failed to unmarshal CoordinationMessage: [%v]", err)
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
@@ -183,7 +190,7 @@ func (cm *coordinationMessage) Unmarshal(bytes []byte) error {
 		return fmt.Errorf("failed to unmarshal proposal: [%v]", err)
 	}
 
-	cm.senderID = group.MemberIndex(pbMsg.SenderID)
+	cm.senderID = senderID
 	cm.coordinationBlock = pbMsg.CoordinationBlock
 	cm.walletPublicKeyHash = walletPublicKeyHash
 	cm.proposal = proposal
@@ -306,6 +313,9 @@ func (dsp *DepositSweepProposal) Marshal() ([]byte, error) {
 
 	depositsRevealBlocks := make([]uint64, len(dsp.DepositsRevealBlocks))
 	for i, block := range dsp.DepositsRevealBlocks {
+		if block == nil || !block.IsUint64() {
+			return nil, fmt.Errorf("invalid deposit reveal block: [%v]", block)
+		}
 		depositsRevealBlocks[i] = block.Uint64()
 	}
 
@@ -349,7 +359,7 @@ func (dsp *DepositSweepProposal) Unmarshal(bytes []byte) error {
 
 	depositsRevealBlocks := make([]*big.Int, len(pbMsg.DepositsRevealBlocks))
 	for i, block := range pbMsg.DepositsRevealBlocks {
-		depositsRevealBlocks[i] = big.NewInt(int64(block))
+		depositsRevealBlocks[i] = new(big.Int).SetUint64(block)
 	}
 
 	dsp.DepositsKeys = depositsKeys
@@ -474,13 +484,4 @@ func marshalPublicKey(publicKey *ecdsa.PublicKey) ([]byte, error) {
 // public key.
 func unmarshalPublicKey(bytes []byte) (*ecdsa.PublicKey, error) {
 	return secp256k1.Unmarshal(bytes)
-}
-
-func validateMemberIndex(protoIndex uint32) error {
-	// Protobuf does not have uint8 type, so we are using uint32. When
-	// unmarshalling message, we need to make sure we do not overflow.
-	if protoIndex > group.MaxMemberIndex {
-		return fmt.Errorf("invalid member index value: [%v]", protoIndex)
-	}
-	return nil
 }

--- a/pkg/tbtc/marshaling_test.go
+++ b/pkg/tbtc/marshaling_test.go
@@ -53,7 +53,8 @@ func TestSignerMarshalling_NonTECDSAKey(t *testing.T) {
 
 func TestSignerUnmarshalling_InvalidPublicKey(t *testing.T) {
 	marshaled, err := proto.Marshal(&pb.Signer{
-		Wallet: &pb.Wallet{PublicKey: []byte{0x04}},
+		Wallet:                  &pb.Wallet{PublicKey: []byte{0x04}},
+		SigningGroupMemberIndex: 1,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/tbtc/redemption.go
+++ b/pkg/tbtc/redemption.go
@@ -3,6 +3,7 @@ package tbtc
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -541,7 +542,14 @@ func assembleRedemptionTransaction(
 		// The redeemable amount for a redemption request is the difference
 		// between the requested amount and treasury fee computed upon
 		// request creation.
-		redeemableAmount := int64(request.RequestedAmount - request.TreasuryFee)
+		if request.TreasuryFee > request.RequestedAmount {
+			return nil, fmt.Errorf("treasury fee exceeds requested amount")
+		}
+		amount := request.RequestedAmount - request.TreasuryFee
+		if amount > math.MaxInt64 {
+			return nil, fmt.Errorf("redeemable amount exceeds int64 range: [%v]", amount)
+		}
+		redeemableAmount := int64(amount)
 		// The actual value of the redemption output is the difference between
 		// the request's redeemable amount and share of the transaction fee
 		// incurred by the given request.

--- a/pkg/tbtc/redemption_test.go
+++ b/pkg/tbtc/redemption_test.go
@@ -2,7 +2,10 @@ package tbtc
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"math/big"
+	"reflect"
 	"testing"
 	"time"
 
@@ -266,6 +269,77 @@ func TestAssembleRedemptionTransaction(t *testing.T) {
 				scenario.ExpectedRedemptionTransactionWitnessHash.Hex(bitcoin.InternalByteOrder),
 				transaction.WitnessHash().Hex(bitcoin.InternalByteOrder),
 			)
+		})
+	}
+}
+
+func TestAssembleRedemptionTransaction_ValidationErrors(t *testing.T) {
+	scenarios, err := test.LoadRedemptionTestScenarios()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scenario := scenarios[0]
+
+	var tests = map[string]struct {
+		requestedAmount uint64
+		treasuryFee     uint64
+		expectedError   error
+	}{
+		"treasury fee exceeds requested amount": {
+			requestedAmount: 10000,
+			treasuryFee:     10001,
+			expectedError:   fmt.Errorf("treasury fee exceeds requested amount"),
+		},
+		"redeemable amount exceeds int64 range": {
+			requestedAmount: math.MaxUint64,
+			treasuryFee:     0,
+			expectedError: fmt.Errorf(
+				"redeemable amount exceeds int64 range: [%v]",
+				uint64(math.MaxUint64),
+			),
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			bitcoinChain := newLocalBitcoinChain()
+
+			err := bitcoinChain.BroadcastTransaction(scenario.InputTransaction)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			requests := []*RedemptionRequest{
+				{
+					Redeemer:             scenario.RedemptionRequests[0].Redeemer,
+					RedeemerOutputScript: scenario.RedemptionRequests[0].RedeemerOutputScript,
+					RequestedAmount:      test.requestedAmount,
+					TreasuryFee:          test.treasuryFee,
+					TxMaxFee:             scenario.RedemptionRequests[0].TxMaxFee,
+					RequestedAt:          scenario.RedemptionRequests[0].RequestedAt,
+				},
+			}
+
+			feeDistribution := func(requests []*RedemptionRequest) []int64 {
+				return []int64{0}
+			}
+
+			_, err = assembleRedemptionTransaction(
+				bitcoinChain,
+				scenario.WalletPublicKey,
+				scenario.WalletMainUtxo,
+				requests,
+				feeDistribution,
+				RedemptionChangeLast,
+			)
+
+			if !reflect.DeepEqual(test.expectedError, err) {
+				t.Errorf(
+					"unexpected error\nexpected: %v\nactual:   %v\n",
+					test.expectedError,
+					err,
+				)
+			}
 		})
 	}
 }

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -113,6 +113,7 @@ func newSigningRetryLoop(
 	// not care in this piece of the code about the length of the message and
 	// how this message is proposed.
 	messageSha256 := sha256.Sum256(message.Bytes())
+	// #nosec G115 -- Preserve all 64 seed bits, including the sign bit, for deterministic retries.
 	attemptSeed := int64(binary.BigEndian.Uint64(messageSha256[:8]))
 
 	return &signingRetryLoop{
@@ -535,6 +536,7 @@ func (srl *signingRetryLoop) excludedMembersIndexes(
 		// #nosec G404 (insecure random number source (rand))
 		// Shuffling does not require secure randomness.
 		rng := rand.New(rand.NewSource(
+			// #nosec G115 -- Retry seed arithmetic intentionally wraps modulo 2^64 for compatibility.
 			srl.attemptSeed + int64(srl.attemptCounter),
 		))
 		// Sort in ascending order just in case.

--- a/pkg/tbtc/signing_loop.go
+++ b/pkg/tbtc/signing_loop.go
@@ -533,12 +533,10 @@ func (srl *signingRetryLoop) excludedMembersIndexes(
 	// Make sure we always use just the smallest required count of
 	// signing members for performance reasons
 	if len(includedMembersIndexes) > srl.groupParameters.HonestThreshold {
-		// #nosec G404 (insecure random number source (rand))
-		// Shuffling does not require secure randomness.
-		rng := rand.New(rand.NewSource(
-			// #nosec G115 -- Retry seed arithmetic intentionally wraps modulo 2^64 for compatibility.
-			srl.attemptSeed + int64(srl.attemptCounter),
-		))
+		// #nosec G115 -- Retry seed arithmetic intentionally wraps modulo 2^64 for compatibility.
+		seed := srl.attemptSeed + int64(srl.attemptCounter)
+		// #nosec G404 -- Shuffling does not require secure randomness.
+		rng := rand.New(rand.NewSource(seed))
 		// Sort in ascending order just in case.
 		sort.Slice(includedMembersIndexes, func(i, j int) bool {
 			return includedMembersIndexes[i] < includedMembersIndexes[j]

--- a/pkg/tbtcpg/deposit_sweep.go
+++ b/pkg/tbtcpg/deposit_sweep.go
@@ -517,7 +517,7 @@ func (dst *DepositSweepTask) ProposeDepositsSweep(
 			FundingTxHash:      deposit.FundingTxHash,
 			FundingOutputIndex: deposit.FundingOutputIndex,
 		}
-		depositsRevealBlocks[i] = big.NewInt(int64(deposit.RevealBlock))
+		depositsRevealBlocks[i] = new(big.Int).SetUint64(deposit.RevealBlock)
 	}
 
 	proposal := &tbtc.DepositSweepProposal{
@@ -630,6 +630,13 @@ func estimateDepositsSweepFee(
 	depositsCount int,
 	perDepositMaxFee uint64,
 ) (int64, int64, error) {
+	if depositsCount <= 0 {
+		return 0, 0, fmt.Errorf("invalid deposits count: [%v]", depositsCount)
+	}
+	if perDepositMaxFee > math.MaxUint64/uint64(depositsCount) {
+		return 0, 0, fmt.Errorf("maximum sweep fee exceeds uint64 range")
+	}
+
 	transactionSize, err := bitcoin.NewTransactionSizeEstimator().
 		// 1 P2WPKH main UTXO input.
 		AddPublicKeyHashInputs(1, true).
@@ -654,7 +661,7 @@ func estimateDepositsSweepFee(
 
 	// A raw estimate already above the Bridge maximum means the sweep is
 	// uneconomical to perform; return an error.
-	if uint64(totalFee) > totalMaxFee {
+	if totalFee < 0 || uint64(totalFee) > totalMaxFee {
 		return 0, 0, fmt.Errorf("estimated fee exceeds the maximum fee")
 	}
 

--- a/pkg/tbtcpg/fee.go
+++ b/pkg/tbtcpg/fee.go
@@ -132,8 +132,12 @@ func applyWalletTxFeeFloor(
 			tbtc.MinWalletTxSatPerVByteFee, txVsize,
 		)
 	}
+	feeLimit := int64(math.MaxInt64)
+	if maxTotalFee <= math.MaxInt64 {
+		feeLimit = int64(maxTotalFee)
+	}
 	floorProduct := tbtc.MinWalletTxSatPerVByteFee * txVsize
-	if uint64(floorProduct) > maxTotalFee {
+	if floorProduct > feeLimit {
 		return 0, fmt.Errorf(
 			"%w: minimum fee [%d], maximum fee [%d]",
 			ErrMaxFeeTooLow,
@@ -191,8 +195,8 @@ func applyWalletTxFeeFloor(
 	// product is now guaranteed to fit in int64 by the rate*txVsize
 	// guard above.
 	totalFee := rate * txVsize
-	if uint64(totalFee) > maxTotalFee {
-		totalFee = int64(maxTotalFee)
+	if totalFee > feeLimit {
+		totalFee = feeLimit
 	}
 
 	return totalFee, nil
@@ -226,7 +230,7 @@ func estimateCappedFee(
 		return 0, fmt.Errorf("cannot estimate transaction fee: [%v]", err)
 	}
 
-	if uint64(totalFee) > maxTotalFee {
+	if totalFee < 0 || uint64(totalFee) > maxTotalFee {
 		return 0, feeTooHighErr
 	}
 

--- a/pkg/tbtcpg/fee_test.go
+++ b/pkg/tbtcpg/fee_test.go
@@ -32,6 +32,12 @@ func TestApplyWalletTxFeeFloor(t *testing.T) {
 		expectedFee         int64
 		expectErrorContains string
 	}{
+		"unsigned maximum cap preserves the normal fee": {
+			estimatedFee: 4000, txVsize: vsize, maxTotalFee: math.MaxUint64, expectedFee: 5000,
+		},
+		"signed maximum cap preserves the normal fee": {
+			estimatedFee: 4000, txVsize: vsize, maxTotalFee: math.MaxInt64, expectedFee: 5000,
+		},
 		"estimate above the floor is buffered by 25%": {
 			estimatedFee: 4000, // rate 20 sat/vByte
 			txVsize:      vsize,

--- a/pkg/tbtcpg/internal/test/marshaling.go
+++ b/pkg/tbtcpg/internal/test/marshaling.go
@@ -103,6 +103,10 @@ func (dsts *FindDepositsToSweepTestScenario) UnmarshalJSON(data []byte) error {
 		}
 		ageBlocks := uint64(blockCount)
 
+		if ageBlocks > currentBlock {
+			return fmt.Errorf("invalid block age: age exceeds current block")
+		}
+
 		revealedAt := now.Add(-age)
 		revealBlockNumber := currentBlock - ageBlocks
 
@@ -350,6 +354,10 @@ func (fprts *FindPendingRedemptionsTestScenario) UnmarshalJSON(data []byte) erro
 			return fmt.Errorf("invalid block age")
 		}
 		ageBlocks := uint64(blockCount)
+
+		if ageBlocks > currentBlock {
+			return fmt.Errorf("invalid block age: age exceeds current block")
+		}
 
 		requestedAt := now.Add(-age)
 		requestBlock := currentBlock - ageBlocks

--- a/pkg/tbtcpg/internal/test/marshaling.go
+++ b/pkg/tbtcpg/internal/test/marshaling.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/keep-network/keep-core/pkg/tbtcpg"
+	"math"
 	"math/big"
 	"time"
+
+	"github.com/keep-network/keep-core/pkg/tbtcpg"
 
 	"github.com/keep-network/keep-core/internal/hexutils"
 	"github.com/keep-network/keep-core/pkg/bitcoin"
@@ -91,8 +93,15 @@ func (dsts *FindDepositsToSweepTestScenario) UnmarshalJSON(data []byte) error {
 	for i, deposit := range unmarshaled.Deposits {
 		d := new(Deposit)
 
+		if deposit.Age < 0 || deposit.Age > math.MaxInt64/int64(time.Second) || averageBlockTime.Milliseconds() <= 0 {
+			return fmt.Errorf("invalid age or average block time")
+		}
 		age := time.Duration(deposit.Age) * time.Second
-		ageBlocks := uint64(age.Milliseconds() / averageBlockTime.Milliseconds())
+		blockCount := age.Milliseconds() / averageBlockTime.Milliseconds()
+		if blockCount < 0 {
+			return fmt.Errorf("invalid block age")
+		}
+		ageBlocks := uint64(blockCount)
 
 		revealedAt := now.Add(-age)
 		revealBlockNumber := currentBlock - ageBlocks
@@ -332,8 +341,15 @@ func (fprts *FindPendingRedemptionsTestScenario) UnmarshalJSON(data []byte) erro
 		var wpkh [20]byte
 		copy(wpkh[:], hexToSlice(pr.WalletPublicKeyHash))
 
+		if pr.Age < 0 || pr.Age > math.MaxInt64/int64(time.Second) || averageBlockTime.Milliseconds() <= 0 {
+			return fmt.Errorf("invalid age or average block time")
+		}
 		age := time.Duration(pr.Age) * time.Second
-		ageBlocks := uint64(age.Milliseconds() / averageBlockTime.Milliseconds())
+		blockCount := age.Milliseconds() / averageBlockTime.Milliseconds()
+		if blockCount < 0 {
+			return fmt.Errorf("invalid block age")
+		}
+		ageBlocks := uint64(blockCount)
 
 		requestedAt := now.Add(-age)
 		requestBlock := currentBlock - ageBlocks

--- a/pkg/tbtcpg/moving_funds.go
+++ b/pkg/tbtcpg/moving_funds.go
@@ -338,13 +338,13 @@ func (mft *MovingFundsTask) findNewTargetWallets(
 		if wallet.State == tbtc.StateLive {
 			targetWallets = append(targetWallets, walletPubKeyHash)
 		}
-		if len(targetWallets) == int(targetWalletsCount) {
+		if uint64(len(targetWallets)) == targetWalletsCount {
 			// Stop the iteration if enough live wallets have been gathered.
 			break
 		}
 	}
 
-	if len(targetWallets) != int(targetWalletsCount) {
+	if uint64(len(targetWallets)) != targetWalletsCount {
 		return nil, fmt.Errorf(
 			"%w: required [%v] target wallets; gathered [%v]",
 			ErrNotEnoughTargetWallets,

--- a/pkg/tbtcpg/redemptions.go
+++ b/pkg/tbtcpg/redemptions.go
@@ -270,7 +270,7 @@ func (rt *RedemptionTask) ProposeRedemption(
 		// diagnostic rather than an exact predictor.
 		requestsCount := int64(len(redeemersOutputScripts))
 		maxShare := fee/requestsCount + fee%requestsCount
-		if uint64(maxShare) > txMaxFee {
+		if maxShare < 0 || uint64(maxShare) > txMaxFee {
 			taskLogger.Warnf(
 				"floored redemption fee share [%d] exceeds the per-request "+
 					"maximum fee [%d]; the proposal will likely be rejected "+
@@ -562,7 +562,7 @@ func EstimateRedemptionFee(
 	// A raw estimate already above the maximum means the redemption is
 	// uneconomical to perform at the required fee; return an error rather than
 	// clamping to the maximum and broadcasting an underpriced transaction.
-	if uint64(totalFee) > maxTotalFee {
+	if totalFee < 0 || uint64(totalFee) > maxTotalFee {
 		return 0, fmt.Errorf("estimated fee exceeds the maximum fee")
 	}
 

--- a/pkg/tecdsa/dkg/integer_conversion_test.go
+++ b/pkg/tecdsa/dkg/integer_conversion_test.go
@@ -1,0 +1,127 @@
+package dkg
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/keep-network/keep-core/pkg/tecdsa/dkg/gen/pb"
+)
+
+// TestUnmarshal_SenderIDBounds verifies that every round message rejects a
+// SenderID value that overflows group.MaxMemberIndex.
+func TestUnmarshal_SenderIDBounds(t *testing.T) {
+	tests := map[string]struct {
+		marshal func(senderID uint32) ([]byte, error)
+		decode  func(bytes []byte) error
+	}{
+		"ephemeralPublicKeyMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.EphemeralPublicKeyMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(ephemeralPublicKeyMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundOneMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundOneMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundOneMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundTwoMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundTwoMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundTwoMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundThreeMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundThreeMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundThreeMessage).Unmarshal(bytes)
+			},
+		},
+		"tssFinalizationMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSFinalizationMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssFinalizationMessage).Unmarshal(bytes)
+			},
+		},
+		"resultSignatureMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.ResultSignatureMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(resultSignatureMessage).Unmarshal(bytes)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := test.marshal(256)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := test.decode(data); err == nil {
+				t.Fatal("expected out-of-range SenderID to be rejected")
+			}
+		})
+	}
+}
+
+// TestUnmarshal_PeerMapKeyBounds verifies that the messages carrying a
+// per-member map reject a map key that overflows group.MaxMemberIndex.
+func TestUnmarshal_PeerMapKeyBounds(t *testing.T) {
+	overflowKeyMap := map[uint32][]byte{256: []byte{1}}
+
+	tests := map[string]struct {
+		marshal func() ([]byte, error)
+		decode  func(bytes []byte) error
+	}{
+		"ephemeralPublicKeyMessage/EphemeralPublicKeys": {
+			marshal: func() ([]byte, error) {
+				return proto.Marshal(&pb.EphemeralPublicKeyMessage{
+					SenderID:            1,
+					EphemeralPublicKeys: overflowKeyMap,
+				})
+			},
+			decode: func(bytes []byte) error {
+				return new(ephemeralPublicKeyMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundTwoMessage/PeersPayload": {
+			marshal: func() ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundTwoMessage{
+					SenderID:     1,
+					PeersPayload: overflowKeyMap,
+				})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundTwoMessage).Unmarshal(bytes)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := test.marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := test.decode(data); err == nil {
+				t.Fatal("expected out-of-range peer map key to be rejected")
+			}
+		})
+	}
+}

--- a/pkg/tecdsa/dkg/marshaling.go
+++ b/pkg/tecdsa/dkg/marshaling.go
@@ -32,10 +32,11 @@ func (epkm *ephemeralPublicKeyMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	epkm.senderID = group.MemberIndex(pbMsg.SenderID)
+	epkm.senderID = senderID
 
 	ephemeralPublicKeys, err := unmarshalPublicKeyMap(pbMsg.EphemeralPublicKeys)
 	if err != nil {
@@ -65,11 +66,12 @@ func (trom *tssRoundOneMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trom.senderID = group.MemberIndex(pbMsg.SenderID)
+	trom.senderID = senderID
 	trom.broadcastPayload = pbMsg.BroadcastPayload
 	trom.sessionID = pbMsg.SessionID
 
@@ -99,20 +101,22 @@ func (trtm *tssRoundTwoMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
 	peersPayload := make(map[group.MemberIndex][]byte, len(pbMsg.PeersPayload))
 	for receiverID, payload := range pbMsg.PeersPayload {
-		if err := validateMemberIndex(receiverID); err != nil {
+		memberIndex, err := group.MemberIndexFromUint32(receiverID)
+		if err != nil {
 			return err
 		}
 
-		peersPayload[group.MemberIndex(receiverID)] = payload
+		peersPayload[memberIndex] = payload
 	}
 
-	trtm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trtm.senderID = senderID
 	trtm.broadcastPayload = pbMsg.BroadcastPayload
 	trtm.peersPayload = peersPayload
 	trtm.sessionID = pbMsg.SessionID
@@ -137,11 +141,12 @@ func (trtm *tssRoundThreeMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trtm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trtm.senderID = senderID
 	trtm.broadcastPayload = pbMsg.BroadcastPayload
 	trtm.sessionID = pbMsg.SessionID
 
@@ -165,22 +170,14 @@ func (tfm *tssFinalizationMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	tfm.senderID = group.MemberIndex(pbMsg.SenderID)
+	tfm.senderID = senderID
 	tfm.sessionID = pbMsg.SessionID
 
-	return nil
-}
-
-func validateMemberIndex(protoIndex uint32) error {
-	// Protobuf does not have uint8 type, so we are using uint32. When
-	// unmarshalling message, we need to make sure we do not overflow.
-	if protoIndex > group.MaxMemberIndex {
-		return fmt.Errorf("invalid member index value: [%v]", protoIndex)
-	}
 	return nil
 }
 
@@ -202,10 +199,11 @@ func unmarshalPublicKeyMap(
 ) (map[group.MemberIndex][]byte, error) {
 	unmarshalled := make(map[group.MemberIndex][]byte, len(publicKeys))
 	for memberID, publicKeyBytes := range publicKeys {
-		if err := validateMemberIndex(memberID); err != nil {
+		memberIndex, err := group.MemberIndexFromUint32(memberID)
+		if err != nil {
 			return nil, err
 		}
-		unmarshalled[group.MemberIndex(memberID)] = publicKeyBytes
+		unmarshalled[memberIndex] = publicKeyBytes
 	}
 	return unmarshalled, nil
 }
@@ -230,10 +228,11 @@ func (rsm *resultSignatureMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	rsm.senderID = group.MemberIndex(pbMsg.SenderID)
+	rsm.senderID = senderID
 
 	resultHash, err := ResultSignatureHashFromBytes(pbMsg.ResultHash)
 	if err != nil {

--- a/pkg/tecdsa/dkg/member.go
+++ b/pkg/tecdsa/dkg/member.go
@@ -326,7 +326,13 @@ func (ic *identityConverter) TssPartyIDToMemberIndex(
 		return group.MemberIndex(0)
 	}
 
-	return group.MemberIndex(
-		new(big.Int).Sub(partyID.KeyInt(), ic.seed).Int64(),
-	)
+	index := new(big.Int).Sub(partyID.KeyInt(), ic.seed)
+	if !index.IsUint64() {
+		return 0
+	}
+	value := index.Uint64()
+	if value > group.MaxMemberIndex {
+		return 0
+	}
+	return group.MemberIndex(value)
 }

--- a/pkg/tecdsa/dkg/member_test.go
+++ b/pkg/tecdsa/dkg/member_test.go
@@ -184,3 +184,14 @@ func TestIdentityConverter_TssPartyIDToMemberIndex_Corrupted(t *testing.T) {
 
 	testutils.AssertIntsEqual(t, "member ID", 0, int(memberIndex))
 }
+
+func TestIdentityConverter_TssPartyIDToMemberIndex_Overflow(t *testing.T) {
+	converter := &identityConverter{seed: big.NewInt(300)}
+	partyID := tss.NewPartyID("556", "member-256", big.NewInt(556))
+
+	// index (556 - 300 = 256) exceeds group.MaxMemberIndex; the party ID is
+	// considered corrupted and MemberIndex(0) is returned.
+	memberIndex := converter.TssPartyIDToMemberIndex(partyID)
+
+	testutils.AssertIntsEqual(t, "member ID", 0, int(memberIndex))
+}

--- a/pkg/tecdsa/retry/retry.go
+++ b/pkg/tecdsa/retry/retry.go
@@ -57,6 +57,7 @@ func EvaluateRetryParticipantsForSigning(
 
 	// #nosec G404 (insecure random number source (rand))
 	// Shuffling operators for retries does not require secure randomness.
+	// #nosec G115 -- Retry seed arithmetic intentionally wraps modulo 2^64 for compatibility.
 	rng := rand.New(rand.NewSource(seed + int64(retryCount)))
 
 	operators := make([]chain.Address, len(operatorToSeatCount))

--- a/pkg/tecdsa/signature.go
+++ b/pkg/tecdsa/signature.go
@@ -30,8 +30,9 @@ func NewSignature(data *common.SignatureData) *Signature {
 	recoveryInt = (recoveryInt << 8) | int(recoveryBytes[0])
 
 	return &Signature{
-		R:          new(big.Int).SetBytes(data.GetR()),
-		S:          new(big.Int).SetBytes(data.GetS()),
+		R: new(big.Int).SetBytes(data.GetR()),
+		S: new(big.Int).SetBytes(data.GetS()),
+		// #nosec G115 -- tss-lib signing output supplies a recovery ID in {0, 1, 2, 3}.
 		RecoveryID: int8(recoveryInt),
 	}
 }

--- a/pkg/tecdsa/signing/integer_conversion_test.go
+++ b/pkg/tecdsa/signing/integer_conversion_test.go
@@ -1,0 +1,170 @@
+package signing
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/keep-network/keep-core/pkg/tecdsa/signing/gen/pb"
+)
+
+// TestUnmarshal_SenderIDBounds verifies that every round message rejects a
+// SenderID value that overflows group.MaxMemberIndex.
+func TestUnmarshal_SenderIDBounds(t *testing.T) {
+	tests := map[string]struct {
+		marshal func(senderID uint32) ([]byte, error)
+		decode  func(bytes []byte) error
+	}{
+		"ephemeralPublicKeyMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.EphemeralPublicKeyMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(ephemeralPublicKeyMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundOneMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundOneMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundOneMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundTwoMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundTwoMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundTwoMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundThreeMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundThreeMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundThreeMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundFourMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundFourMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundFourMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundFiveMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundFiveMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundFiveMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundSixMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundSixMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundSixMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundSevenMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundSevenMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundSevenMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundEightMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundEightMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundEightMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundNineMessage": {
+			marshal: func(senderID uint32) ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundNineMessage{SenderID: senderID})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundNineMessage).Unmarshal(bytes)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := test.marshal(256)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := test.decode(data); err == nil {
+				t.Fatal("expected out-of-range SenderID to be rejected")
+			}
+		})
+	}
+}
+
+// TestUnmarshal_PeerMapKeyBounds verifies that the messages carrying a
+// per-member map reject a map key that overflows group.MaxMemberIndex.
+func TestUnmarshal_PeerMapKeyBounds(t *testing.T) {
+	overflowKeyMap := map[uint32][]byte{256: []byte{1}}
+
+	tests := map[string]struct {
+		marshal func() ([]byte, error)
+		decode  func(bytes []byte) error
+	}{
+		"ephemeralPublicKeyMessage/EphemeralPublicKeys": {
+			marshal: func() ([]byte, error) {
+				return proto.Marshal(&pb.EphemeralPublicKeyMessage{
+					SenderID:            1,
+					EphemeralPublicKeys: overflowKeyMap,
+				})
+			},
+			decode: func(bytes []byte) error {
+				return new(ephemeralPublicKeyMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundOneMessage/PeersPayload": {
+			marshal: func() ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundOneMessage{
+					SenderID:     1,
+					PeersPayload: overflowKeyMap,
+				})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundOneMessage).Unmarshal(bytes)
+			},
+		},
+		"tssRoundTwoMessage/PeersPayload": {
+			marshal: func() ([]byte, error) {
+				return proto.Marshal(&pb.TSSRoundTwoMessage{
+					SenderID:     1,
+					PeersPayload: overflowKeyMap,
+				})
+			},
+			decode: func(bytes []byte) error {
+				return new(tssRoundTwoMessage).Unmarshal(bytes)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := test.marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := test.decode(data); err == nil {
+				t.Fatal("expected out-of-range peer map key to be rejected")
+			}
+		})
+	}
+}

--- a/pkg/tecdsa/signing/marshaling.go
+++ b/pkg/tecdsa/signing/marshaling.go
@@ -2,8 +2,6 @@
 package signing
 
 import (
-	"fmt"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/keep-network/keep-core/pkg/protocol/group"
@@ -28,10 +26,11 @@ func (epkm *ephemeralPublicKeyMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
-	epkm.senderID = group.MemberIndex(pbMsg.SenderID)
+	epkm.senderID = senderID
 
 	ephemeralPublicKeys, err := unmarshalPublicKeyMap(pbMsg.EphemeralPublicKeys)
 	if err != nil {
@@ -67,20 +66,22 @@ func (trom *tssRoundOneMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
 	peersPayload := make(map[group.MemberIndex][]byte, len(pbMsg.PeersPayload))
 	for receiverID, payload := range pbMsg.PeersPayload {
-		if err := validateMemberIndex(receiverID); err != nil {
+		memberIndex, err := group.MemberIndexFromUint32(receiverID)
+		if err != nil {
 			return err
 		}
 
-		peersPayload[group.MemberIndex(receiverID)] = payload
+		peersPayload[memberIndex] = payload
 	}
 
-	trom.senderID = group.MemberIndex(pbMsg.SenderID)
+	trom.senderID = senderID
 	trom.broadcastPayload = pbMsg.BroadcastPayload
 	trom.peersPayload = peersPayload
 	trom.sessionID = pbMsg.SessionID
@@ -110,20 +111,22 @@ func (trtm *tssRoundTwoMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
 	peersPayload := make(map[group.MemberIndex][]byte, len(pbMsg.PeersPayload))
 	for receiverID, payload := range pbMsg.PeersPayload {
-		if err := validateMemberIndex(receiverID); err != nil {
+		memberIndex, err := group.MemberIndexFromUint32(receiverID)
+		if err != nil {
 			return err
 		}
 
-		peersPayload[group.MemberIndex(receiverID)] = payload
+		peersPayload[memberIndex] = payload
 	}
 
-	trtm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trtm.senderID = senderID
 	trtm.peersPayload = peersPayload
 	trtm.sessionID = pbMsg.SessionID
 
@@ -147,11 +150,12 @@ func (trtm *tssRoundThreeMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trtm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trtm.senderID = senderID
 	trtm.broadcastPayload = pbMsg.BroadcastPayload
 	trtm.sessionID = pbMsg.SessionID
 
@@ -175,11 +179,12 @@ func (trfm *tssRoundFourMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trfm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trfm.senderID = senderID
 	trfm.broadcastPayload = pbMsg.BroadcastPayload
 	trfm.sessionID = pbMsg.SessionID
 
@@ -203,11 +208,12 @@ func (trfm *tssRoundFiveMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trfm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trfm.senderID = senderID
 	trfm.broadcastPayload = pbMsg.BroadcastPayload
 	trfm.sessionID = pbMsg.SessionID
 
@@ -231,11 +237,12 @@ func (trsm *tssRoundSixMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trsm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trsm.senderID = senderID
 	trsm.broadcastPayload = pbMsg.BroadcastPayload
 	trsm.sessionID = pbMsg.SessionID
 
@@ -259,11 +266,12 @@ func (trsm *tssRoundSevenMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trsm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trsm.senderID = senderID
 	trsm.broadcastPayload = pbMsg.BroadcastPayload
 	trsm.sessionID = pbMsg.SessionID
 
@@ -287,11 +295,12 @@ func (trem *tssRoundEightMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trem.senderID = group.MemberIndex(pbMsg.SenderID)
+	trem.senderID = senderID
 	trem.broadcastPayload = pbMsg.BroadcastPayload
 	trem.sessionID = pbMsg.SessionID
 
@@ -315,23 +324,15 @@ func (trnm *tssRoundNineMessage) Unmarshal(bytes []byte) error {
 		return err
 	}
 
-	if err := validateMemberIndex(pbMsg.SenderID); err != nil {
+	senderID, err := group.MemberIndexFromUint32(pbMsg.SenderID)
+	if err != nil {
 		return err
 	}
 
-	trnm.senderID = group.MemberIndex(pbMsg.SenderID)
+	trnm.senderID = senderID
 	trnm.broadcastPayload = pbMsg.BroadcastPayload
 	trnm.sessionID = pbMsg.SessionID
 
-	return nil
-}
-
-func validateMemberIndex(protoIndex uint32) error {
-	// Protobuf does not have uint8 type, so we are using uint32. When
-	// unmarshalling message, we need to make sure we do not overflow.
-	if protoIndex > group.MaxMemberIndex {
-		return fmt.Errorf("invalid member index value: [%v]", protoIndex)
-	}
 	return nil
 }
 
@@ -353,10 +354,11 @@ func unmarshalPublicKeyMap(
 ) (map[group.MemberIndex][]byte, error) {
 	unmarshalled := make(map[group.MemberIndex][]byte, len(publicKeys))
 	for memberID, publicKeyBytes := range publicKeys {
-		if err := validateMemberIndex(memberID); err != nil {
+		memberIndex, err := group.MemberIndexFromUint32(memberID)
+		if err != nil {
 			return nil, err
 		}
-		unmarshalled[group.MemberIndex(memberID)] = publicKeyBytes
+		unmarshalled[memberIndex] = publicKeyBytes
 	}
 	return unmarshalled, nil
 }

--- a/pkg/tecdsa/signing/member.go
+++ b/pkg/tecdsa/signing/member.go
@@ -330,5 +330,8 @@ func (ic *identityConverter) TssPartyIDToMemberIndex(
 		return key.Cmp(partyID.KeyInt()) == 0
 	})
 
+	if index < 0 || index >= group.MaxMemberIndex {
+		return 0
+	}
 	return group.MemberIndex(index + 1)
 }

--- a/pkg/tecdsa/signing/member_test.go
+++ b/pkg/tecdsa/signing/member_test.go
@@ -204,3 +204,21 @@ func TestIdentityConverter_TssPartyIDToMemberIndex_Corrupted(t *testing.T) {
 
 	testutils.AssertIntsEqual(t, "member ID", 0, int(memberIndex))
 }
+
+func TestIdentityConverter_TssPartyIDToMemberIndex_Overflow(t *testing.T) {
+	keys := make([]*big.Int, group.MaxMemberIndex+1)
+	for i := range keys {
+		keys[i] = big.NewInt(int64(1000 + i))
+	}
+	converter := &identityConverter{keys: keys}
+
+	// The matching key sits at slice index group.MaxMemberIndex (the 256th
+	// entry), one past the last valid member index; it should never happen,
+	// so the party ID is considered corrupted and MemberIndex(0) is returned.
+	targetKey := keys[group.MaxMemberIndex]
+	partyID := tss.NewPartyID(targetKey.Text(10), "member-256", targetKey)
+
+	memberIndex := converter.TssPartyIDToMemberIndex(partyID)
+
+	testutils.AssertIntsEqual(t, "member ID", 0, int(memberIndex))
+}


### PR DESCRIPTION
Resolve the current 101 G115 findings on `dev` and re-enable the rule in client CI. Most protocol member-index conversions already validate their range; a shared checked conversion now returns the validated index so the analyzer and callers use the same value. Add the missing checks to persisted signers and propagate accusation-decoder validation errors.

Preserve unsigned block numbers and transaction indices with `SetUint64`, reject amounts and heights that cannot fit their destination types, and guard fee arithmetic before it can wrap. Deterministic seed and Bitcoin version conversions retain their existing bit patterns, with narrowly documented G115 exceptions. Add boundary/compatibility tests and document the conversion patterns.

Validation on `dev`:
- gosec v2.29.0: 101 G115 findings before, zero after, with CI's generated-code exclusions and no package-load errors. The complete scan with CI's `-exclude=G118` also reports zero findings.
- Focused protocol, marshaling, member-index, amount, block, fee, leader/retry, and Bitcoin wire-compatibility tests passed. The final Ethereum boundary tests also passed after resolving the rebase.
- Formatting, `git diff --check`, and the CI command `GOTOOLCHAIN=go1.24.1 go vet` passed.
- Staticcheck 2025.1.1 with CI's `-checks=-SA1019` and Go 1.24.1 passed locally.
- The full `GOTOOLCHAIN=go1.24.1 go test -p 2 -timeout 15m ./...` run did not pass: `TestOnTickTimeTicker`, `TestLocalBlockHeightWaiter`, and DKG tests failed on timing/round-one generation deadlines. Each failure category reproduces on unchanged `dev` code with the same toolchain, including an isolated `TestTssRoundOne` run. The tBTC, proposal-generation, signing, and other package suites passed.
- All current GitHub checks pass, including build/test, integration tests, gosec, format, lint, and vet. Lint and vet passed on retry after transient dependency-download errors from `proxy.golang.org`.

The added numerical checks use integer operations and add no I/O. No standalone performance benchmark or live chain integration test was run locally.

Fixes #3831.

