### PR TITLE
Use Threshold CI actions and Go Electrum

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Load environment variables
       if: inputs.push == 'true'
-      uses: threshold-network/ci/actions/load-env-variables@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+      uses: threshold-network/ci/actions/load-env-variables@20b35345d276a3c7365e3829b8078387a7c9dccb
       with:
         environment: ${{ inputs.environment }}
 

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -22,10 +22,10 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Cache Docker layers
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -34,13 +34,13 @@ runs:
 
     - name: Load environment variables
       if: inputs.push == 'true'
-      uses: keep-network/ci/actions/load-env-variables@v2
+      uses: threshold-network/ci/actions/load-env-variables@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
       with:
         environment: ${{ inputs.environment }}
 
     - name: Login to Google Container Registry
       if: inputs.push == 'true'
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.GCR_REGISTRY_URL }}
         username: _json_key
@@ -59,8 +59,10 @@ runs:
         echo "IMAGE_NAME=${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ inputs.imageName }}" >> $GITHUB_ENV
 
     - name: Build and push image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
+        # Preserve the existing image format.
+        provenance: false
         context: ${{ inputs.context }}
         # GCR image should be named according to following convention:
         # HOSTNAME/PROJECT-ID/IMAGE:TAG

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -32,9 +32,12 @@ runs:
         restore-keys: |
           ${{ runner.os }}-buildx-
 
+    # Environment values (GCR registry, project id, network id) are resolved by
+    # load-env-variables from this pinned threshold-network/ci revision; changing
+    # them requires re-pinning the SHA used below.
     - name: Load environment variables
       if: inputs.push == 'true'
-      uses: threshold-network/ci/actions/load-env-variables@20b35345d276a3c7365e3829b8078387a7c9dccb
+      uses: threshold-network/ci/actions/load-env-variables@91f574f226348afad6b87beb353a4e9718f2b652
       with:
         environment: ${{ inputs.environment }}
 

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -37,7 +37,7 @@ runs:
     # them requires re-pinning the SHA used below.
     - name: Load environment variables
       if: inputs.push == 'true'
-      uses: threshold-network/ci/actions/load-env-variables@91f574f226348afad6b87beb353a4e9718f2b652
+      uses: threshold-network/ci/actions/load-env-variables@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
       with:
         environment: ${{ inputs.environment }}
 

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -130,7 +130,7 @@ jobs:
           echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Load environment variables
-        uses: threshold-network/ci/actions/load-env-variables@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/load-env-variables@91f574f226348afad6b87beb353a4e9718f2b652
         if: github.event_name == 'workflow_dispatch'
         with:
           environment: ${{ github.event.inputs.environment }}
@@ -268,7 +268,7 @@ jobs:
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -130,7 +130,7 @@ jobs:
           echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Load environment variables
-        uses: threshold-network/ci/actions/load-env-variables@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/load-env-variables@20b35345d276a3c7365e3829b8078387a7c9dccb
         if: github.event_name == 'workflow_dispatch'
         with:
           environment: ${{ github.event.inputs.environment }}
@@ -268,7 +268,7 @@ jobs:
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -130,7 +130,7 @@ jobs:
           echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Load environment variables
-        uses: threshold-network/ci/actions/load-env-variables@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/load-env-variables@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         if: github.event_name == 'workflow_dispatch'
         with:
           environment: ${{ github.event.inputs.environment }}
@@ -268,7 +268,7 @@ jobs:
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/notify-workflow-completed@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -130,7 +130,7 @@ jobs:
           echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@v2
+        uses: threshold-network/ci/actions/load-env-variables@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         if: github.event_name == 'workflow_dispatch'
         with:
           environment: ${{ github.event.inputs.environment }}
@@ -268,11 +268,11 @@ jobs:
 
       - name: Notify CI about completion of the workflow
         if: github.event_name == 'workflow_dispatch'
