### PR TITLE
Remove unused direct Thesis dependency from Random Beacon

### DIFF
--- a/solidity/random-beacon/package.json
+++ b/solidity/random-beacon/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@keep-network/sortition-pools": "^2.0.0-pre.16",
     "@openzeppelin/contracts": "4.7.3",
-    "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
     "@threshold-network/solidity-contracts": "1.3.0-dev.14"
   },
   "devDependencies": {

--- a/solidity/random-beacon/yarn.lock
+++ b/solidity/random-beacon/yarn.lock
@@ -1182,7 +1182,6 @@ __metadata:
     "@openzeppelin/hardhat-upgrades": "npm:^1.20.0"
     "@tenderly/hardhat-tenderly": "npm:1.0.12"
     "@thesis-co/eslint-config": "https://codeload.github.com/thesis/eslint-config/tar.gz/e63608fab2a1ad5c8fe89873bf0d4d4f9ef4a081"
-    "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
     "@threshold-network/solidity-contracts": "npm:1.3.0-dev.14"
     "@typechain/ethers-v5": "npm:^9.0.0"
     "@typechain/hardhat": "npm:^4.0.0"


### PR DESCRIPTION
Remove the unused direct `@thesis/solidity-contracts` declaration from the Random Beacon package and its Yarn workspace entry. Contracts, tests, deployment code, and Hardhat configuration do not import this package; required transitive entries remain in the lockfile.

This does not remove sortition-pools: the current public WalletRegistry/Beacon code and deployment fixtures still import it, so removing that package requires a separate retirement of those build paths. No runtime-use claim is inferred from source references.

Validation: checked all package source/config/task references, parsed the manifest and Yarn lockfile, and confirmed the only lockfile change removes this root dependency edge. No Solidity source, deployment artifacts, or resolved dependency versions change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the GitHub-based Solidity contracts package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->