### PR TITLE
Update contract docs publishers for repository rename

### DIFF
--- a/.github/workflows/contracts-ecdsa-docs.yml
+++ b/.github/workflows/contracts-ecdsa-docs.yml
@@ -65,7 +65,7 @@ jobs:
   # This job will be triggered for releases which name starts with
   # `refs/tags/solidity/`. It will generate contracts documentation in
   # Markdown and sync it with a specific path of
-  # `threshold-network/threshold` repository. If changes will be detected,
+  # `threshold-network/docs` repository. If changes will be detected,
   # a PR updating the docs will be created in the destination repository. The
   # commit pushing the changes will be verified using GPG key.
   contracts-docs-publish:
@@ -77,7 +77,7 @@ jobs:
       publish: true
       addTOC: false
       verifyCommits: true
-      destinationRepo: threshold-network/threshold
+      destinationRepo: threshold-network/docs
       destinationFolder: ./docs/app-development/tbtc-v2/tbtc-contracts-api/ecdsa-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com

--- a/.github/workflows/contracts-random-beacon-docs.yml
+++ b/.github/workflows/contracts-random-beacon-docs.yml
@@ -53,7 +53,7 @@ jobs:
   # This job will be triggered for releases which name starts with
   # `refs/tags/solidity/`. It will generate contracts documentation in
   # Markdown and sync it with a specific path of
-  # `threshold-network/threshold` repository. If changes will be detected,
+  # `threshold-network/docs` repository. If changes will be detected,
   # a PR updating the docs will be created in the destination repository. The
   # commit pushing the changes will be verified using GPG key.
   contracts-docs-publish:
@@ -66,7 +66,7 @@ jobs:
       publish: true
       addTOC: false
       verifyCommits: true
-      destinationRepo: threshold-network/threshold
+      destinationRepo: threshold-network/docs
       destinationFolder: ./docs/app-development/random-beacon/random-beacon-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com


### PR DESCRIPTION
The ECDSA and random beacon release jobs still publish documentation to `threshold-network/threshold`. Update both destinations and their comments to `threshold-network/docs` for the completed repository rename.

The in-place rename of `threshold-network/threshold` to `threshold-network/docs` completed on 2026-09-08 (repo id 446490352 preserved; the old repository path now redirects to the new name). Both destination folders are verified present on `docs` @ `main`, so this PR is unblocked.

Companion to https://github.com/threshold-network/solidity-contracts/pull/148.

Validation: parsed both YAML files and verified that `destinationRepo` is the only configuration value changed; `git diff --check` passes. Live documentation publishing was not executed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation publishing workflows to sync release documentation to the `threshold-network/docs` repository.
  * Updated related workflow comments to reflect the new documentation destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