-        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          module: "github.com/keep-network/keep-core/client"
+          module: "github.com/threshold-network/keep-core/client"
           url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -191,7 +191,7 @@ jobs:
           working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/upstream-builds-query@91f574f226348afad6b87beb353a4e9718f2b652
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -228,7 +228,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
         with:
           work-dir: solidity/ecdsa
           environment: ${{ github.event.inputs.environment }}
@@ -250,7 +250,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -291,7 +291,7 @@ jobs:
           working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/upstream-builds-query@91f574f226348afad6b87beb353a4e9718f2b652
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -315,7 +315,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
         with:
           work-dir: solidity/ecdsa
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -337,7 +337,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -191,7 +191,7 @@ jobs:
           working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/upstream-builds-query@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -228,7 +228,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/npm-version-bump@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         with:
           work-dir: solidity/ecdsa
           environment: ${{ github.event.inputs.environment }}
@@ -250,7 +250,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/notify-workflow-completed@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -291,7 +291,7 @@ jobs:
           working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/upstream-builds-query@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -315,7 +315,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/npm-version-bump@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         with:
           work-dir: solidity/ecdsa
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -337,7 +337,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/notify-workflow-completed@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -48,9 +48,9 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -74,16 +74,16 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
           node-version: "22.23.1"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.10.8
 
@@ -116,9 +116,9 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -143,9 +143,9 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -176,9 +176,9 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -191,13 +191,13 @@ jobs:
           working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
-        uses: keep-network/ci/actions/upstream-builds-query@v2
+        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
             threshold-contracts-version = github.com/threshold-network/solidity-contracts#version
-            random-beacon-version = github.com/keep-network/keep-core/random-beacon#version
+            random-beacon-version = github.com/threshold-network/keep-core/random-beacon#version
 
       - name: Resolve latest contracts
         run: |
@@ -228,7 +228,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: solidity/ecdsa
           environment: ${{ github.event.inputs.environment }}
@@ -250,11 +250,11 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          module: "github.com/keep-network/keep-core/ecdsa"
+          module: "github.com/threshold-network/keep-core/ecdsa"
           url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
@@ -276,9 +276,9 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -291,13 +291,13 @@ jobs:
           working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
-        uses: keep-network/ci/actions/upstream-builds-query@v2
+        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
             threshold-contracts-version = github.com/threshold-network/solidity-contracts#version
-            random-beacon-version = github.com/keep-network/keep-core/random-beacon#version
+            random-beacon-version = github.com/threshold-network/keep-core/random-beacon#version
 
       - name: Resolve latest contracts
         run: |
@@ -315,7 +315,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: solidity/ecdsa
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -337,11 +337,11 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          module: "github.com/keep-network/keep-core/ecdsa"
+          module: "github.com/threshold-network/keep-core/ecdsa"
           url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}

--- a/.github/workflows/contracts-ecdsa.yml
+++ b/.github/workflows/contracts-ecdsa.yml
@@ -191,7 +191,7 @@ jobs:
           working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -228,7 +228,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: solidity/ecdsa
           environment: ${{ github.event.inputs.environment }}
@@ -250,7 +250,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -291,7 +291,7 @@ jobs:
           working-directory: ./solidity/ecdsa
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -315,7 +315,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: solidity/ecdsa
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -337,7 +337,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -189,7 +189,7 @@ jobs:
           working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/upstream-builds-query@91f574f226348afad6b87beb353a4e9718f2b652
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -224,7 +224,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
         with:
           work-dir: solidity/random-beacon
           environment: ${{ github.event.inputs.environment }}
@@ -246,7 +246,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -287,7 +287,7 @@ jobs:
           working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/upstream-builds-query@91f574f226348afad6b87beb353a4e9718f2b652
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -309,7 +309,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
         with:
           work-dir: solidity/random-beacon
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -331,7 +331,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -189,7 +189,7 @@ jobs:
           working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/upstream-builds-query@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -224,7 +224,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/npm-version-bump@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         with:
           work-dir: solidity/random-beacon
           environment: ${{ github.event.inputs.environment }}
@@ -246,7 +246,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/notify-workflow-completed@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -287,7 +287,7 @@ jobs:
           working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/upstream-builds-query@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -309,7 +309,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/npm-version-bump@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         with:
           work-dir: solidity/random-beacon
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -331,7 +331,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/notify-workflow-completed@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -189,7 +189,7 @@ jobs:
           working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -224,7 +224,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: solidity/random-beacon
           environment: ${{ github.event.inputs.environment }}
@@ -246,7 +246,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -287,7 +287,7 @@ jobs:
           working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -309,7 +309,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: solidity/random-beacon
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -331,7 +331,7 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts-random-beacon.yml
+++ b/.github/workflows/contracts-random-beacon.yml
@@ -48,9 +48,9 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -74,16 +74,16 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
           # https://github.com/NomicFoundation/hardhat/issues/3877
           node-version: "22.23.1"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.10.8
 
@@ -114,9 +114,9 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -141,9 +141,9 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -174,9 +174,9 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -189,7 +189,7 @@ jobs:
           working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
-        uses: keep-network/ci/actions/upstream-builds-query@v2
+        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -224,7 +224,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: solidity/random-beacon
           environment: ${{ github.event.inputs.environment }}
@@ -246,11 +246,11 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          module: "github.com/keep-network/keep-core/random-beacon"
+          module: "github.com/threshold-network/keep-core/random-beacon"
           url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
@@ -272,9 +272,9 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -287,7 +287,7 @@ jobs:
           working-directory: ./solidity/random-beacon
 
       - name: Get upstream packages versions
-        uses: keep-network/ci/actions/upstream-builds-query@v2
+        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -309,7 +309,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: solidity/random-beacon
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -331,11 +331,11 @@ jobs:
           gcrJsonKey: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          module: "github.com/keep-network/keep-core/random-beacon"
+          module: "github.com/threshold-network/keep-core/random-beacon"
           url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/npm-version-bump@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         with:
           work-dir: ./solidity/ecdsa
           environment: dev

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -21,9 +21,9 @@ jobs:
       run:
         working-directory: ./solidity/ecdsa
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 may cause issues with the
           # artifacts generation during `hardhat compile` - see
@@ -42,7 +42,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: ./solidity/ecdsa
           environment: dev

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
         with:
           work-dir: ./solidity/ecdsa
           environment: dev

--- a/.github/workflows/npm-ecdsa.yml
+++ b/.github/workflows/npm-ecdsa.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: ./solidity/ecdsa
           environment: dev

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
+        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
         with:
           work-dir: ./solidity/random-beacon
           environment: dev

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@91f574f226348afad6b87beb353a4e9718f2b652
+        uses: threshold-network/ci/actions/npm-version-bump@86506f8dcdd80179a95ee149cccf4ce9a793ad8d
         with:
           work-dir: ./solidity/random-beacon
           environment: dev

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -21,9 +21,9 @@ jobs:
       run:
         working-directory: ./solidity/random-beacon
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 may cause issues with the
           # artifacts generation during `hardhat compile` - see
@@ -58,7 +58,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: ./solidity/random-beacon
           environment: dev

--- a/.github/workflows/npm-random-beacon.yml
+++ b/.github/workflows/npm-random-beacon.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: ./solidity/random-beacon
           environment: dev

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ replace (
 	// (GO-2022-1098, GO-2024-2818, GO-2024-3189) into the Bitcoin consensus,
 	// wire, and script packages.
 	github.com/btcsuite/btcd/btcec => ./third_party/btcsuite/btcec
-	github.com/checksum0/go-electrum => github.com/keep-network/go-electrum v0.0.0-20240206170935-6038cb594daa
+	github.com/checksum0/go-electrum => github.com/threshold-network/go-electrum v0.0.0-20240206170935-6038cb594daa
 	github.com/keep-network/keep-common => github.com/threshold-network/keep-common v1.7.1-tlabs.0
 	// Temporary replacement until v1.28.2 is released containing `protodelim` package.
 	// See https://github.com/protocolbuffers/protobuf-go/commit/fb0abd915897428ccfdd6b03b48ad8219751ee54

--- a/go.sum
+++ b/go.sum
@@ -414,8 +414,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/keep-network/go-electrum v0.0.0-20240206170935-6038cb594daa h1:AKTJr+STc4rP9NcN2ppP9Zft3GbYechFW8q/S8UNQrQ=
-github.com/keep-network/go-electrum v0.0.0-20240206170935-6038cb594daa/go.mod h1:eiMFzdvS+x8Voi0bmiZtVfJ3zMNRUnPNDnhCQR0tudo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -780,6 +778,8 @@ github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/threshold-network/go-electrum v0.0.0-20240206170935-6038cb594daa h1:cODdqxyBCq8jIhiqc9qND2GLcyPI8iOZXeGH4tHj/OE=
+github.com/threshold-network/go-electrum v0.0.0-20240206170935-6038cb594daa/go.mod h1:eiMFzdvS+x8Voi0bmiZtVfJ3zMNRUnPNDnhCQR0tudo=
 github.com/threshold-network/keep-common v1.7.1-tlabs.0 h1:E3Qy3yoeA3+9Ybi08Bb1Xm1D2fFxoberQwUjw+UEK8k=
 github.com/threshold-network/keep-common v1.7.1-tlabs.0/go.mod h1:OmaZrnZODf6RJ95yUn2kBjy8Z4u2npPJQkSiyimluto=
 github.com/threshold-network/tss-lib v0.0.0-20230901144531-2e712689cfbe h1:dOKhoYxZjXwFIyGnxgU+Sa1obZPMHRhu6e44oOLkzU4=


### PR DESCRIPTION
Repoint Go Electrum to the Threshold fork at the same immutable upstream revision (`6038cb594daa`), preserving the imported module path and implementation. Update go.sum for the new source and remove the old source checksums.

Use the maintained actions from [threshold-network/ci #1](https://github.com/threshold-network/ci/pull/1), pinned to the merge commit `86506f8dcdd80179a95ee149cccf4ce9a793ad8d` of PR #1, merged to the producer's main branch. This includes the vendored npm-version-bump action. Completion payloads and upstream-build queries use the Threshold module identifiers configured by the release manager. The consumed action bundle is byte-identical between this pin and the ci main tip that followed (the next producer merge touched only the docs workflow, its README, and tests), so the pin excludes no reviewed action code.

Update obsolete action runtimes in the affected workflows. Environment values for release jobs (GCR registry/project, network id) resolve from the pinned threshold-network/ci revision; changing them requires re-pinning the SHA. The consumer migrations must merge before starting a new inter-repository release pipeline; `CI_GITHUB_TOKEN` must be configured where missing. npm/cloud/docs credentials stay in their existing consumer repositories.

Validation: actionlint passes for every changed workflow; producer paths, input names, commit pins, dispatch input contracts, and module/query identifiers were checked against the producer. Its 51 tests and four standalone action-bundle checks pass in GitHub CI. Release/deployment/publishing paths were not invoked during validation.

The shared Docker action also uses supported action runtimes, with provenance disabled to preserve the prior image format. keep-core's local docs workflow is already owned and remains local. This change is independent of the helper/local-network/common-library PRs already open.

Additional validation: `go test -mod=readonly ./pkg/bitcoin/...` passes against the fork; the fork's tests and vet pass on Go 1.24.1 and 1.26.0 in CI.

GitHub CI: all 1,678 Go unit tests and the Docker/runtime/binary builds pass, as do the contracts test/lint/Slither/deployment-dry-run jobs. The separate full integration suite also passes.